### PR TITLE
feat(pipeline): wire Obsidian vault export into config, pipeline, and CLI

### DIFF
--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -274,6 +274,12 @@ def _print_next_steps(profile: str) -> None:
     default=None,
     help="Session name under sessions/ to resume or append; omit to auto-create",
 )
+@click.option(
+    "--obsidian-vault",
+    is_flag=True,
+    default=False,
+    help="Write an Obsidian vault to output/obsidian_vault/ (overrides config obsidian_enabled)",
+)
 def extract_graph(
     input_dir,
     output_dir,
@@ -288,6 +294,7 @@ def extract_graph(
     confidence_agg,
     append,
     session,
+    obsidian_vault,
 ):
     """Extract a knowledge graph from a directory of Markdown files."""
     from mykg.llm.config import load_adapter
@@ -354,6 +361,10 @@ def extract_graph(
     if from_step:
         from_step, orphan_incremental = _resolve_from_step(from_step)
         _delete_from_step(from_step, intermediate_dir, output_dir, incremental=orphan_incremental)
+
+    if obsidian_vault:
+        import mykg.config as _config_mod
+        _config_mod.OBSIDIAN_ENABLED = True
 
     from mykg.llm.error_gate import ErrorGate
 
@@ -625,9 +636,12 @@ def _delete_from_step(
             if incremental and filename in _INCREMENTAL_PRESERVE:
                 click.echo(f"Preserved {base_dir / filename} (incremental sweep)")
                 continue
-            path = base_dir / filename
+            path = base_dir / filename.rstrip("/")
             if path.exists():
-                path.unlink()
+                if path.is_dir():
+                    shutil.rmtree(path)
+                else:
+                    path.unlink()
                 click.echo(f"Deleted {path}")
 
     # Shard directories are not listed in Step.outputs but must be cleared when
@@ -644,6 +658,16 @@ def _delete_from_step(
         if concat_map_path.exists():
             concat_map_path.unlink()
             click.echo(f"Deleted {concat_map_path}")
+
+    # obsidian_vault/ is written by validate_graph but not tracked in Step.outputs
+    # (it is optional; omitting it prevents _is_done from breaking when disabled).
+    # Delete it when re-running from validate_graph or any earlier step.
+    validate_graph_idx = step_names.index("validate_graph") if "validate_graph" in step_names else -1
+    if validate_graph_idx >= 0 and idx <= validate_graph_idx:
+        obsidian_path = output_dir / _cfg().OBSIDIAN_VAULT_DIR
+        if obsidian_path.exists():
+            shutil.rmtree(obsidian_path)
+            click.echo(f"Deleted {obsidian_path}")
 
     human_review_idx = step_names.index("human_review") if "human_review" in step_names else -1
     if idx > human_review_idx >= 0:

--- a/src/mykg/config.py
+++ b/src/mykg/config.py
@@ -135,6 +135,8 @@ TTL_DATA_PREFIX_LABEL: str = _get("export", "data_prefix_label")
 TTL_COMMENT_WIDTH: int = _get("export", "comment_width")
 TTL_NAMESPACE_SKOS: str = _get("export", "skos_namespace")
 NETWORKX_ENABLED: bool = _get("export", "networkx_enabled")
+OBSIDIAN_ENABLED: bool = _get_opt("export", "obsidian_enabled", False)
+OBSIDIAN_VAULT_DIR: str = _get_opt("export", "obsidian_vault_dir", "obsidian_vault")
 
 # ---------------------------------------------------------------------------
 # Output / intermediate paths (D16, D18)

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -100,6 +100,8 @@ profiles:
         comment_width: 42          # column width for section divider comments in knowledge_graph.ttl
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"  # SKOS namespace for skos:altLabel alias triples
         networkx_enabled: true     # write NetworkX multi-format exports to output/networkx_output/ (GML, GraphML, GEXF, etc.)
+        obsidian_enabled: false    # write Obsidian vault to output/obsidian_vault/ (markdown notes + graph links)
+        obsidian_vault_dir: obsidian_vault  # subdirectory under output/ for the Obsidian vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:               # circuit-breaker: pauses the run when too many API errors accumulate
         enabled: false          # set false for fully unattended runs (e.g. providers with no rate limits)
@@ -208,6 +210,8 @@ profiles:
         comment_width: 42          # column width for section divider comments in knowledge_graph.ttl
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"  # SKOS namespace for skos:altLabel alias triples
         networkx_enabled: true     # write NetworkX multi-format exports to output/networkx_output/ (GML, GraphML, GEXF, etc.)
+        obsidian_enabled: false
+        obsidian_vault_dir: obsidian_vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:               # circuit-breaker: pauses the run when too many API errors accumulate
         enabled: false
@@ -316,6 +320,8 @@ profiles:
         comment_width: 42
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"
         networkx_enabled: true
+        obsidian_enabled: false
+        obsidian_vault_dir: obsidian_vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:
         enabled: false
@@ -425,6 +431,8 @@ profiles:
         comment_width: 42
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"
         networkx_enabled: true
+        obsidian_enabled: false
+        obsidian_vault_dir: obsidian_vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:
         enabled: false

--- a/src/mykg/steps/step_validate_graph.py
+++ b/src/mykg/steps/step_validate_graph.py
@@ -35,6 +35,12 @@ def run_validate_graph(ctx: PipelineContext) -> None:
         written = export_networkx(nodes, valid_edge_metadata, ctx.output_dir)
         log.info("Step 12c — NetworkX export: %s", ", ".join(written))
 
+    if _cfg.OBSIDIAN_ENABLED:
+        from mykg.exporter import export_obsidian
+
+        obs_written = export_obsidian(nodes, valid_edge_metadata, schema, ctx.output_dir)
+        log.info("Step 12d — Obsidian vault export: %d notes written", len(obs_written))
+
     (ctx.output_dir / "knowledge_graph_validation.json").write_text(
         json.dumps(result, indent=_cfg.JSON_INDENT)
     )

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -146,6 +146,17 @@ def test_extract_creates_session_dir(tmp_path, input_dir, monkeypatch):
     assert any((d / "intermediate").is_dir() for d in subdirs)
 
 
+def test_extract_graph_help_contains_obsidian_vault():
+    """--help output for extract-graph must advertise --obsidian-vault."""
+    import mykg.cli as cli_mod
+    from click.testing import CliRunner
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["extract-graph", "--help"])
+    assert result.exit_code == 0
+    assert "--obsidian-vault" in result.output
+
+
 def test_from_step_without_session_or_dirs_errors(tmp_path, input_dir, monkeypatch):
     import mykg.cli as cli_mod
     import mykg.config as cfg_mod

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -356,6 +356,62 @@ def test_run_validate_graph_does_not_raise_on_tbox_errors(tmp_path):
     assert (output_dir / "knowledge_graph_validation.json").exists()
 
 
+def test_run_validate_graph_calls_export_obsidian_when_enabled(tmp_path, monkeypatch):
+    """run_validate_graph calls export_obsidian when OBSIDIAN_ENABLED is True."""
+    import mykg.config as cfg_mod
+    from unittest.mock import patch
+
+    monkeypatch.setattr(cfg_mod, "OBSIDIAN_ENABLED", True)
+    monkeypatch.setattr(cfg_mod, "OBSIDIAN_VAULT_DIR", "obsidian_vault")
+
+    ctx = _make_ctx(tmp_path)
+    (ctx.intermediate_dir / "schema.json").write_text(json.dumps(SCHEMA))
+    ctx.nodes = [
+        {
+            "id": "person-alice",
+            "type": "Person",
+            "confidence": 0.9,
+            "source_files": ["doc.md"],
+            "attributes": {"name": {"value": "Alice", "confidence": 0.9}},
+        }
+    ]
+    ctx.edge_metadata = {}
+
+    with patch("mykg.exporter.export_obsidian", create=True, wraps=None) as mock_obs:
+        mock_obs.return_value = ["obsidian_vault/person/alice.md"]
+        with patch("mykg.steps.step_validate_graph._cfg", cfg_mod):
+            run_validate_graph(ctx)
+
+    mock_obs.assert_called_once()
+
+
+def test_run_validate_graph_skips_export_obsidian_when_disabled(tmp_path, monkeypatch):
+    """run_validate_graph does not call export_obsidian when OBSIDIAN_ENABLED is False."""
+    import mykg.config as cfg_mod
+    from unittest.mock import patch
+
+    monkeypatch.setattr(cfg_mod, "OBSIDIAN_ENABLED", False)
+
+    ctx = _make_ctx(tmp_path)
+    (ctx.intermediate_dir / "schema.json").write_text(json.dumps(SCHEMA))
+    ctx.nodes = [
+        {
+            "id": "person-alice",
+            "type": "Person",
+            "confidence": 0.9,
+            "source_files": ["doc.md"],
+            "attributes": {"name": {"value": "Alice", "confidence": 0.9}},
+        }
+    ]
+    ctx.edge_metadata = {}
+
+    with patch("mykg.exporter.export_obsidian", create=True) as mock_obs:
+        with patch("mykg.steps.step_validate_graph._cfg", cfg_mod):
+            run_validate_graph(ctx)
+
+    mock_obs.assert_not_called()
+
+
 def test_export_step_not_llm_step():
     """The validate_graph Step must have is_llm_step=False."""
     from mykg.pipeline import STEPS


### PR DESCRIPTION
## Summary
- Adds OBSIDIAN_ENABLED and OBSIDIAN_VAULT_DIR constants to config.py (off by default)
- Adds obsidian_enabled/obsidian_vault_dir keys to all 4 profiles in mykg_config.yaml
- Calls export_obsidian() in step_validate_graph when OBSIDIAN_ENABLED is True
- Adds --obsidian-vault flag to mykg extract-graph for one-off vault export
- Handles obsidian_vault/ directory cleanup when --from-step validate_graph is used
- Adds CLI flag test and 2 step-level dispatch tests

## Test plan
- [x] pytest tests/test_steps.py -k obsidian -v — 2 tests pass
- [x] pytest tests/test_cli_commands.py -k obsidian -v — 1 test passes
- [ ] Merge with PR 6 (Unit 1), then test end-to-end with --obsidian-vault flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate optional Obsidian vault export into the validate_graph pipeline step, CLI, and configuration, including cleanup behavior and tests.

New Features:
- Add configuration flags to enable Obsidian vault export and configure its output directory.
- Invoke Obsidian vault export during the validate_graph step when enabled.
- Introduce an --obsidian-vault flag on the extract-graph CLI command to force Obsidian vault generation for one-off runs.

Enhancements:
- Extend pipeline cleanup logic to remove Obsidian vault output and support deletion of directories as well as files.

Tests:
- Add step-level tests to verify that validate_graph calls or skips Obsidian export based on configuration.
- Add a CLI help test to ensure the new --obsidian-vault flag is exposed in extract-graph help output.