### PR TITLE
feat(exporter): add export_obsidian() for Obsidian vault output

### DIFF
--- a/src/mykg/exporter.py
+++ b/src/mykg/exporter.py
@@ -17,6 +17,11 @@ export.networkx_enabled; written to output/networkx_output/):
   edges_nx.txt                 — plain edge list with attributes
   adjacency.txt                — adjacency list, topology only
 
+Obsidian vault output (export_obsidian, toggled via mykg_config.yaml
+export.obsidian_enabled; written to output/obsidian_vault/):
+  <Type>/<node_id>.md          — one note per entity with YAML frontmatter and wikilinks
+  index.md                     — vault root overview with per-type entity tables
+
 Node/edge attributes are flattened to GML-safe scalars:
   attr_<name>_value / attr_<name>_confidence
 source_files lists are pipe-joined ("a.md|b.md") for format compatibility.
@@ -27,9 +32,11 @@ from __future__ import annotations
 import html as _html
 import json
 import re
+from collections import defaultdict
 from pathlib import Path
 
 import networkx as nx
+import yaml
 from networkx.readwrite import json_graph
 
 from mykg import config as _cfg
@@ -665,5 +672,189 @@ def export_networkx(nodes: list[dict], edge_metadata: dict, output_dir: Path) ->
 
     nx.write_adjlist(G, str(nx_dir / "adjacency.txt"))
     written.append("adjacency.txt")
+
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Obsidian vault export
+# ---------------------------------------------------------------------------
+
+
+def _node_display_name(node: dict) -> str:
+    """Return the human-readable display name for a node (name attribute value or node ID)."""
+    name_attr = node.get("attributes", {}).get("name")
+    if isinstance(name_attr, dict):
+        val = name_attr.get("value")
+        if val:
+            return str(val)
+    return node["id"]
+
+
+def _obsidian_entity_note(
+    node: dict,
+    outgoing: list[tuple[str, str, float]],
+    incoming: list[tuple[str, str, float]],
+) -> str:
+    """Render a single entity note as a Markdown string with YAML frontmatter."""
+    node_id = node["id"]
+    node_type = node.get("type", "")
+    confidence = node.get("confidence", 0.0)
+    source_files = node.get("source_files", [])
+    attributes = node.get("attributes", {})
+    display_name = _node_display_name(node)
+
+    frontmatter_data: dict = {
+        "id": node_id,
+        "type": node_type,
+        "confidence": round(float(confidence), 4),
+    }
+    if source_files:
+        frontmatter_data["sources"] = list(source_files)
+
+    frontmatter = yaml.dump(frontmatter_data, default_flow_style=False, allow_unicode=True).rstrip()
+    lines: list[str] = ["---", frontmatter, "---", "", f"# {display_name}", ""]
+
+    # Attributes section (skip "name" — it is the heading)
+    attr_lines = []
+    for attr_name, payload in attributes.items():
+        if attr_name == "name":
+            continue
+        if isinstance(payload, dict):
+            val = payload.get("value")
+            conf = payload.get("confidence", 0.0)
+        else:
+            val = payload
+            conf = 0.0
+        if val is None:
+            continue
+        attr_lines.append(f"- **{attr_name}**: {val} ({round(float(conf), 2)})")
+
+    if attr_lines:
+        lines.append("## Attributes")
+        lines.extend(attr_lines)
+        lines.append("")
+
+    # Relationships section
+    if outgoing or incoming:
+        lines.append("## Relationships")
+        lines.append("")
+        if outgoing:
+            lines.append("### Outgoing")
+            for target_name, edge_type, edge_conf in outgoing:
+                lines.append(f"- [[{target_name}]] — {edge_type} ({round(float(edge_conf), 2)})")
+            lines.append("")
+        if incoming:
+            lines.append("### Incoming")
+            for source_name, edge_type, edge_conf in incoming:
+                lines.append(f"- [[{source_name}]] — {edge_type} ({round(float(edge_conf), 2)})")
+            lines.append("")
+
+    # Source Files section
+    if source_files:
+        lines.append("## Source Files")
+        for sf in source_files:
+            lines.append(f"- {sf}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _obsidian_index(nodes: list[dict], edge_count: int) -> str:
+    """Render the vault index.md listing all entities grouped by type."""
+    lines: list[str] = [
+        "# Knowledge Graph Index",
+        "",
+        f"**{len(nodes)} entities** — **{edge_count} relationships**",
+        "",
+    ]
+
+    # Group nodes by type, sorted for deterministic output
+    by_type: dict[str, list[dict]] = defaultdict(list)
+    for node in nodes:
+        by_type[node.get("type", "Unknown")].append(node)
+
+    for node_type in sorted(by_type):
+        # Compute display name once per node to avoid double attribute lookups
+        group = sorted(
+            ((n, _node_display_name(n)) for n in by_type[node_type]),
+            key=lambda pair: pair[1],
+        )
+        lines.append(f"## {node_type}")
+        lines.append("")
+        lines.append("| Entity |")
+        lines.append("| --- |")
+        for _node, name in group:
+            lines.append(f"| [[{name}]] |")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def export_obsidian(
+    nodes: list[dict],
+    edge_metadata: dict,
+    schema: dict,  # kept for API symmetry with other export_ functions
+    output_dir: Path,
+) -> list[str]:
+    """Write an Obsidian vault to output_dir/obsidian_vault/.
+
+    One Markdown note per entity (Type/node_id.md), with YAML frontmatter,
+    attributes, wikilinked relationships, and an index.md overview.
+
+    Returns a list of written file paths as relative strings (same contract as
+    export_networkx).  Returns an empty list when OBSIDIAN_ENABLED is False.
+    """
+    if not getattr(_cfg, "OBSIDIAN_ENABLED", False):
+        return []
+
+    vault_dir = output_dir / "obsidian_vault"
+    vault_dir.mkdir(exist_ok=True)
+
+    # Build id → display_name lookup for wikilinks
+    id_to_name: dict[str, str] = {node["id"]: _node_display_name(node) for node in nodes}
+
+    # Build adjacency: outgoing/incoming per node_id
+    # Values: list of (peer_display_name, edge_type, confidence)
+    outgoing: dict[str, list[tuple[str, str, float]]] = defaultdict(list)
+    incoming: dict[str, list[tuple[str, str, float]]] = defaultdict(list)
+    for edge in edge_metadata.values():
+        from_id = edge.get("from", "")
+        to_id = edge.get("to", "")
+        edge_type = edge.get("type", "")
+        conf = float(edge.get("confidence", 0.0))
+        outgoing[from_id].append((id_to_name.get(to_id, to_id), edge_type, conf))
+        incoming[to_id].append((id_to_name.get(from_id, from_id), edge_type, conf))
+
+    # Pre-create one subdir per concept type to avoid repeated mkdir calls in the node loop
+    type_dirs: dict[str, Path] = {}
+    for node in nodes:
+        node_type = node.get("type", "Unknown")
+        if node_type not in type_dirs:
+            d = vault_dir / node_type
+            d.mkdir(exist_ok=True)
+            type_dirs[node_type] = d
+
+    written: list[str] = []
+
+    for node in nodes:
+        node_id = node["id"]
+        node_type = node.get("type", "Unknown")
+        type_dir = type_dirs[node_type]
+
+        note_content = _obsidian_entity_note(
+            node,
+            outgoing=outgoing.get(node_id, []),
+            incoming=incoming.get(node_id, []),
+        )
+        note_path = type_dir / f"{node_id}.md"
+        note_path.write_text(note_content, encoding="utf-8")
+        # Derive the relative path from the actual filesystem path to stay in sync
+        written.append(str(note_path.relative_to(output_dir)))
+
+    # Index
+    index_content = _obsidian_index(nodes, edge_count=len(edge_metadata))
+    (vault_dir / "index.md").write_text(index_content, encoding="utf-8")
+    written.append("obsidian_vault/index.md")
 
     return written

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,6 +1,12 @@
-import json
+from __future__ import annotations
 
-from mykg.exporter import export_edges_jsonl, export_nodes_jsonl, export_ttl
+import json
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+from mykg.exporter import export_edges_jsonl, export_nodes_jsonl, export_obsidian, export_ttl
 
 SCHEMA = {
     "concepts": [
@@ -123,3 +129,169 @@ def test_ttl_escapes_newline_in_literal():
 
     g = Graph()
     g.parse(data=ttl, format="turtle")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# export_obsidian tests
+# ---------------------------------------------------------------------------
+
+_OBS_NODES = [
+    {
+        "id": "person-alice-johnson",
+        "type": "Person",
+        "confidence": 0.94,
+        "source_files": ["team.md"],
+        "attributes": {
+            "name": {"value": "Alice Johnson", "confidence": 1.0},
+            "role": {"value": "Engineer", "confidence": 0.91},
+            "email": {"value": "alice@example.com", "confidence": 1.0},
+        },
+        "aliases": ["Alice", "A. Johnson"],
+    },
+    {
+        "id": "organization-acme-corp",
+        "type": "Organization",
+        "confidence": 0.99,
+        "source_files": ["team.md"],
+        "attributes": {
+            "name": {"value": "Acme Corp", "confidence": 0.99},
+        },
+    },
+    {
+        "id": "person-bob-smith",
+        "type": "Person",
+        "confidence": 0.88,
+        "source_files": ["team.md"],
+        "attributes": {
+            "name": {"value": "Bob Smith", "confidence": 1.0},
+        },
+    },
+]
+
+_OBS_EDGE_METADATA = {
+    "edge-001": {
+        "type": "works_at",
+        "from": "person-alice-johnson",
+        "to": "organization-acme-corp",
+        "confidence": 0.96,
+        "source_files": ["team.md"],
+        "attributes": {"role": {"value": "engineer", "confidence": 0.91}},
+    },
+    "edge-002": {
+        "type": "manages",
+        "from": "person-bob-smith",
+        "to": "person-alice-johnson",
+        "confidence": 0.88,
+        "source_files": ["team.md"],
+        "attributes": {},
+    },
+}
+
+_OBS_SCHEMA = {
+    "concepts": [
+        {"type": "Person", "parent": None, "attributes": ["name", "role", "email"]},
+        {"type": "Organization", "parent": None, "attributes": ["name"]},
+    ],
+    "properties": [
+        {"name": "works_at", "domain": "Person", "range": "Organization", "attributes": ["role"]},
+        {"name": "manages", "domain": "Person", "range": "Person", "attributes": []},
+    ],
+}
+
+
+def _run_obsidian(tmp_path: Path) -> list[str]:
+    """Call export_obsidian with OBSIDIAN_ENABLED patched to True."""
+    with mock.patch("mykg.exporter._cfg") as mock_cfg:
+        mock_cfg.OBSIDIAN_ENABLED = True
+        mock_cfg.JSON_INDENT = 2
+        return export_obsidian(_OBS_NODES, _OBS_EDGE_METADATA, _OBS_SCHEMA, tmp_path)
+
+
+def test_obsidian_returns_empty_when_disabled(tmp_path: Path) -> None:
+    """export_obsidian returns [] when OBSIDIAN_ENABLED is False (or absent)."""
+    with mock.patch("mykg.exporter._cfg") as mock_cfg:
+        mock_cfg.OBSIDIAN_ENABLED = False
+        result = export_obsidian(_OBS_NODES, _OBS_EDGE_METADATA, _OBS_SCHEMA, tmp_path)
+    assert result == []
+
+
+def test_obsidian_creates_type_subdirs(tmp_path: Path) -> None:
+    """Nodes are written under Type/ subdirectories inside obsidian_vault/."""
+    _run_obsidian(tmp_path)
+    vault = tmp_path / "obsidian_vault"
+    assert (vault / "Person").is_dir()
+    assert (vault / "Organization").is_dir()
+
+
+def test_obsidian_creates_node_files(tmp_path: Path) -> None:
+    """One .md file is created per node with the node_id as filename."""
+    _run_obsidian(tmp_path)
+    vault = tmp_path / "obsidian_vault"
+    assert (vault / "Person" / "person-alice-johnson.md").exists()
+    assert (vault / "Organization" / "organization-acme-corp.md").exists()
+    assert (vault / "Person" / "person-bob-smith.md").exists()
+
+
+def test_obsidian_frontmatter_is_valid_yaml(tmp_path: Path) -> None:
+    """YAML frontmatter in entity notes must parse without error."""
+    _run_obsidian(tmp_path)
+    note_path = tmp_path / "obsidian_vault" / "Person" / "person-alice-johnson.md"
+    content = note_path.read_text(encoding="utf-8")
+
+    # Extract frontmatter between the first pair of '---' delimiters
+    parts = content.split("---")
+    assert len(parts) >= 3, "expected YAML frontmatter delimiters"
+    fm = yaml.safe_load(parts[1])
+    assert fm["id"] == "person-alice-johnson"
+    assert fm["type"] == "Person"
+    assert isinstance(fm["confidence"], float)
+    assert "team.md" in fm["sources"]
+
+
+def test_obsidian_outgoing_wikilink(tmp_path: Path) -> None:
+    """Outgoing relationship section contains a wikilink to the target entity."""
+    _run_obsidian(tmp_path)
+    note_path = tmp_path / "obsidian_vault" / "Person" / "person-alice-johnson.md"
+    content = note_path.read_text(encoding="utf-8")
+    assert "[[Acme Corp]]" in content
+    assert "works_at" in content
+
+
+def test_obsidian_incoming_wikilink(tmp_path: Path) -> None:
+    """Incoming relationship section contains a wikilink to the source entity."""
+    _run_obsidian(tmp_path)
+    note_path = tmp_path / "obsidian_vault" / "Person" / "person-alice-johnson.md"
+    content = note_path.read_text(encoding="utf-8")
+    assert "[[Bob Smith]]" in content
+    assert "manages" in content
+
+
+def test_obsidian_index_exists(tmp_path: Path) -> None:
+    """index.md is created at the vault root."""
+    _run_obsidian(tmp_path)
+    assert (tmp_path / "obsidian_vault" / "index.md").exists()
+
+
+def test_obsidian_index_lists_all_nodes(tmp_path: Path) -> None:
+    """index.md wikilinks to every node by display name."""
+    _run_obsidian(tmp_path)
+    index = (tmp_path / "obsidian_vault" / "index.md").read_text(encoding="utf-8")
+    assert "[[Alice Johnson]]" in index
+    assert "[[Acme Corp]]" in index
+    assert "[[Bob Smith]]" in index
+
+
+def test_obsidian_return_value_is_list_of_strings(tmp_path: Path) -> None:
+    """Return value is a list of relative path strings."""
+    result = _run_obsidian(tmp_path)
+    assert isinstance(result, list)
+    assert all(isinstance(p, str) for p in result)
+    assert any(p.startswith("obsidian_vault/") for p in result)
+    assert "obsidian_vault/index.md" in result
+
+
+def test_obsidian_return_value_includes_all_node_paths(tmp_path: Path) -> None:
+    """Return value contains one path per node plus index.md."""
+    result = _run_obsidian(tmp_path)
+    node_paths = [p for p in result if p != "obsidian_vault/index.md"]
+    assert len(node_paths) == len(_OBS_NODES)


### PR DESCRIPTION
## Summary
- Adds `export_obsidian()` to `src/mykg/exporter.py` — exports the full knowledge graph as a linked Obsidian vault
- One `.md` note per entity with YAML frontmatter, attribute listings, outgoing/incoming wikilinks, and source file references
- Generates `obsidian_vault/index.md` with a per-type summary table linking every entity
- 10 new tests in `tests/test_exporter.py` covering frontmatter validity, wikilink presence, index generation, and path correctness

## Test plan
- [x] `pytest tests/test_exporter.py -k obsidian -v` — 10 tests pass
- [ ] Wire into pipeline (Unit 2 PR) then test end-to-end with `mykg extract-graph <dir> --obsidian-vault`
- [ ] Open `output/obsidian_vault/` in Obsidian to verify graph view and backlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for exporting the knowledge graph as an Obsidian-compatible vault with per-entity notes and an index file.

New Features:
- Introduce export_obsidian() to generate an Obsidian vault under output/obsidian_vault/ with one Markdown note per entity and a vault index.

Tests:
- Add a suite of tests validating Obsidian export behavior, including directory structure, note creation, YAML frontmatter, wikilinks, index contents, and returned paths.