### PR TITLE
feat: Obsidian vault export, ruff lint, test fixes — v0.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ sessions/2026-05-17T18-31-07/
     knowledge_graph.ttl            ← RDFS/OWL TBox + RDF ABox (Protégé, SPARQL)
     networkx_output/               ← GML, GraphML, GEXF, Pajek, JSON node-link,
                                       knowledge_graph.html (interactive vis)
+    obsidian_vault/                ← Obsidian-ready linked Markdown notes
+      index.md                     ←   overview table with links to every entity
+      Person/                      ←   one .md note per entity, grouped by type
+      Organization/
+      ...
   walkthrough.md                   ← per-run report: schema, stats, timing
 ```
 
@@ -57,6 +62,7 @@ sessions/2026-05-17T18-31-07/
   - [Append Mode](#append-mode)
   - [Merging Sessions](#merging-sessions)
   - [Walkthrough Report](#walkthrough-report)
+  - [Obsidian Vault Export](#obsidian-vault-export)
 - [Development](#development)
 - [Roadmap](#roadmap)
 - [Design](#design)
@@ -81,7 +87,8 @@ sessions/2026-05-17T18-31-07/
 ### Graph & Output
 
 - **Provider-agnostic** — works with Anthropic (Claude), OpenAI (GPT-4o), Ollama (local), OpenRouter, or the `claude` CLI with no API key
-- **Three output families** — JSONL for Neo4j/NetworkX/RAG, Turtle RDF for OWL toolchains, NetworkX multi-format for graph analysis
+- **Four output families** — JSONL for Neo4j/NetworkX/RAG, Turtle RDF for OWL toolchains, NetworkX multi-format for graph analysis, and Obsidian vault for linked personal knowledge management
+- **Obsidian vault export** — automatically writes one linked Markdown note per entity to `output/obsidian_vault/`; open the folder directly in [Obsidian](https://obsidian.md) to explore the graph with backlinks and Graph View
 - **Interactive HTML graph** — node/edge filtering, search, hover popups; opens directly in a browser
 - **Confidence scoring** — every extracted attribute, node, and edge carries a `0.0–1.0` confidence score
 - **Name normalization** — surface-form variants ("Acme Corp", "ACME", "Acme Corporation") resolved to a single canonical node with aliases
@@ -254,6 +261,8 @@ Switch provider by setting `profile:` at the top of [`mykg_config.yaml`](mykg_co
 | `pipeline.orphan_pass.enabled` | `true` | Run the orphan-connection pass |
 | `pipeline.orphan_pass.schema_max_restarts` | `1` | Max automated Pass 2 restarts from schema-gap recovery |
 | `pipeline.export.networkx_enabled` | `true` | Write NetworkX formats to `output/networkx_output/` |
+| `pipeline.export.obsidian_enabled` | `true` | Write Obsidian vault to `output/obsidian_vault/` |
+| `pipeline.export.obsidian_vault_dir` | `obsidian_vault` | Subdirectory name for the Obsidian vault inside `output/` |
 | `pipeline.error_gate.enabled` | `true` | Pause all workers on repeated API errors |
 
 Run `context-calculator --context <N> --max-output <M>` to compute correct `window_tokens` and `batch_token_target` for a different model's context window.
@@ -283,6 +292,7 @@ mykg extract-graph <input_dir> [OPTIONS]
 | `--confidence-agg mean\|max` | Confidence aggregation when deduplicating |
 | `--base-schema PATH` | Locked TBox TTL file (locked classes/properties cannot be changed by the LLM) |
 | `--thesaurus PATH` | SKOS TTL thesaurus for synonym resolution in schema merge |
+| `--obsidian-vault` | Force Obsidian vault export for this run (overrides config) |
 | `--log-file PATH` | Write logs here (relative paths placed inside the session folder) |
 | `--verbose / -v` | Enable DEBUG-level logging |
 
@@ -342,7 +352,7 @@ The pipeline runs 11 steps in sequence. All intermediate state is written to dis
 | 8 | `assemble` | — | `edge_metadata.json`, `nodes.json`, `merge_log.json` |
 | 9 | `orphan_score` | — | `orphan_candidates.json` |
 | 10 | `orphan_connect` | ✓ | `orphan_connections.json`, `orphan_log.json` |
-| 11 | `validate_graph` | — | `nodes.jsonl`, `edges.jsonl`, `knowledge_graph.ttl`, `knowledge_graph.html`, `networkx_output/` |
+| 11 | `validate_graph` | — | `nodes.jsonl`, `edges.jsonl`, `knowledge_graph.ttl`, `knowledge_graph.html`, `networkx_output/`, `obsidian_vault/` |
 
 Pass 1 internally runs four sequential stages: parallel batch induction → algorithmic merge → harmonization LLM call → quality review LLM call.
 
@@ -426,6 +436,12 @@ Load in Protégé, query with SPARQL (Fuseki, GraphDB), or reason with HermiT/Pe
 | `adjacency.txt` | Adjacency list | Topology consumers |
 
 Node/edge attributes are exported as `attr_<name>_value` / `attr_<name>_confidence` scalar pairs for GML compatibility.
+
+### Obsidian Vault (`obsidian_vault/`)
+
+One `.md` note per extracted entity, grouped into subdirectories by concept type. Each note has YAML frontmatter (id, type, confidence, sources), an attributes section, outgoing and incoming wikilink relationship sections, and a source files list. An `index.md` at the vault root summarizes node counts per type with links to every entity.
+
+Open `output/obsidian_vault/` as a vault in [Obsidian](https://obsidian.md) to get Graph View, backlink navigation, and full-text search across the extracted entities.
 
 ### Re-running from a Specific Step
 
@@ -553,6 +569,65 @@ Configure the re-extraction strategy:
 merge_graphs:
   reextraction_strategy: surgical   # none | surgical | full
 ```
+
+### Obsidian Vault Export
+
+Every run writes a linked Markdown vault to `output/obsidian_vault/` by default. Open that folder in [Obsidian](https://obsidian.md) to explore the extracted knowledge graph with Graph View and backlinks.
+
+**Vault structure:**
+
+```
+output/obsidian_vault/
+  index.md                  ← overview: node count per type, links to every entity
+  Person/
+    person-alice-smith.md   ← one note per entity
+    person-bob-jones.md
+  Organization/
+    organization-acme-corp.md
+  ...
+```
+
+**Each entity note contains:**
+
+```markdown
+---
+id: person-alice-smith
+type: Person
+confidence: 0.94
+sources:
+  - team.md
+---
+
+# Alice Smith
+
+## Attributes
+- **role**: Engineer (0.91)
+- **email**: alice@acme.com (1.0)
+
+## Relationships
+
+### Outgoing
+- [[Acme Corp]] — works_at (0.96)
+
+### Incoming
+- [[Bob Jones]] — manages (0.88)
+
+## Source Files
+- team.md
+```
+
+Wikilinks (`[[...]]`) are Obsidian-native — clicking them in the app navigates to the linked entity note, and the Graph View shows the full relationship network automatically.
+
+**Config:**
+
+```yaml
+pipeline:
+  export:
+    obsidian_enabled: true          # default — set false to skip vault export
+    obsidian_vault_dir: obsidian_vault   # subfolder name inside output/
+```
+
+Or use `--obsidian-vault` on the command line for a one-off run without editing config.
 
 ### Walkthrough Report
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **myKG** automatically generates a confidence-scored knowledge graph from a directory of Markdown files, grounded in an induced RDFS/OWL ontology schema.
 
-It uses a **two-pass LLM pipeline**: Pass 1 induces a global RDFS/OWL schema from your document corpus; Pass 2 extracts typed entity and relationship instances per file against that schema. The result is exported to multiple formats: JSONL for property-graph consumers such as Neo4j, Turtle RDF for OWL toolchains, and seven NetworkX formats for graph analysis and visualization.
+It uses a **two-pass LLM pipeline**: Pass 1 induces a global RDFS/OWL schema from your document corpus; Pass 2 extracts typed entity and relationship instances per file against that schema. The result is exported to multiple formats: JSONL for property-graph consumers such as Neo4j, Turtle RDF for OWL toolchains, seven NetworkX formats for graph analysis and visualization, and an **Obsidian vault** — a second brain of wikilinked Markdown notes your AI coding assistant (Claude Code, Cursor, Copilot) can read and reason over directly.
 
 ## Command line
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **myKG** automatically generates a confidence-scored knowledge graph from a directory of Markdown files, grounded in an induced RDFS/OWL ontology schema.
 
-It uses a **two-pass LLM pipeline**: Pass 1 induces a global RDFS/OWL schema from your document corpus; Pass 2 extracts typed entity and relationship instances per file against that schema. The result is exported to multiple formats: JSONL for property-graph consumers such as Neo4j, Turtle RDF for OWL toolchains, seven NetworkX formats for graph analysis and visualization, and an Obsidian vault — a second brain of wikilinked Markdown notes your AI coding assistant (Claude Code, Cursor, Copilot) can read and reason over directly.
+It uses a **two-pass LLM pipeline**: Pass 1 induces a global RDFS/OWL schema from your document corpus; Pass 2 extracts typed entity and relationship instances per file against that schema. The result is exported to multiple formats: JSONL for property-graph consumers such as Neo4j, Turtle RDF for OWL toolchains, seven NetworkX formats for graph analysis and visualization, and an **Obsidian vault** — a second brain of wikilinked Markdown notes your AI coding assistant (Claude Code, Cursor, Copilot) can read and reason over directly.
 
 ## Command line
 
@@ -69,26 +69,35 @@ sessions/2026-05-17T18-31-07/
 
 ## Features
 
-### Extraction
-- **Schema-first** — Pass 1 induces an RDFS/OWL schema; Pass 2 extracts entities and relationships against it
-- **Bring your own ontology** — lock classes/properties with `--base-schema`; the LLM can only extend, not contradict
-- **SKOS thesaurus** — `--thesaurus` resolves synonyms during schema merge
-- **Human review gate** — `--review` pauses after schema induction so you can edit before extraction begins
-- **Incremental** — `--append` adds new files without re-running Pass 1
+### Ontology-Guided Extraction
 
-### Output
-- **Obsidian vault — second brain for AI coding assistants** — one wikilinked Markdown note per entity in `output/obsidian_vault/`; open in [Obsidian](https://obsidian.md) or point Claude Code, Cursor, or Copilot at the folder to query your knowledge base in natural language
-- **JSONL** — `nodes.jsonl` + `edges.jsonl` for Neo4j, Kuzu, NetworkX, and RAG pipelines
-- **Turtle RDF** — RDFS/OWL TBox + ABox for Protégé, SPARQL endpoints, and OWL reasoners
-- **NetworkX formats** — GML, GraphML, GEXF, Pajek, JSON node-link, and interactive HTML graph
-- **Confidence scoring** — every attribute, node, and edge carries a `0.0–1.0` score
+- **Schema-guided knowledge graph generation** — the extracted graph is always grounded in a formal RDFS/OWL schema: concept types, property names, domain/range constraints, and the is-a hierarchy are explicit and inspectable before any entity is extracted
+- **Bring your own ontology** — supply a `--base-schema` TTL file to lock in classes and properties from an existing formal ontology; the LLM expands it with domain-specific concepts but cannot rename, remove, or contradict your authoritative vocabulary
+- **SKOS thesaurus support** — pass `--thesaurus` to load a SKOS vocabulary; `skos:exactMatch` terms are collapsed silently, `skos:closeMatch` terms trigger a warning — giving the schema merger richer synonym awareness than string matching alone
+- **Verifiable TTL ontology** — after Pass 1, the induced schema is exported as a valid RDFS/OWL Turtle file (`intermediate/schema.ttl`) that can be opened directly in ontology editors such as [Protégé](https://protege.stanford.edu/). The TTL is validated by rdflib (syntax + semantic checks: domain/range refer to declared classes, no conflicting ranges) before any extraction begins
+- **Human-in-the-loop ontology design** — run with `--review` to pause after schema induction; inspect and edit `schema.json` (or load `schema.ttl` in Protégé, modify, and save back) before a single entity is extracted; resume with `mykg approve-schema`
+- **Incremental updates** — run with `--append` on an existing session to add new or modified Markdown files without re-running Pass 1; the schema is reused and only the new files go through Pass 2
+- **AI coding assistant friendly** — designed for smooth use alongside AI coding assistants such as [Claude Code](https://claude.ai/code); run extractions, inspect outputs, and iterate on your knowledge graph without leaving your coding environment; see [Using with Claude Code](#using-with-claude-code)
+- **Second brain for AI coding assistants** — the Obsidian vault output turns your extracted knowledge graph into a directory of wikilinked Markdown notes that any AI coding assistant can read as project context; point Claude Code, Cursor, or Copilot at `output/obsidian_vault/` and ask questions, trace relationships, and get answers grounded in your own documents
 
-### Pipeline
-- **Name normalization** — surface-form variants merged to a single canonical node with aliases
-- **Orphan-connection pass** — co-occurrence heuristic + LLM reconnects isolated nodes
-- **Cross-session merge** — combine two sessions into one unified graph
-- **Resumable** — re-enter at any step after a crash or edit; work already done is never repeated
-- **Provider-agnostic** — Anthropic, OpenAI, Ollama, OpenRouter, or the `claude` CLI (no API key needed)
+### Input
+
+- **Markdown files** — any directory of `.md` files; subdirectory structure is preserved; YAML/TOML frontmatter, headings, lists, and code blocks are all treated as structural signals
+- **Other formats** — convert PDFs, Word docs, HTML, and other formats to Markdown first using a document parser such as [MinerU](https://github.com/opendatalab/mineru), then point myKG at the output directory
+
+### Graph & Output
+
+- **Provider-agnostic** — works with Anthropic (Claude), OpenAI (GPT-4o), Ollama (local), OpenRouter, or the `claude` CLI with no API key
+- **Four output families** — JSONL for Neo4j/NetworkX/RAG, Turtle RDF for OWL toolchains, NetworkX multi-format for graph analysis, and Obsidian vault for linked personal knowledge management
+- **Obsidian vault — second brain for AI coding assistants** — every extracted entity becomes a wikilinked Markdown note in `output/obsidian_vault/`; open it in [Obsidian](https://obsidian.md) to navigate the graph with backlinks and Graph View, or point your AI coding assistant (Claude Code, Cursor, Copilot) at the vault folder so it can answer questions, trace relationships, and reason over your knowledge base in natural language
+- **Interactive HTML graph** — node/edge filtering, search, hover popups; opens directly in a browser
+- **Confidence scoring** — every extracted attribute, node, and edge carries a `0.0–1.0` confidence score
+- **Name normalization** — surface-form variants ("Acme Corp", "ACME", "Acme Corporation") resolved to a single canonical node with aliases
+- **Orphan-connection pass** — reconnects isolated nodes via co-occurrence heuristic + LLM confirmation
+- **Cross-session merge** — combine two independently-produced graphs into one unified knowledge graph
+- **Resumable pipeline** — every stage persists intermediate state; re-enter at any step after a crash or edit
+- **Session isolation** — each run is fully self-contained; inputs, intermediate state, outputs, and logs co-located
+- **Query knowledge graph** — natural-language and structured queries directly against the extracted graph via AI coding assistants such as [Claude Code](https://claude.ai/code), SPARQL endpoints, or graph traversal APIs
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ sessions/2026-05-17T18-31-07/
 - **Human-in-the-loop ontology design** — run with `--review` to pause after schema induction; inspect and edit `schema.json` (or load `schema.ttl` in Protégé, modify, and save back) before a single entity is extracted; resume with `mykg approve-schema`
 - **Incremental updates** — run with `--append` on an existing session to add new or modified Markdown files without re-running Pass 1; the schema is reused and only the new files go through Pass 2
 - **AI coding assistant friendly** — designed for smooth use alongside AI coding assistants such as [Claude Code](https://claude.ai/code); run extractions, inspect outputs, and iterate on your knowledge graph without leaving your coding environment; see [Using with Claude Code](#using-with-claude-code)
+- **Second brain for AI coding assistants** — the Obsidian vault output turns your extracted knowledge graph into a directory of wikilinked Markdown notes that any AI coding assistant can read as project context; point Claude Code, Cursor, or Copilot at `output/obsidian_vault/` and ask questions, trace relationships, and get answers grounded in your own documents
 
 ### Input
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **myKG** automatically generates a confidence-scored knowledge graph from a directory of Markdown files, grounded in an induced RDFS/OWL ontology schema.
 
-It uses a **two-pass LLM pipeline**: Pass 1 induces a global RDFS/OWL schema from your document corpus; Pass 2 extracts typed entity and relationship instances per file against that schema. The result is exported to multiple formats: JSONL for property-graph consumers such as Neo4j, Turtle RDF for OWL toolchains, seven NetworkX formats for graph analysis and visualization, and an **Obsidian vault** — a second brain of wikilinked Markdown notes your AI coding assistant (Claude Code, Cursor, Copilot) can read and reason over directly.
+It uses a **two-pass LLM pipeline**: Pass 1 induces a global RDFS/OWL schema from your document corpus; Pass 2 extracts typed entity and relationship instances per file against that schema. The result is exported to multiple formats: JSONL for property-graph consumers such as Neo4j, Turtle RDF for OWL toolchains, seven NetworkX formats for graph analysis and visualization, and an Obsidian vault — a second brain of wikilinked Markdown notes your AI coding assistant (Claude Code, Cursor, Copilot) can read and reason over directly.
 
 ## Command line
 
@@ -69,35 +69,26 @@ sessions/2026-05-17T18-31-07/
 
 ## Features
 
-### Ontology-Guided Extraction
+### Extraction
+- **Schema-first** — Pass 1 induces an RDFS/OWL schema; Pass 2 extracts entities and relationships against it
+- **Bring your own ontology** — lock classes/properties with `--base-schema`; the LLM can only extend, not contradict
+- **SKOS thesaurus** — `--thesaurus` resolves synonyms during schema merge
+- **Human review gate** — `--review` pauses after schema induction so you can edit before extraction begins
+- **Incremental** — `--append` adds new files without re-running Pass 1
 
-- **Schema-guided knowledge graph generation** — the extracted graph is always grounded in a formal RDFS/OWL schema: concept types, property names, domain/range constraints, and the is-a hierarchy are explicit and inspectable before any entity is extracted
-- **Bring your own ontology** — supply a `--base-schema` TTL file to lock in classes and properties from an existing formal ontology; the LLM expands it with domain-specific concepts but cannot rename, remove, or contradict your authoritative vocabulary
-- **SKOS thesaurus support** — pass `--thesaurus` to load a SKOS vocabulary; `skos:exactMatch` terms are collapsed silently, `skos:closeMatch` terms trigger a warning — giving the schema merger richer synonym awareness than string matching alone
-- **Verifiable TTL ontology** — after Pass 1, the induced schema is exported as a valid RDFS/OWL Turtle file (`intermediate/schema.ttl`) that can be opened directly in ontology editors such as [Protégé](https://protege.stanford.edu/). The TTL is validated by rdflib (syntax + semantic checks: domain/range refer to declared classes, no conflicting ranges) before any extraction begins
-- **Human-in-the-loop ontology design** — run with `--review` to pause after schema induction; inspect and edit `schema.json` (or load `schema.ttl` in Protégé, modify, and save back) before a single entity is extracted; resume with `mykg approve-schema`
-- **Incremental updates** — run with `--append` on an existing session to add new or modified Markdown files without re-running Pass 1; the schema is reused and only the new files go through Pass 2
-- **AI coding assistant friendly** — designed for smooth use alongside AI coding assistants such as [Claude Code](https://claude.ai/code); run extractions, inspect outputs, and iterate on your knowledge graph without leaving your coding environment; see [Using with Claude Code](#using-with-claude-code)
-- **Second brain for AI coding assistants** — the Obsidian vault output turns your extracted knowledge graph into a directory of wikilinked Markdown notes that any AI coding assistant can read as project context; point Claude Code, Cursor, or Copilot at `output/obsidian_vault/` and ask questions, trace relationships, and get answers grounded in your own documents
+### Output
+- **Obsidian vault — second brain for AI coding assistants** — one wikilinked Markdown note per entity in `output/obsidian_vault/`; open in [Obsidian](https://obsidian.md) or point Claude Code, Cursor, or Copilot at the folder to query your knowledge base in natural language
+- **JSONL** — `nodes.jsonl` + `edges.jsonl` for Neo4j, Kuzu, NetworkX, and RAG pipelines
+- **Turtle RDF** — RDFS/OWL TBox + ABox for Protégé, SPARQL endpoints, and OWL reasoners
+- **NetworkX formats** — GML, GraphML, GEXF, Pajek, JSON node-link, and interactive HTML graph
+- **Confidence scoring** — every attribute, node, and edge carries a `0.0–1.0` score
 
-### Input
-
-- **Markdown files** — any directory of `.md` files; subdirectory structure is preserved; YAML/TOML frontmatter, headings, lists, and code blocks are all treated as structural signals
-- **Other formats** — convert PDFs, Word docs, HTML, and other formats to Markdown first using a document parser such as [MinerU](https://github.com/opendatalab/mineru), then point myKG at the output directory
-
-### Graph & Output
-
-- **Provider-agnostic** — works with Anthropic (Claude), OpenAI (GPT-4o), Ollama (local), OpenRouter, or the `claude` CLI with no API key
-- **Four output families** — JSONL for Neo4j/NetworkX/RAG, Turtle RDF for OWL toolchains, NetworkX multi-format for graph analysis, and Obsidian vault for linked personal knowledge management
-- **Obsidian vault — second brain for AI coding assistants** — every extracted entity becomes a wikilinked Markdown note in `output/obsidian_vault/`; open it in [Obsidian](https://obsidian.md) to navigate the graph with backlinks and Graph View, or point your AI coding assistant (Claude Code, Cursor, Copilot) at the vault folder so it can answer questions, trace relationships, and reason over your knowledge base in natural language
-- **Interactive HTML graph** — node/edge filtering, search, hover popups; opens directly in a browser
-- **Confidence scoring** — every extracted attribute, node, and edge carries a `0.0–1.0` confidence score
-- **Name normalization** — surface-form variants ("Acme Corp", "ACME", "Acme Corporation") resolved to a single canonical node with aliases
-- **Orphan-connection pass** — reconnects isolated nodes via co-occurrence heuristic + LLM confirmation
-- **Cross-session merge** — combine two independently-produced graphs into one unified knowledge graph
-- **Resumable pipeline** — every stage persists intermediate state; re-enter at any step after a crash or edit
-- **Session isolation** — each run is fully self-contained; inputs, intermediate state, outputs, and logs co-located
-- **Query knowledge graph** — natural-language and structured queries directly against the extracted graph via AI coding assistants such as [Claude Code](https://claude.ai/code), SPARQL endpoints, or graph traversal APIs
+### Pipeline
+- **Name normalization** — surface-form variants merged to a single canonical node with aliases
+- **Orphan-connection pass** — co-occurrence heuristic + LLM reconnects isolated nodes
+- **Cross-session merge** — combine two sessions into one unified graph
+- **Resumable** — re-enter at any step after a crash or edit; work already done is never repeated
+- **Provider-agnostic** — Anthropic, OpenAI, Ollama, OpenRouter, or the `claude` CLI (no API key needed)
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sessions/2026-05-17T18-31-07/
 
 - **Provider-agnostic** — works with Anthropic (Claude), OpenAI (GPT-4o), Ollama (local), OpenRouter, or the `claude` CLI with no API key
 - **Four output families** — JSONL for Neo4j/NetworkX/RAG, Turtle RDF for OWL toolchains, NetworkX multi-format for graph analysis, and Obsidian vault for linked personal knowledge management
-- **Obsidian vault export** — automatically writes one linked Markdown note per entity to `output/obsidian_vault/`; open the folder directly in [Obsidian](https://obsidian.md) to explore the graph with backlinks and Graph View
+- **Obsidian vault — second brain for AI coding assistants** — every extracted entity becomes a wikilinked Markdown note in `output/obsidian_vault/`; open it in [Obsidian](https://obsidian.md) to navigate the graph with backlinks and Graph View, or point your AI coding assistant (Claude Code, Cursor, Copilot) at the vault folder so it can answer questions, trace relationships, and reason over your knowledge base in natural language
 - **Interactive HTML graph** — node/edge filtering, search, hover popups; opens directly in a browser
 - **Confidence scoring** — every extracted attribute, node, and edge carries a `0.0–1.0` confidence score
 - **Name normalization** — surface-form variants ("Acme Corp", "ACME", "Acme Corporation") resolved to a single canonical node with aliases

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-669%20passing-brightgreen.svg)](tests/)
-[![Coverage](https://img.shields.io/badge/coverage-89%25-brightgreen.svg)](htmlcov/index.html)
+[![Tests](https://img.shields.io/badge/tests-687%20passing-brightgreen.svg)](tests/)
+[![Coverage](https://img.shields.io/badge/coverage-87%25-brightgreen.svg)](htmlcov/index.html)
 [![Providers](https://img.shields.io/badge/LLM-Anthropic%20%7C%20OpenAI%20%7C%20Ollama%20%7C%20OpenRouter-orange.svg)](#configuration)
 [![PyPI version](https://img.shields.io/pypi/v/mykg.svg)](https://pypi.org/project/mykg/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/mykg.svg)](https://clickpy.clickhouse.com/dashboard/mykg)

--- a/architecture.md
+++ b/architecture.md
@@ -86,6 +86,7 @@ Both pipelines run as a sequence of named steps. All intermediate state is writt
 │  knowledge_graph.ttl            → Protégé, SPARQL, OWL reasoners    │
 │  networkx_output/ (7 formats)   → Gephi, D3.js, yEd, …             │
 │  knowledge_graph.html           → Interactive browser visualization  │
+│  obsidian_vault/                → Obsidian-ready linked notes        │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -120,7 +121,7 @@ The extract pipeline (`mykg extract-graph`) runs 11 steps in sequence. Steps mar
 | 8 | `assemble` | — | Assigns stable IDs, deduplicates nodes and edges across all files, applies the name normalization map, writes the edge metadata sidecar, and logs all merge decisions | `edge_metadata.json`, `nodes.json`, `merge_log.json` |
 | 9 | `orphan_score` | — | Maps each zero-edge node to its source chunk using the chunk node index. Produces one candidate group per source chunk that contains at least one orphan | `orphan_candidates.json` |
 | 10 | `orphan_connect` | ✓ | For each candidate group, calls the LLM once with the full source chunk text to find missing relationships. Validates and merges confirmed edges into the sidecar. Escalates to schema-gap restart if needed | `orphan_connections.json`, `orphan_log.json` |
-| 11 | `validate_graph` | — | Exports all three output formats from the same in-memory data: JSONL, Turtle RDF, and all NetworkX formats. Validates the Turtle file before writing. Generates the interactive HTML visualization | `nodes.jsonl`, `edges.jsonl`, `knowledge_graph.ttl`, `networkx_output/` |
+| 11 | `validate_graph` | — | Exports all output formats from the same in-memory data: JSONL, Turtle RDF, NetworkX formats, and the Obsidian vault. Validates the Turtle file before writing. Generates the interactive HTML visualization | `nodes.jsonl`, `edges.jsonl`, `knowledge_graph.ttl`, `networkx_output/`, `obsidian_vault/` |
 
 ---
 
@@ -140,7 +141,7 @@ The merge pipeline (`mykg merge-graphs`) runs 12 steps. Steps 3–5 and 8–11 a
 | 8 | `assemble` | — | Reused from extract pipeline | `edge_metadata.json`, `nodes.json`, `merge_log.json` |
 | 9 | `orphan_score` | — | Reused from extract pipeline | `orphan_candidates.json` |
 | 10 | `orphan_connect` | ✓ | Reused from extract pipeline | `orphan_connections.json`, `orphan_log.json` |
-| 11 | `validate_graph` | — | Reused from extract pipeline | `nodes.jsonl`, `edges.jsonl`, `knowledge_graph.ttl`, `networkx_output/` |
+| 11 | `validate_graph` | — | Reused from extract pipeline | `nodes.jsonl`, `edges.jsonl`, `knowledge_graph.ttl`, `networkx_output/`, `obsidian_vault/` |
 | 12 | `merge_manifest` | — | Writes the merge audit record: source session names, timestamp, schema deltas for each session, re-extraction strategy used, and synonym collapse events from schema merge | `merge_manifest.json` |
 
 ---
@@ -248,7 +249,7 @@ To resume or correct a merge session, pass `--session <merged-session-name>` whe
 
 ## Output Formats
 
-All three output formats are produced from the same in-memory data at export time and are always kept in sync.
+All four output formats are produced from the same in-memory data at export time and are always kept in sync.
 
 ### Property Graph (JSONL)
 
@@ -267,6 +268,18 @@ Seven graph formats are written to `output/networkx_output/`: GML (human-readabl
 ### Interactive HTML
 
 `output/networkx_output/knowledge_graph.html` is a self-contained force-directed graph visualization built with vis.js. It requires no server. It supports filtering nodes and edges by type, filtering by confidence threshold, name search, and hover popups with full attribute values.
+
+### Obsidian Vault
+
+`output/obsidian_vault/` is a directory of linked Markdown files that can be opened directly as a vault in [Obsidian](https://obsidian.md). One `.md` note is written per extracted entity, grouped into subdirectories by concept type (e.g. `Person/`, `Organization/`). An `index.md` at the root summarizes node counts per type and links to every entity note.
+
+Each entity note is structured as:
+- **YAML frontmatter** — `id`, `type`, `confidence`, and `sources` (list of source files)
+- **Attributes section** — one bullet per extracted attribute with value and confidence
+- **Relationships section** — outgoing and incoming edges as Obsidian wikilinks (`[[Entity Name]] — edge_type (confidence)`); wikilinks are resolved by Obsidian's native backlink index, so Graph View shows the full relationship network automatically
+- **Source files section** — Markdown files from which the entity was extracted
+
+Enabled by default via `pipeline.export.obsidian_enabled: true` in `mykg_config.yaml`. The output directory name is configurable via `pipeline.export.obsidian_vault_dir`.
 
 ---
 
@@ -365,6 +378,7 @@ All provider parameters — model, context window, token limits, timeout, base U
 
 | Decision | What was chosen | Why |
 |---|---|---|
-| **Three parallel output families** | JSONL, Turtle RDF, and NetworkX — all generated from the same in-memory data | Each format serves a different consumer without requiring a separate pipeline run |
+| **Four parallel output families** | JSONL, Turtle RDF, NetworkX, and Obsidian vault — all generated from the same in-memory data | Each format serves a different consumer without requiring a separate pipeline run |
+| **Obsidian vault as first-class output** | One entity note per node with YAML frontmatter, attribute listings, and wikilinked relationships; `index.md` as overview | Enables native Obsidian Graph View and backlink navigation with zero manual setup; vault is ready to open immediately after extraction |
 | **Node aliases as `skos:altLabel`** | Non-canonical surface forms stored as a flat sorted list on each node; emitted as `skos:altLabel` triples in the TTL | Standard well-known predicate; no custom vocabulary needed; works in any SPARQL endpoint |
 | **Edge metadata excluded from TTL** | Confidence scores, role, start date, and other edge attributes live only in `edge_metadata.json` | Keeps the TTL valid with any standard RDF toolchain; avoids RDF reification, blank nodes, and RDF-star |

--- a/mykg_config.yaml
+++ b/mykg_config.yaml
@@ -100,6 +100,8 @@ profiles:
         comment_width: 42          # column width for section divider comments in knowledge_graph.ttl
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"  # SKOS namespace for skos:altLabel alias triples
         networkx_enabled: true     # write NetworkX multi-format exports to output/networkx_output/ (GML, GraphML, GEXF, etc.)
+        obsidian_enabled: true     # write Obsidian vault to output/obsidian_vault/ (markdown notes + graph links)
+        obsidian_vault_dir: obsidian_vault  # subdirectory under output/ for the Obsidian vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:               # circuit-breaker: pauses the run when too many API errors accumulate
         enabled: false          # set false for fully unattended runs (e.g. providers with no rate limits)
@@ -316,6 +318,8 @@ profiles:
         comment_width: 42
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"
         networkx_enabled: true
+        obsidian_enabled: true
+        obsidian_vault_dir: obsidian_vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:
         enabled: false
@@ -425,6 +429,8 @@ profiles:
         comment_width: 42
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"
         networkx_enabled: true
+        obsidian_enabled: true
+        obsidian_vault_dir: obsidian_vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:
         enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mykg"
-version = "0.2.5"
+version = "0.2.6"
 description = "Two-pass LLM pipeline that turns Markdown files into a confidence-scored knowledge graph with an induced RDFS/OWL ontology"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/mykg/__init__.py
+++ b/src/mykg/__init__.py
@@ -8,6 +8,7 @@ def __getattr__(name: str):
         import mykg.llm.config as _llm_cfg
         import mykg.orchestrator as _orch
         import mykg.pipeline as _pipe
+
         globals()["load_adapter"] = _llm_cfg.load_adapter
         globals()["PipelineContext"] = _orch.PipelineContext
         globals()["run"] = _orch.run

--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 
 def _cfg():
     from mykg import config
+
     return config
 
 
@@ -91,8 +92,14 @@ _PROFILE_META = {
 @cli.command("init")
 @click.option("--force", is_flag=True, help="Overwrite existing mykg_config.yaml")
 @click.option("--profile", default=None, help="LLM profile to activate (skips interactive prompt)")
-@click.option("--model", default=None, help="Model name to set in the active profile (skips interactive prompt)")
-@click.option("--api-key", default=None, help="API key to write to .env.mykg (skips interactive prompt)")
+@click.option(
+    "--model",
+    default=None,
+    help="Model name to set in the active profile (skips interactive prompt)",
+)
+@click.option(
+    "--api-key", default=None, help="API key to write to .env.mykg (skips interactive prompt)"
+)
 def init_config(force: bool, profile: str | None, model: str | None, api_key: str | None) -> None:
     """Create mykg_config.yaml and optionally configure LLM provider, model, and API key."""
     dest = Path.cwd() / "mykg_config.yaml"
@@ -127,7 +134,7 @@ def init_config(force: bool, profile: str | None, model: str | None, api_key: st
     if model is None:
         default_model = meta["default_model"]
         model_input = click.prompt(
-            f"Model name (press Enter for default)",
+            "Model name (press Enter for default)",
             default=default_model,
             show_default=True,
         ).strip()
@@ -135,6 +142,7 @@ def init_config(force: bool, profile: str | None, model: str | None, api_key: st
 
     # --- Write mykg_config.yaml with selected profile and optional model -
     import re
+
     template = Path(__file__).parent / "data" / "mykg_config.yaml"
     content = template.read_text()
     content = re.sub(r"^profile:.*$", f"profile: {profile}", content, count=1, flags=re.MULTILINE)
@@ -157,8 +165,8 @@ def init_config(force: bool, profile: str | None, model: str | None, api_key: st
     existing_key = None
     if env_file.exists():
         for line in env_file.read_text().splitlines():
-            if line.startswith(f"{var}=") and line[len(var) + 1:].strip():
-                existing_key = line[len(var) + 1:].strip()
+            if line.startswith(f"{var}=") and line[len(var) + 1 :].strip():
+                existing_key = line[len(var) + 1 :].strip()
                 break
 
     if existing_key:
@@ -186,6 +194,7 @@ def init_config(force: bool, profile: str | None, model: str | None, api_key: st
 def _patch_profile_model(content: str, profile: str, model: str) -> str:
     """Replace the model: line inside a specific profile block in the YAML text."""
     import re
+
     # Find the profile block start, then replace the first `      model:` line within it.
     # Profile blocks are indented with two spaces; llm.model is indented with six.
     profile_pattern = re.compile(
@@ -216,7 +225,9 @@ def _print_next_steps(profile: str) -> None:
     if profile == "ollama-local":
         click.echo("  (make sure Ollama is running: ollama serve)")
     elif profile == "claude-cli":
-        click.echo("  (make sure the claude CLI is installed: npm install -g @anthropic-ai/claude-code)")
+        click.echo(
+            "  (make sure the claude CLI is installed: npm install -g @anthropic-ai/claude-code)"
+        )
 
 
 @cli.command("extract-graph")
@@ -247,8 +258,8 @@ def _print_next_steps(profile: str) -> None:
     "--from-step",
     default=None,
     help="Force re-run from this step. Use 'orphan_connect_fullsweep' for a full clean "
-         "sweep (deletes prior orphan_connections.json) or 'orphan_connect_incremental' "
-         "to preserve it and only re-send unresolved groups to the LLM.",
+    "sweep (deletes prior orphan_connections.json) or 'orphan_connect_incremental' "
+    "to preserve it and only re-send unresolved groups to the LLM.",
 )
 @click.option(
     "--workers",
@@ -364,11 +375,14 @@ def extract_graph(
 
     if obsidian_vault:
         import mykg.config as _config_mod
+
         _config_mod.OBSIDIAN_ENABLED = True
 
     from mykg.llm.error_gate import ErrorGate
 
-    error_gate = ErrorGate(threshold=_cfg().ERROR_GATE_THRESHOLD) if _cfg().ERROR_GATE_ENABLED else None
+    error_gate = (
+        ErrorGate(threshold=_cfg().ERROR_GATE_THRESHOLD) if _cfg().ERROR_GATE_ENABLED else None
+    )
     adapter = load_adapter(error_gate=error_gate)
     logging.getLogger(__name__).info("LLM endpoint: %s", adapter.endpoint_label())
 
@@ -421,6 +435,7 @@ def extract_graph(
 def approve_schema(intermediate_dir, log_file, verbose, session):
     """Regenerate schema.ttl from schema.json and write the approval flag."""
     from mykg.logging import setup
+
     setup(log_file=log_file, verbose=verbose)
 
     if session and intermediate_dir is not None:
@@ -443,7 +458,9 @@ def approve_schema(intermediate_dir, log_file, verbose, session):
 
     flag = Path(intermediate_dir) / "schema_approved.flag"
     flag.write_text("approved")
-    click.echo("Schema approved. schema.ttl regenerated. Resume with the original extract-graph command.")
+    click.echo(
+        "Schema approved. schema.ttl regenerated. Resume with the original extract-graph command."
+    )
 
 
 @cli.command("walkthrough")
@@ -497,7 +514,7 @@ def walkthrough_cmd(session_name: str, log_file: str | None) -> None:
     "--from-step",
     default=None,
     help="Force re-run from this merge step (e.g. orphan_score, orphan_connect). "
-         "Requires --output-session targeting an existing merged session.",
+    "Requires --output-session targeting an existing merged session.",
 )
 def merge_graphs(
     session_a, session_b, output_session, thesaurus, base_schema, log_file, verbose, from_step
@@ -543,6 +560,7 @@ def merge_graphs(
 
     from mykg.llm.config import load_adapter
     from mykg.logging import setup
+
     setup(log_file=log_file, verbose=verbose)
 
     if from_step:
@@ -592,7 +610,7 @@ def merge_graphs(
 # Aliases for --from-step that encode the orphan-connect sweep mode.
 # Maps alias → (real_step_name, orphan_incremental)
 _FROM_STEP_ALIASES: dict[str, tuple[str, bool]] = {
-    "orphan_connect_fullsweep":   ("orphan_connect", False),
+    "orphan_connect_fullsweep": ("orphan_connect", False),
     "orphan_connect_incremental": ("orphan_connect", True),
 }
 
@@ -662,7 +680,9 @@ def _delete_from_step(
     # obsidian_vault/ is written by validate_graph but not tracked in Step.outputs
     # (it is optional; omitting it prevents _is_done from breaking when disabled).
     # Delete it when re-running from validate_graph or any earlier step.
-    validate_graph_idx = step_names.index("validate_graph") if "validate_graph" in step_names else -1
+    validate_graph_idx = (
+        step_names.index("validate_graph") if "validate_graph" in step_names else -1
+    )
     if validate_graph_idx >= 0 and idx <= validate_graph_idx:
         obsidian_path = output_dir / _cfg().OBSIDIAN_VAULT_DIR
         if obsidian_path.exists():
@@ -702,7 +722,9 @@ def _delete_merge_from_step(
 
     # Shard directories must be cleared when re-running from merge_reextract or
     # earlier, otherwise existing shards are reused and the step is silently skipped.
-    merge_reextract_idx = step_names.index("merge_reextract") if "merge_reextract" in step_names else -1
+    merge_reextract_idx = (
+        step_names.index("merge_reextract") if "merge_reextract" in step_names else -1
+    )
     if merge_reextract_idx >= 0 and idx <= merge_reextract_idx:
         for shard_dir_name in ("raw_extractions_shards", "chunk_index_shards"):
             shard_path = intermediate_dir / shard_dir_name

--- a/src/mykg/config.py
+++ b/src/mykg/config.py
@@ -223,6 +223,4 @@ MERGE_GRAPHS_HUMAN_REVIEW: bool = bool(_get_opt("merge_graphs", "human_review", 
 MERGE_SURGICAL_TOP_K_CHUNKS_PER_PROPERTY: int = _get_opt(
     "merge_graphs", "surgical_top_k_chunks_per_property", 0
 )
-MERGE_ORPHAN_SCHEMA_MAX_RESTARTS: int = _get_opt(
-    "merge_graphs", "orphan_pass_max_restarts", 1
-)
+MERGE_ORPHAN_SCHEMA_MAX_RESTARTS: int = _get_opt("merge_graphs", "orphan_pass_max_restarts", 1)

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -100,7 +100,7 @@ profiles:
         comment_width: 42          # column width for section divider comments in knowledge_graph.ttl
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"  # SKOS namespace for skos:altLabel alias triples
         networkx_enabled: true     # write NetworkX multi-format exports to output/networkx_output/ (GML, GraphML, GEXF, etc.)
-        obsidian_enabled: false    # write Obsidian vault to output/obsidian_vault/ (markdown notes + graph links)
+        obsidian_enabled: true     # write Obsidian vault to output/obsidian_vault/ (markdown notes + graph links)
         obsidian_vault_dir: obsidian_vault  # subdirectory under output/ for the Obsidian vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:               # circuit-breaker: pauses the run when too many API errors accumulate
@@ -210,7 +210,7 @@ profiles:
         comment_width: 42          # column width for section divider comments in knowledge_graph.ttl
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"  # SKOS namespace for skos:altLabel alias triples
         networkx_enabled: true     # write NetworkX multi-format exports to output/networkx_output/ (GML, GraphML, GEXF, etc.)
-        obsidian_enabled: false
+        obsidian_enabled: true
         obsidian_vault_dir: obsidian_vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:               # circuit-breaker: pauses the run when too many API errors accumulate
@@ -320,7 +320,7 @@ profiles:
         comment_width: 42
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"
         networkx_enabled: true
-        obsidian_enabled: false
+        obsidian_enabled: true
         obsidian_vault_dir: obsidian_vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:
@@ -431,7 +431,7 @@ profiles:
         comment_width: 42
         skos_namespace: "http://www.w3.org/2004/02/skos/core#"
         networkx_enabled: true
-        obsidian_enabled: false
+        obsidian_enabled: true
         obsidian_vault_dir: obsidian_vault
       # --- Pipeline infrastructure --------------------------------------------
       error_gate:

--- a/src/mykg/exporter.py
+++ b/src/mykg/exporter.py
@@ -17,6 +17,11 @@ export.networkx_enabled; written to output/networkx_output/):
   edges_nx.txt                 — plain edge list with attributes
   adjacency.txt                — adjacency list, topology only
 
+Obsidian vault output (export_obsidian, toggled via mykg_config.yaml
+export.obsidian_enabled; written to output/obsidian_vault/):
+  <Type>/<node_id>.md          — one note per entity with YAML frontmatter and wikilinks
+  index.md                     — vault root overview with per-type entity tables
+
 Node/edge attributes are flattened to GML-safe scalars:
   attr_<name>_value / attr_<name>_confidence
 source_files lists are pipe-joined ("a.md|b.md") for format compatibility.
@@ -27,9 +32,11 @@ from __future__ import annotations
 import html as _html
 import json
 import re
+from collections import defaultdict
 from pathlib import Path
 
 import networkx as nx
+import yaml
 from networkx.readwrite import json_graph
 
 from mykg import config as _cfg
@@ -665,5 +672,189 @@ def export_networkx(nodes: list[dict], edge_metadata: dict, output_dir: Path) ->
 
     nx.write_adjlist(G, str(nx_dir / "adjacency.txt"))
     written.append("adjacency.txt")
+
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Obsidian vault export
+# ---------------------------------------------------------------------------
+
+
+def _node_display_name(node: dict) -> str:
+    """Return the human-readable display name for a node (name attribute value or node ID)."""
+    name_attr = node.get("attributes", {}).get("name")
+    if isinstance(name_attr, dict):
+        val = name_attr.get("value")
+        if val:
+            return str(val)
+    return node["id"]
+
+
+def _obsidian_entity_note(
+    node: dict,
+    outgoing: list[tuple[str, str, float]],
+    incoming: list[tuple[str, str, float]],
+) -> str:
+    """Render a single entity note as a Markdown string with YAML frontmatter."""
+    node_id = node["id"]
+    node_type = node.get("type", "")
+    confidence = node.get("confidence", 0.0)
+    source_files = node.get("source_files", [])
+    attributes = node.get("attributes", {})
+    display_name = _node_display_name(node)
+
+    frontmatter_data: dict = {
+        "id": node_id,
+        "type": node_type,
+        "confidence": round(float(confidence), 4),
+    }
+    if source_files:
+        frontmatter_data["sources"] = list(source_files)
+
+    frontmatter = yaml.dump(frontmatter_data, default_flow_style=False, allow_unicode=True).rstrip()
+    lines: list[str] = ["---", frontmatter, "---", "", f"# {display_name}", ""]
+
+    # Attributes section (skip "name" — it is the heading)
+    attr_lines = []
+    for attr_name, payload in attributes.items():
+        if attr_name == "name":
+            continue
+        if isinstance(payload, dict):
+            val = payload.get("value")
+            conf = payload.get("confidence", 0.0)
+        else:
+            val = payload
+            conf = 0.0
+        if val is None:
+            continue
+        attr_lines.append(f"- **{attr_name}**: {val} ({round(float(conf), 2)})")
+
+    if attr_lines:
+        lines.append("## Attributes")
+        lines.extend(attr_lines)
+        lines.append("")
+
+    # Relationships section
+    if outgoing or incoming:
+        lines.append("## Relationships")
+        lines.append("")
+        if outgoing:
+            lines.append("### Outgoing")
+            for target_name, edge_type, edge_conf in outgoing:
+                lines.append(f"- [[{target_name}]] — {edge_type} ({round(float(edge_conf), 2)})")
+            lines.append("")
+        if incoming:
+            lines.append("### Incoming")
+            for source_name, edge_type, edge_conf in incoming:
+                lines.append(f"- [[{source_name}]] — {edge_type} ({round(float(edge_conf), 2)})")
+            lines.append("")
+
+    # Source Files section
+    if source_files:
+        lines.append("## Source Files")
+        for sf in source_files:
+            lines.append(f"- {sf}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _obsidian_index(nodes: list[dict], edge_count: int) -> str:
+    """Render the vault index.md listing all entities grouped by type."""
+    lines: list[str] = [
+        "# Knowledge Graph Index",
+        "",
+        f"**{len(nodes)} entities** — **{edge_count} relationships**",
+        "",
+    ]
+
+    # Group nodes by type, sorted for deterministic output
+    by_type: dict[str, list[dict]] = defaultdict(list)
+    for node in nodes:
+        by_type[node.get("type", "Unknown")].append(node)
+
+    for node_type in sorted(by_type):
+        # Compute display name once per node to avoid double attribute lookups
+        group = sorted(
+            ((n, _node_display_name(n)) for n in by_type[node_type]),
+            key=lambda pair: pair[1],
+        )
+        lines.append(f"## {node_type}")
+        lines.append("")
+        lines.append("| Entity |")
+        lines.append("| --- |")
+        for _node, name in group:
+            lines.append(f"| [[{name}]] |")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def export_obsidian(
+    nodes: list[dict],
+    edge_metadata: dict,
+    schema: dict,  # kept for API symmetry with other export_ functions
+    output_dir: Path,
+) -> list[str]:
+    """Write an Obsidian vault to output_dir/obsidian_vault/.
+
+    One Markdown note per entity (Type/node_id.md), with YAML frontmatter,
+    attributes, wikilinked relationships, and an index.md overview.
+
+    Returns a list of written file paths as relative strings (same contract as
+    export_networkx).  Returns an empty list when OBSIDIAN_ENABLED is False.
+    """
+    if not getattr(_cfg, "OBSIDIAN_ENABLED", False):
+        return []
+
+    vault_dir = output_dir / "obsidian_vault"
+    vault_dir.mkdir(exist_ok=True)
+
+    # Build id → display_name lookup for wikilinks
+    id_to_name: dict[str, str] = {node["id"]: _node_display_name(node) for node in nodes}
+
+    # Build adjacency: outgoing/incoming per node_id
+    # Values: list of (peer_display_name, edge_type, confidence)
+    outgoing: dict[str, list[tuple[str, str, float]]] = defaultdict(list)
+    incoming: dict[str, list[tuple[str, str, float]]] = defaultdict(list)
+    for edge in edge_metadata.values():
+        from_id = edge.get("from", "")
+        to_id = edge.get("to", "")
+        edge_type = edge.get("type", "")
+        conf = float(edge.get("confidence", 0.0))
+        outgoing[from_id].append((id_to_name.get(to_id, to_id), edge_type, conf))
+        incoming[to_id].append((id_to_name.get(from_id, from_id), edge_type, conf))
+
+    # Pre-create one subdir per concept type to avoid repeated mkdir calls in the node loop
+    type_dirs: dict[str, Path] = {}
+    for node in nodes:
+        node_type = node.get("type", "Unknown")
+        if node_type not in type_dirs:
+            d = vault_dir / node_type
+            d.mkdir(exist_ok=True)
+            type_dirs[node_type] = d
+
+    written: list[str] = []
+
+    for node in nodes:
+        node_id = node["id"]
+        node_type = node.get("type", "Unknown")
+        type_dir = type_dirs[node_type]
+
+        note_content = _obsidian_entity_note(
+            node,
+            outgoing=outgoing.get(node_id, []),
+            incoming=incoming.get(node_id, []),
+        )
+        note_path = type_dir / f"{node_id}.md"
+        note_path.write_text(note_content, encoding="utf-8")
+        # Derive the relative path from the actual filesystem path to stay in sync
+        written.append(str(note_path.relative_to(output_dir)))
+
+    # Index
+    index_content = _obsidian_index(nodes, edge_count=len(edge_metadata))
+    (vault_dir / "index.md").write_text(index_content, encoding="utf-8")
+    written.append("obsidian_vault/index.md")
 
     return written

--- a/src/mykg/merge_context.py
+++ b/src/mykg/merge_context.py
@@ -26,9 +26,9 @@ class MergeContext(PipelineContext):
     sessions_root: Path
 
     # Runtime fields populated by merge steps
-    session_a: Any | None = None        # SessionData from merger.load_session
-    session_b: Any | None = None        # SessionData from merger.load_session
-    source_map: dict | None = None      # written by merge_setup
+    session_a: Any | None = None  # SessionData from merger.load_session
+    session_b: Any | None = None  # SessionData from merger.load_session
+    source_map: dict | None = None  # written by merge_setup
     synonym_log: list = Field(default_factory=list)  # written by merge_schema
     schema_delta_a: list = Field(default_factory=list)  # new props absent from session_a
     schema_delta_b: list = Field(default_factory=list)  # new props absent from session_b

--- a/src/mykg/merge_pipeline.py
+++ b/src/mykg/merge_pipeline.py
@@ -86,7 +86,12 @@ MERGE_STEPS: list[Step] = [
     Step(
         name="validate_graph",
         fn=run_validate_graph,
-        outputs=["nodes.jsonl", "edges.jsonl", "knowledge_graph.ttl", "knowledge_graph_validation.json"],
+        outputs=[
+            "nodes.jsonl",
+            "edges.jsonl",
+            "knowledge_graph.ttl",
+            "knowledge_graph_validation.json",
+        ],
         blocking=False,
         output_location="output",
     ),

--- a/src/mykg/merge_run.py
+++ b/src/mykg/merge_run.py
@@ -31,15 +31,9 @@ _MERGE_REENTRY_HINTS: dict[str, str] = {
     "merge_reextract": (
         "mykg merge-graphs <A> <B> --output-session <name> --from-step merge_reextract"
     ),
-    "merge_raw": (
-        "mykg merge-graphs <A> <B> --output-session <name> --from-step merge_raw"
-    ),
-    "assemble": (
-        "mykg merge-graphs <A> <B> --output-session <name> --from-step assemble"
-    ),
-    "orphan_score": (
-        "mykg merge-graphs <A> <B> --output-session <name> --from-step orphan_score"
-    ),
+    "merge_raw": ("mykg merge-graphs <A> <B> --output-session <name> --from-step merge_raw"),
+    "assemble": ("mykg merge-graphs <A> <B> --output-session <name> --from-step assemble"),
+    "orphan_score": ("mykg merge-graphs <A> <B> --output-session <name> --from-step orphan_score"),
     "orphan_connect": (
         "mykg merge-graphs <A> <B> --output-session <name> --from-step orphan_connect"
     ),

--- a/src/mykg/merger.py
+++ b/src/mykg/merger.py
@@ -124,9 +124,7 @@ def load_session(session_name: str, sessions_root: Path) -> SessionData:
                 session_name,
                 exc,
             )
-    log.debug(
-        "merger: manifest has %d file(s) for session %s", len(manifest), session_name
-    )
+    log.debug("merger: manifest has %d file(s) for session %s", len(manifest), session_name)
 
     # Optional: prep_mode from mykg_config.yaml snapshot
     prep_mode = _read_prep_mode(session_path)
@@ -155,9 +153,7 @@ def _read_prep_mode(session_path: Path) -> str:
     try:
         raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     except Exception as exc:
-        log.warning(
-            "merger: could not parse mykg_config.yaml at %s — %s", session_path, exc
-        )
+        log.warning("merger: could not parse mykg_config.yaml at %s — %s", session_path, exc)
         return "unknown"
 
     profile_name = raw.get("profile")
@@ -284,9 +280,7 @@ def _copy_shard_dir(src_dir: Path, dst_dir: Path, alias: str) -> None:
             h = hashlib.sha1(candidate.encode()).hexdigest()[:16]
             candidate = f"{alias}_{h}.json"
         dst_file = dst_dir / candidate
-        dst_file.write_text(
-            json.dumps(shard_data, indent=_cfg.JSON_INDENT), encoding="utf-8"
-        )
+        dst_file.write_text(json.dumps(shard_data, indent=_cfg.JSON_INDENT), encoding="utf-8")
         log.debug(
             "merger: shard %s → %s (_fname=%s)",
             shard_file.name,
@@ -689,9 +683,7 @@ def reextract_for_merge(
                     if namespaced_fname.startswith(f"{session_alias}/"):
                         prior_chunk_index[plain] = sd.get("data", {})
                 except (json.JSONDecodeError, OSError) as exc:
-                    log.warning(
-                        "reextract_for_merge: could not read chunk shard %s — %s", sf, exc
-                    )
+                    log.warning("reextract_for_merge: could not read chunk shard %s — %s", sf, exc)
 
         # Load file contents from the session's input directory.
         input_dir = session_path / "input"
@@ -759,9 +751,7 @@ def reextract_for_merge(
         # Critical: run_pass2 re-extracts ALL chunks of any file in `files` that
         # has no entry in reextract_chunks (target_chunks=None path in pass2).
         file_contents = {
-            fname: content
-            for fname, content in file_contents.items()
-            if fname in reextract_chunks
+            fname: content for fname, content in file_contents.items() if fname in reextract_chunks
         }
 
         total_targeted = sum(len(v) for v in reextract_chunks.values())
@@ -816,7 +806,9 @@ def reextract_for_merge(
     file_contents: dict[str, str] = {}
     for namespaced_key in raw_extractions_namespaced:
         # Strip the "session_a/" or "session_b/" prefix
-        original_fname = namespaced_key.split("/", 1)[1] if "/" in namespaced_key else namespaced_key
+        original_fname = (
+            namespaced_key.split("/", 1)[1] if "/" in namespaced_key else namespaced_key
+        )
         file_path = input_dir / original_fname
         if file_path.exists():
             file_contents[original_fname] = file_path.read_text(encoding="utf-8")

--- a/src/mykg/pass2.py
+++ b/src/mykg/pass2.py
@@ -166,7 +166,7 @@ def _normalize_scalars(extraction: dict) -> dict:
     Null scalars get confidence 0.0 (value unknown). Non-null scalars get
     CONFIDENCE_SCALAR_OMITTED (LLM knew the value but omitted the wrapper).
     """
-    for node in (extraction.get("nodes") or []):
+    for node in extraction.get("nodes") or []:
         if node is None:
             continue
         attrs = node.get("attributes", {})
@@ -177,7 +177,7 @@ def _normalize_scalars(extraction: dict) -> dict:
             if not isinstance(val, dict) or "value" not in val:
                 conf = 0.0 if val is None else _cfg.CONFIDENCE_SCALAR_OMITTED
                 node["attributes"][attr] = {"value": val, "confidence": conf}
-    for edge in (extraction.get("edges") or []):
+    for edge in extraction.get("edges") or []:
         if edge is None:
             continue
         attrs = edge.get("attributes", {})
@@ -196,7 +196,7 @@ def _backfill_extraction(extraction: dict, schema: dict, flat_schema: dict) -> d
     prop_attrs: dict[str, list[str]] = {
         p["name"]: p.get("attributes", []) for p in schema["properties"]
     }
-    for node in (extraction.get("nodes") or []):
+    for node in extraction.get("nodes") or []:
         if node is None:
             continue
         expected = flat_schema.get(node["type"], [])
@@ -204,7 +204,7 @@ def _backfill_extraction(extraction: dict, schema: dict, flat_schema: dict) -> d
         for attr in expected:
             if attr not in attrs:
                 attrs[attr] = {"value": None, "confidence": 0.0}
-    for edge in (extraction.get("edges") or []):
+    for edge in extraction.get("edges") or []:
         if edge is None:
             continue
         expected = prop_attrs.get(edge["type"], [])
@@ -619,10 +619,7 @@ def run_pass2_batched(
             "total_batches": total_batches,
             "completed": 0,
             "failed": 0,
-            "batches": {
-                name: {**entry, "status": "pending"}
-                for name, entry in batch_map.items()
-            },
+            "batches": {name: {**entry, "status": "pending"} for name, entry in batch_map.items()},
         }
         progress_path.write_text(json.dumps(progress, indent=2))
 
@@ -638,9 +635,7 @@ def run_pass2_batched(
 
     # Process batches in order so stateful prior_nodes flow correctly when per_file=True.
     # When per_file=False (mixed), prior_nodes are still threaded per source file.
-    def _process_batch(
-        batch_idx: int, batch: list[Chunk]
-    ) -> tuple[int, dict | None, list[Chunk]]:
+    def _process_batch(batch_idx: int, batch: list[Chunk]) -> tuple[int, dict | None, list[Chunk]]:
         # Collect per-file prior_nodes for files appearing in this batch.
         # For mixed batches we aggregate prior_nodes from all files in the batch.
         batch_files = {c.source_file for c in batch}
@@ -663,7 +658,10 @@ def run_pass2_batched(
         token_count = sum(c.token_end - c.token_start for c in batch)
         log.info(
             "  batch %d/%d — %d chunk(s), ~%d tokens",
-            batch_idx + 1, total_batches, len(batch), token_count,
+            batch_idx + 1,
+            total_batches,
+            len(batch),
+            token_count,
         )
         extraction = _extract_batch(
             batch, schema, flat_schema, adapter, batch_idx + 1, prior, hint_block
@@ -672,7 +670,9 @@ def run_pass2_batched(
             clean = _strip_nulls(extraction)
             log.debug(
                 "  batch %d — %d node(s), %d edge(s)",
-                batch_idx + 1, len(clean["nodes"]), len(clean["edges"]),
+                batch_idx + 1,
+                len(clean["nodes"]),
+                len(clean["edges"]),
             )
         return batch_idx, extraction, batch
 
@@ -699,9 +699,7 @@ def run_pass2_batched(
     done_batches = 0
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {
-            executor.submit(_process_batch, i, batch): i for i, batch in enumerate(batches)
-        }
+        futures = {executor.submit(_process_batch, i, batch): i for i, batch in enumerate(batches)}
         # Sort completed futures by batch index before merging so stateful
         # prior_nodes are updated sequentially.
         completed: list[tuple[int, dict | None, list[Chunk]]] = []
@@ -721,15 +719,12 @@ def run_pass2_batched(
             done_batches += 1
             elapsed = time.monotonic() - batch_start
             remaining_secs = (
-                (elapsed / done_batches) * (total_batches - done_batches)
-                if done_batches
-                else 0.0
+                (elapsed / done_batches) * (total_batches - done_batches) if done_batches else 0.0
             )
             eta_h = int(remaining_secs // 3600)
             eta_m = int((remaining_secs % 3600) // 60)
             log.info(
-                "Pass 2 batched progress — %d/%d batches (%.1f%%) "
-                "— elapsed %s — ETA ~%dh %02dm",
+                "Pass 2 batched progress — %d/%d batches (%.1f%%) — elapsed %s — ETA ~%dh %02dm",
                 done_batches,
                 total_batches,
                 done_batches / total_batches * 100 if total_batches else 0.0,
@@ -748,14 +743,15 @@ def run_pass2_batched(
                 break
             log.info(
                 "Pass 2 batched — retry round %d/%d: %d failed batch(es): %s",
-                retry_round + 1, batch_retry_max,
-                len(failed_items), [bi for bi, _ in failed_items],
+                retry_round + 1,
+                batch_retry_max,
+                len(failed_items),
+                [bi for bi, _ in failed_items],
             )
             retry_completed: list[tuple[int, dict | None, list[Chunk]]] = []
             with ThreadPoolExecutor(max_workers=max_workers) as retry_executor:
                 retry_futures = {
-                    retry_executor.submit(_process_batch, bi, b): bi
-                    for bi, b in failed_items
+                    retry_executor.submit(_process_batch, bi, b): bi for bi, b in failed_items
                 }
                 for future in as_completed(retry_futures):
                     bi = retry_futures[future]
@@ -766,13 +762,16 @@ def run_pass2_batched(
                         _flush_progress(bname, result[1], None)
                         log.info(
                             "Pass 2 batched — retry round %d batch %d succeeded",
-                            retry_round + 1, bi,
+                            retry_round + 1,
+                            bi,
                         )
                     except Exception as exc:
                         gate.record_error(exc)
                         log.error(
                             "Pass 2 batched — retry round %d batch %d still failed: %s",
-                            retry_round + 1, bi, exc,
+                            retry_round + 1,
+                            bi,
+                            exc,
                         )
                         retry_completed.append((bi, None, batches[bi]))
                         _flush_progress(bname, None, str(exc))
@@ -810,14 +809,14 @@ def run_pass2_batched(
                 if stateful:
                     prior_nodes_by_file[fname] = _dedup_within_file(file_nodes[fname])
 
-
     # Finalize per-file results: dedup nodes and drop dangling edges.
     results: dict[str, dict] = {}
     for fname in files:
         nodes = _dedup_within_file(file_nodes[fname])
         surviving_ids = {n["id"] for n in nodes}
         edges = [
-            e for e in file_edges[fname]
+            e
+            for e in file_edges[fname]
             if e.get("from") in surviving_ids and e.get("to") in surviving_ids
         ]
         log.info("  %s — total: %d node(s), %d edge(s)", fname, len(nodes), len(edges))

--- a/src/mykg/schema_merge.py
+++ b/src/mykg/schema_merge.py
@@ -185,9 +185,7 @@ def _reject_empty_schema(improved: dict, original: dict, label: str) -> dict | N
     concepts = improved.get("concepts") or []
     original_concepts = original.get("concepts") or []
     if len(concepts) < 1:
-        _log.warning(
-            "%s — LLM returned empty schema (0 concepts); keeping original", label
-        )
+        _log.warning("%s — LLM returned empty schema (0 concepts); keeping original", label)
         return original
     if original_concepts and len(concepts) < 0.5 * len(original_concepts):
         _log.warning(

--- a/src/mykg/steps/step_ingest.py
+++ b/src/mykg/steps/step_ingest.py
@@ -72,7 +72,11 @@ def _load_manifest(manifest_path) -> dict[str, dict]:
     for filename, value in raw.items():
         if isinstance(value, str):
             content = value
-            result[filename] = {"content": content, "sha256": _sha256(content), "token_count": _token_count(content)}
+            result[filename] = {
+                "content": content,
+                "sha256": _sha256(content),
+                "token_count": _token_count(content),
+            }
             migrated = True
         else:
             if "token_count" not in value:
@@ -146,11 +150,19 @@ def _run_append_ingest(ctx: PipelineContext) -> None:
         if filename not in manifest:
             new_files.append(filename)
             changed.add(filename)
-            manifest[filename] = {"content": content, "sha256": sha, "token_count": _token_count(content)}
+            manifest[filename] = {
+                "content": content,
+                "sha256": sha,
+                "token_count": _token_count(content),
+            }
         elif manifest[filename]["sha256"] != sha:
             modified_files.append(filename)
             changed.add(filename)
-            manifest[filename] = {"content": content, "sha256": sha, "token_count": _token_count(content)}
+            manifest[filename] = {
+                "content": content,
+                "sha256": sha,
+                "token_count": _token_count(content),
+            }
 
     manifest_path.write_text(json.dumps(manifest, indent=_cfg.JSON_INDENT))
 

--- a/src/mykg/steps/step_merge_raw.py
+++ b/src/mykg/steps/step_merge_raw.py
@@ -22,8 +22,7 @@ def run_merge_raw(ctx: MergeContext) -> None:
     """
     if ctx.session_a is None or ctx.session_b is None:
         log.info(
-            "merge_raw — session_a or session_b not on context (cold re-entry); "
-            "reloading from disk"
+            "merge_raw — session_a or session_b not on context (cold re-entry); reloading from disk"
         )
         ctx.session_a = load_session(ctx.session_a_name, ctx.sessions_root)
         ctx.session_b = load_session(ctx.session_b_name, ctx.sessions_root)
@@ -58,7 +57,9 @@ def run_merge_raw(ctx: MergeContext) -> None:
             try:
                 shard = json.loads(shard_file.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError) as exc:
-                log.warning("merge_raw — could not read chunk index shard %s: %s", shard_file.name, exc)
+                log.warning(
+                    "merge_raw — could not read chunk index shard %s: %s", shard_file.name, exc
+                )
                 continue
             fname = shard.get("_fname")
             data = shard.get("data")

--- a/src/mykg/steps/step_merge_reextract.py
+++ b/src/mykg/steps/step_merge_reextract.py
@@ -27,16 +27,13 @@ def run_merge_reextract(ctx: MergeContext) -> None:
     """
     if ctx.session_a is None or ctx.session_b is None:
         raise RuntimeError(
-            "merge_reextract requires session_a and session_b on context — "
-            "run merge_setup first"
+            "merge_reextract requires session_a and session_b on context — run merge_setup first"
         )
 
     strategy = _cfg.MERGE_GRAPHS_REEXTRACTION_STRATEGY
     log.info("merge_reextract — strategy=%s", strategy)
 
-    merged_schema = json.loads(
-        (ctx.intermediate_dir / "schema.json").read_text(encoding="utf-8")
-    )
+    merged_schema = json.loads((ctx.intermediate_dir / "schema.json").read_text(encoding="utf-8"))
     flattened = json.loads(
         (ctx.intermediate_dir / "flattened_schema.json").read_text(encoding="utf-8")
     )

--- a/src/mykg/steps/step_merge_schema.py
+++ b/src/mykg/steps/step_merge_schema.py
@@ -18,8 +18,7 @@ def run_merge_schema(ctx: MergeContext) -> None:
     """
     if ctx.session_a is None or ctx.session_b is None:
         raise RuntimeError(
-            "merge_schema requires session_a and session_b on context — "
-            "run merge_setup first"
+            "merge_schema requires session_a and session_b on context — run merge_setup first"
         )
 
     locked_classes: dict = {}

--- a/src/mykg/steps/step_orphan_connect.py
+++ b/src/mykg/steps/step_orphan_connect.py
@@ -70,18 +70,21 @@ def run_orphan_connect(ctx: PipelineContext) -> None:
         already_connected.add(edge["to"])
 
     unresolved_groups = [
-        g for g in groups
-        if not all(oid in already_connected for oid in g.orphan_ids)
+        g for g in groups if not all(oid in already_connected for oid in g.orphan_ids)
     ]
     skipped_groups = len(groups) - len(unresolved_groups)
     if skipped_groups:
         log.info(
             "Step orphan_connect — %d group(s) already resolved; passing %d unresolved group(s) to LLM",
-            skipped_groups, len(unresolved_groups),
+            skipped_groups,
+            len(unresolved_groups),
         )
 
     confirmed, rejections = confirm_orphan_chunk_groups(
-        unresolved_groups, nodes, schema, ctx.adapter,
+        unresolved_groups,
+        nodes,
+        schema,
+        ctx.adapter,
         chunk_texts=chunk_texts,
         error_gate=ctx.error_gate,
     )
@@ -129,14 +132,16 @@ def run_orphan_connect(ctx: PipelineContext) -> None:
     new_edge_ids = {_edge_id(e) for e in confirmed}
     for eid, edge in prior_connections.items():
         if eid not in new_edge_ids:
-            orphan_log.append({
-                "event": "orphan_edge_retained",
-                "id": eid,
-                "type": edge["type"],
-                "from": edge["from"],
-                "to": edge["to"],
-                "confidence": edge["confidence"],
-            })
+            orphan_log.append(
+                {
+                    "event": "orphan_edge_retained",
+                    "id": eid,
+                    "type": edge["type"],
+                    "from": edge["from"],
+                    "to": edge["to"],
+                    "confidence": edge["confidence"],
+                }
+            )
 
     edge_metadata_path = ctx.intermediate_dir / "edge_metadata.json"
     edge_metadata = json.loads(edge_metadata_path.read_text())

--- a/src/mykg/utility/context_calculator.py
+++ b/src/mykg/utility/context_calculator.py
@@ -22,20 +22,21 @@ In auto mode the script:
 
 import argparse
 import math
-import os
 from pathlib import Path
 
-
-SYSTEM_PROMPT_OVERHEAD = 1000   # approximate tokens consumed by system prompt + JSON scaffolding
-OVERLAP_RATIO          = 0.10   # overlap_tokens = window_tokens * this
-SAFETY_MARGIN_RATIO    = 0.05   # batch_token_target = input_headroom * (1 - this); remainder = feedback reserve
-DEFAULT_CHUNK_DIVISOR  = 12     # window_tokens = batch_token_target / this
-CHARS_PER_TOKEN        = 4      # character-to-token ratio for JSON/prose (used to derive max_file_chars)
+SYSTEM_PROMPT_OVERHEAD = 1000  # approximate tokens consumed by system prompt + JSON scaffolding
+OVERLAP_RATIO = 0.10  # overlap_tokens = window_tokens * this
+SAFETY_MARGIN_RATIO = (
+    0.05  # batch_token_target = input_headroom * (1 - this); remainder = feedback reserve
+)
+DEFAULT_CHUNK_DIVISOR = 12  # window_tokens = batch_token_target / this
+CHARS_PER_TOKEN = 4  # character-to-token ratio for JSON/prose (used to derive max_file_chars)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def round_to_nice(n: int) -> int:
     """Round down to the nearest 'nice' number (multiple of 1000, 500, or 100)."""
@@ -65,6 +66,7 @@ def load_mykg_config() -> tuple[dict, Path]:
                 if profile_name not in profiles:
                     raise KeyError(f"Profile '{profile_name}' not found in mykg_config.yaml")
                 import copy
+
                 result = copy.deepcopy(raw)
                 profile = profiles[profile_name]
                 for key in ("provider", "pipeline", "llm", "llm_retry"):
@@ -81,6 +83,7 @@ def load_mykg_config() -> tuple[dict, Path]:
 def count_corpus_tokens(input_dir: Path, encoding_name: str) -> int:
     """Count total tokens across all .md files in input_dir (recursive)."""
     import tiktoken
+
     enc = tiktoken.get_encoding(encoding_name)
     total = 0
     files = list(input_dir.rglob("*.md"))
@@ -105,6 +108,7 @@ def count_chunks(total_tokens: int, window_tokens: int, overlap_tokens: int) -> 
 # ---------------------------------------------------------------------------
 # Core calculation
 # ---------------------------------------------------------------------------
+
 
 def calculate(
     context_window: int,
@@ -136,14 +140,14 @@ def calculate(
     max_file_chars = feedback_token_reserve * CHARS_PER_TOKEN
 
     return {
-        "context_window":         context_window,
-        "max_output_tokens":      max_output_tokens,
-        "input_headroom":         input_headroom,
-        "batch_token_target":     batch_token_target,
+        "context_window": context_window,
+        "max_output_tokens": max_output_tokens,
+        "input_headroom": input_headroom,
+        "batch_token_target": batch_token_target,
         "feedback_token_reserve": feedback_token_reserve,
-        "max_file_chars":         max_file_chars,
-        "window_tokens":          window_tokens,
-        "overlap_tokens":         overlap_tokens,
+        "max_file_chars": max_file_chars,
+        "window_tokens": window_tokens,
+        "overlap_tokens": overlap_tokens,
     }
 
 
@@ -183,6 +187,7 @@ def suggest_chunk_divisor(
 # Output
 # ---------------------------------------------------------------------------
 
+
 def write_candidate_config(config_path: "Path", profile_name: str, result: dict) -> "Path":
     """Write a candidate mykg_config.yaml next to the original with suggested token-budget values.
 
@@ -196,12 +201,12 @@ def write_candidate_config(config_path: "Path", profile_name: str, result: dict)
     lines = text.splitlines(keepends=True)
 
     patch_map = {
-        "context_window":          result["context_window"],
-        "max_output_tokens":       result["max_output_tokens"],
-        "batch_token_target":      result["batch_token_target"],
-        "window_tokens":           result["window_tokens"],
-        "overlap_tokens":          result["overlap_tokens"],
-        "max_file_chars":          result["max_file_chars"],
+        "context_window": result["context_window"],
+        "max_output_tokens": result["max_output_tokens"],
+        "batch_token_target": result["batch_token_target"],
+        "window_tokens": result["window_tokens"],
+        "overlap_tokens": result["overlap_tokens"],
+        "max_file_chars": result["max_file_chars"],
         "concat_batch_token_target": result["batch_token_target"],
     }
 
@@ -230,22 +235,24 @@ def write_candidate_config(config_path: "Path", profile_name: str, result: dict)
 
         new_lines.append(line)
 
-    stem = config_path.stem          # "mykg_config"
-    suffix = config_path.suffix      # ".yaml"
+    stem = config_path.stem  # "mykg_config"
+    suffix = config_path.suffix  # ".yaml"
     out_path = config_path.with_name(f"{stem}_candidate{suffix}")
     out_path.write_text("".join(new_lines))
     return out_path
 
 
-def print_report(result: dict, model: str, chunk_divisor: int, corpus_info: dict | None = None) -> None:
-    cw  = result["context_window"]
+def print_report(
+    result: dict, model: str, chunk_divisor: int, corpus_info: dict | None = None
+) -> None:
+    cw = result["context_window"]
     mot = result["max_output_tokens"]
-    ih  = result["input_headroom"]
+    ih = result["input_headroom"]
     btt = result["batch_token_target"]
     ftr = result["feedback_token_reserve"]
     mfc = result["max_file_chars"]
-    wt  = result["window_tokens"]
-    ot  = result["overlap_tokens"]
+    wt = result["window_tokens"]
+    ot = result["overlap_tokens"]
 
     print()
     print("=" * 60)
@@ -262,42 +269,61 @@ def print_report(result: dict, model: str, chunk_divisor: int, corpus_info: dict
         print("  CORPUS")
         print(f"    files               = {corpus_info['file_count']:>8,}")
         print(f"    total tokens        = {corpus_info['total_tokens']:>8,}")
-        print(f"    chunk count         = {corpus_info['chunk_count']:>8,}   at window={wt}, overlap={ot}")
-        print(f"    suggested divisor   = {chunk_divisor:>8}   (window_tokens = batch_token_target ÷ this)")
+        print(
+            f"    chunk count         = {corpus_info['chunk_count']:>8,}   at window={wt}, overlap={ot}"
+        )
+        print(
+            f"    suggested divisor   = {chunk_divisor:>8}   (window_tokens = batch_token_target ÷ this)"
+        )
 
     print()
     print("  DERIVED PARAMETERS")
-    print(f"    batch_token_target  = {btt:>8,}   = input_headroom × {1 - SAFETY_MARGIN_RATIO:.0%}  (safety margin)")
-    print(f"    feedback_reserve    = {ftr:>8,}   = input_headroom - batch_token_target  (safety margin remainder)")
-    print(f"    max_file_chars      = {mfc:>8,}   = feedback_reserve × {CHARS_PER_TOKEN} chars/token")
-    print(f"    window_tokens       = {wt:>8,}   = batch_token_target ÷ {chunk_divisor}  (chunk size)")
+    print(
+        f"    batch_token_target  = {btt:>8,}   = input_headroom × {1 - SAFETY_MARGIN_RATIO:.0%}  (safety margin)"
+    )
+    print(
+        f"    feedback_reserve    = {ftr:>8,}   = input_headroom - batch_token_target  (safety margin remainder)"
+    )
+    print(
+        f"    max_file_chars      = {mfc:>8,}   = feedback_reserve × {CHARS_PER_TOKEN} chars/token"
+    )
+    print(
+        f"    window_tokens       = {wt:>8,}   = batch_token_target ÷ {chunk_divisor}  (chunk size)"
+    )
     print(f"    overlap_tokens      = {ot:>8,}   = window_tokens × {OVERLAP_RATIO:.0%}")
     print()
     print("  VALIDATION")
     ok = mot + ih == cw
-    print(f"    max_output + input_headroom = {mot + ih:,}  {'✓ = context_window' if ok else f'✗ ≠ context_window ({cw:,})'}")
+    print(
+        f"    max_output + input_headroom = {mot + ih:,}  {'✓ = context_window' if ok else f'✗ ≠ context_window ({cw:,})'}"
+    )
     fits = btt <= ih
-    print(f"    batch_token_target ≤ input_headroom: {'✓' if fits else '✗ EXCEEDS — API will return context-length errors'}")
+    print(
+        f"    batch_token_target ≤ input_headroom: {'✓' if fits else '✗ EXCEEDS — API will return context-length errors'}"
+    )
     print()
     print("  YAML SNIPPET — paste into the active profile in mykg_config.yaml")
     print("  " + "-" * 56)
-    print(f"    llm:")
+    print("    llm:")
     print(f"      context_window: {cw}  # model total context limit")
     print(f"      max_output_tokens: {mot}  # ① output cap; input_headroom = {ih}")
-    print(f"    pipeline:")
-    print(f"      chunking:")
+    print("    pipeline:")
+    print("      chunking:")
     print(f"        window_tokens: {wt}  # = batch_token_target ÷ {chunk_divisor}")
     print(f"        overlap_tokens: {ot}  # = window_tokens × {OVERLAP_RATIO:.0%}")
-    print(f"      pass1:")
+    print("      pass1:")
     print(f"        batch_token_target: {btt}  # = input_headroom × {1 - SAFETY_MARGIN_RATIO:.0%}")
-    print(f"      feedback:")
-    print(f"        max_file_chars: {mfc}  # = safety margin remainder × {CHARS_PER_TOKEN} chars/token ({ftr:,} tokens)")
+    print("      feedback:")
+    print(
+        f"        max_file_chars: {mfc}  # = safety margin remainder × {CHARS_PER_TOKEN} chars/token ({ftr:,} tokens)"
+    )
     print()
 
 
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -315,16 +341,36 @@ Examples:
   python context_calculator.py --context 128000 --input-headroom 96000 --chunk-divisor 8
         """,
     )
-    parser.add_argument("--from-config",    action="store_true",
-                        help="Read context_window and max_output_tokens from mykg_config.yaml active profile")
-    parser.add_argument("--input-dir",      type=Path, default=None,
-                        help="Directory of .md input files to measure (default: ./input_files or ./_input_files)")
-    parser.add_argument("--model",          default=None,   help="Model name label (manual mode only)")
-    parser.add_argument("--context",        type=int, default=None,   help="Model context window in tokens (manual mode)")
-    parser.add_argument("--max-output",     type=int, default=None,   help="Model max output tokens (manual mode)")
-    parser.add_argument("--input-headroom", type=int, default=None,   help="Desired input headroom in tokens (manual mode)")
-    parser.add_argument("--chunk-divisor",  type=int, default=None,
-                        help=f"window_tokens = batch_token_target ÷ this (default: auto-suggested from corpus, or {DEFAULT_CHUNK_DIVISOR})")
+    parser.add_argument(
+        "--from-config",
+        action="store_true",
+        help="Read context_window and max_output_tokens from mykg_config.yaml active profile",
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=None,
+        help="Directory of .md input files to measure (default: ./input_files or ./_input_files)",
+    )
+    parser.add_argument("--model", default=None, help="Model name label (manual mode only)")
+    parser.add_argument(
+        "--context", type=int, default=None, help="Model context window in tokens (manual mode)"
+    )
+    parser.add_argument(
+        "--max-output", type=int, default=None, help="Model max output tokens (manual mode)"
+    )
+    parser.add_argument(
+        "--input-headroom",
+        type=int,
+        default=None,
+        help="Desired input headroom in tokens (manual mode)",
+    )
+    parser.add_argument(
+        "--chunk-divisor",
+        type=int,
+        default=None,
+        help=f"window_tokens = batch_token_target ÷ this (default: auto-suggested from corpus, or {DEFAULT_CHUNK_DIVISOR})",
+    )
     args = parser.parse_args()
 
     corpus_info = None
@@ -359,7 +405,7 @@ Examples:
                     break
         if input_dir is None or not input_dir.exists():
             parser.error(
-                f"Could not find input directory. Pass --input-dir <path> or create ./input_files/."
+                "Could not find input directory. Pass --input-dir <path> or create ./input_files/."
             )
 
         print(f"\n  Counting tokens in {input_dir} …", end="", flush=True)
@@ -371,7 +417,15 @@ Examples:
         # Auto-suggest chunk divisor from corpus unless user supplied one
         if args.chunk_divisor is not None:
             chunk_divisor = args.chunk_divisor
-            wt = max(round_to_nice(int(round_to_nice(int(input_headroom * (1 - SAFETY_MARGIN_RATIO))) / chunk_divisor)), 100)
+            wt = max(
+                round_to_nice(
+                    int(
+                        round_to_nice(int(input_headroom * (1 - SAFETY_MARGIN_RATIO)))
+                        / chunk_divisor
+                    )
+                ),
+                100,
+            )
             ot = max(round_to_nice(int(wt * OVERLAP_RATIO)), 10)
             chunk_count = count_chunks(total_tokens, wt, ot)
         else:
@@ -395,7 +449,9 @@ Examples:
     else:
         # Manual mode
         if args.context is None:
-            parser.error("Manual mode requires --context (or use --from-config to read from mykg_config.yaml)")
+            parser.error(
+                "Manual mode requires --context (or use --from-config to read from mykg_config.yaml)"
+            )
         model_label = args.model or "custom-model"
         chunk_divisor = args.chunk_divisor or DEFAULT_CHUNK_DIVISOR
         result = calculate(
@@ -410,7 +466,7 @@ Examples:
     if args.from_config:
         out_path = write_candidate_config(config_path, profile_name, result)
         print(f"  ✓  Candidate written to: {out_path}")
-        print(f"     Review, then rename to mykg_config.yaml when satisfied.")
+        print("     Review, then rename to mykg_config.yaml when satisfied.")
         print()
 
 

--- a/src/mykg/walkthrough.py
+++ b/src/mykg/walkthrough.py
@@ -654,14 +654,20 @@ def _section_node_edge_trace(session_root: Path) -> str | None:
 
     # Merge log breakdown
     merge_log = _load_json(session_root / "intermediate" / "merge_log.json") or []
-    node_merge_events = sum(1 for e in merge_log if e.get("event") == "node_merge") if isinstance(merge_log, list) else 0
-    edge_merge_events = sum(1 for e in merge_log if e.get("event") == "edge_merge") if isinstance(merge_log, list) else 0
+    node_merge_events = (
+        sum(1 for e in merge_log if e.get("event") == "node_merge")
+        if isinstance(merge_log, list)
+        else 0
+    )
+    edge_merge_events = (
+        sum(1 for e in merge_log if e.get("event") == "edge_merge")
+        if isinstance(merge_log, list)
+        else 0
+    )
 
     # Orphan pass
     orphan_candidates = _load_json(session_root / "intermediate" / "orphan_candidates.json")
-    orphan_groups_count = (
-        len(orphan_candidates.get("groups", [])) if orphan_candidates else None
-    )
+    orphan_groups_count = len(orphan_candidates.get("groups", [])) if orphan_candidates else None
     orphan_connections = _load_json(session_root / "intermediate" / "orphan_connections.json")
     orphan_edges_added = len(orphan_connections) if orphan_connections is not None else None
 
@@ -680,7 +686,11 @@ def _section_node_edge_trace(session_root: Path) -> str | None:
 
     # Type-filter at validate_graph: edges in edge_metadata whose type is not in merged schema
     declared_props = {p["name"] for p in merged_schema.get("properties", [])}
-    valid_edges = sum(1 for e in merged_edge_data.values() if isinstance(e, dict) and e.get("type") in declared_props)
+    valid_edges = sum(
+        1
+        for e in merged_edge_data.values()
+        if isinstance(e, dict) and e.get("type") in declared_props
+    )
     filtered_edges = m_edges - valid_edges
     filtered_by_type: dict[str, int] = {}
     for e in merged_edge_data.values():
@@ -695,9 +705,13 @@ def _section_node_edge_trace(session_root: Path) -> str | None:
     nodes_jsonl = output_dir / "nodes.jsonl"
     edges_jsonl = output_dir / "edges.jsonl"
     if nodes_jsonl.exists():
-        nodes_jsonl_count = sum(1 for ln in nodes_jsonl.read_text(encoding="utf-8").splitlines() if ln.strip())
+        nodes_jsonl_count = sum(
+            1 for ln in nodes_jsonl.read_text(encoding="utf-8").splitlines() if ln.strip()
+        )
     if edges_jsonl.exists():
-        edges_jsonl_count = sum(1 for ln in edges_jsonl.read_text(encoding="utf-8").splitlines() if ln.strip())
+        edges_jsonl_count = sum(
+            1 for ln in edges_jsonl.read_text(encoding="utf-8").splitlines() if ln.strip()
+        )
 
     delta_b = manifest.get("schema_delta_session_b") or []
     reextract_note = (
@@ -876,11 +890,19 @@ def _section_merge_provenance(session_root: Path) -> str | None:
     ]
 
     # Net-new nodes: present in merged but not in either source session
-    ids_a = {n["id"] for n in (_load_json(sessions_root / name_a / "intermediate" / "nodes.json") or [])}
-    ids_b = {n["id"] for n in (_load_json(sessions_root / name_b / "intermediate" / "nodes.json") or [])}
+    ids_a = {
+        n["id"] for n in (_load_json(sessions_root / name_a / "intermediate" / "nodes.json") or [])
+    }
+    ids_b = {
+        n["id"] for n in (_load_json(sessions_root / name_b / "intermediate" / "nodes.json") or [])
+    }
     merged_by_id = {n["id"]: n for n in merged_nodes}
-    net_new = sorted((merged_by_id[nid] for nid in (set(merged_by_id) - ids_a - ids_b)), key=lambda n: n["id"])
-    deduped = sorted((merged_by_id[nid] for nid in (ids_a & ids_b & set(merged_by_id))), key=lambda n: n["id"])
+    net_new = sorted(
+        (merged_by_id[nid] for nid in (set(merged_by_id) - ids_a - ids_b)), key=lambda n: n["id"]
+    )
+    deduped = sorted(
+        (merged_by_id[nid] for nid in (ids_a & ids_b & set(merged_by_id))), key=lambda n: n["id"]
+    )
 
     out += ["", "### Node Provenance", ""]
     out += [
@@ -949,7 +971,10 @@ def _section_merge_provenance(session_root: Path) -> str | None:
 
     if edges_cross:
         out += ["", "**Cross-session edges:**", ""]
-        out += ["| ID | Type | From | From-session | To | To-session |", "|---|---|---|---|---|---|"]
+        out += [
+            "| ID | Type | From | From-session | To | To-session |",
+            "|---|---|---|---|---|---|",
+        ]
         for eid, edge in edges_cross[:20]:
             frm = edge.get("from", "?")
             to = edge.get("to", "?")
@@ -971,7 +996,9 @@ def _section_merge_provenance(session_root: Path) -> str | None:
         for eid, edge in edges_new_prop[:20]:
             frm = edge.get("from", "?")
             to = edge.get("to", "?")
-            out.append(f"| `{eid}` | {edge.get('type', '?')} | {_node_name(frm)} | {_node_name(to)} |")
+            out.append(
+                f"| `{eid}` | {edge.get('type', '?')} | {_node_name(frm)} | {_node_name(to)} |"
+            )
         if len(edges_new_prop) > 20:
             out.append(f"| *…and {len(edges_new_prop) - 20} more* | | | |")
 
@@ -979,9 +1006,16 @@ def _section_merge_provenance(session_root: Path) -> str | None:
     delta_a = manifest.get("schema_delta_session_a") or []
     delta_b = manifest.get("schema_delta_session_b") or []
     if delta_a:
-        out += ["", "**New properties for Session A** (surgical re-extraction): " + ", ".join(f"`{p}`" for p in delta_a)]
+        out += [
+            "",
+            "**New properties for Session A** (surgical re-extraction): "
+            + ", ".join(f"`{p}`" for p in delta_a),
+        ]
     if delta_b:
-        out += ["**New properties for Session B** (surgical re-extraction): " + ", ".join(f"`{p}`" for p in delta_b)]
+        out += [
+            "**New properties for Session B** (surgical re-extraction): "
+            + ", ".join(f"`{p}`" for p in delta_b)
+        ]
 
     # Schema synonym log
     synonym_log = manifest.get("schema_synonym_log") or []
@@ -1006,11 +1040,15 @@ def _section_health_status(session_root: Path, lines: list[dict], state: dict) -
     steps = state.get("steps", {})
     failed_steps = [name for name, info in steps.items() if info.get("status") == "failed"]
     if failed_steps:
-        issues.append(f"**{len(failed_steps)} step(s) failed:** " + ", ".join(f"`{s}`" for s in failed_steps))
+        issues.append(
+            f"**{len(failed_steps)} step(s) failed:** " + ", ".join(f"`{s}`" for s in failed_steps)
+        )
 
     # ERROR-level log lines (includes 402 credit errors after our fix)
     error_lines = [ln for ln in lines if ln["level"] == "ERROR"]
-    credit_errors = [ln for ln in error_lines if "402" in ln["message"] or "credit" in ln["message"].lower()]
+    credit_errors = [
+        ln for ln in error_lines if "402" in ln["message"] or "credit" in ln["message"].lower()
+    ]
     other_errors = [ln for ln in error_lines if ln not in credit_errors]
     if credit_errors:
         issues.append(
@@ -1150,7 +1188,9 @@ def generate_walkthrough(session_root: Path, log_file: Path | None = None) -> st
     if node_edge_trace:
         # Renumber trace header: §2 when provenance present, §1 when alone
         trace_num = 2 if merge_provenance else 1
-        nt = node_edge_trace.replace("## 2. Node & Edge Count Trace", f"## {trace_num}. Node & Edge Count Trace")
+        nt = node_edge_trace.replace(
+            "## 2. Node & Edge Count Trace", f"## {trace_num}. Node & Edge Count Trace"
+        )
         sections += [nt, ""]
     final_graph_num = 1 + offset
     sections += [

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -148,8 +148,9 @@ def test_extract_creates_session_dir(tmp_path, input_dir, monkeypatch):
 
 def test_extract_graph_help_contains_obsidian_vault():
     """--help output for extract-graph must advertise --obsidian-vault."""
-    import mykg.cli as cli_mod
     from click.testing import CliRunner
+
+    import mykg.cli as cli_mod
 
     runner = CliRunner()
     result = runner.invoke(cli_mod.cli, ["extract-graph", "--help"])

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -24,7 +24,7 @@ def test_extract_session_and_output_dir_mutually_exclusive(tmp_path, input_dir, 
     import mykg.config as cfg_mod
 
     monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
 
     runner = CliRunner()
     result = runner.invoke(
@@ -53,8 +53,8 @@ def test_extract_append_and_from_step_mutually_exclusive(tmp_path, input_dir, mo
 
     (sessions_root / "2026-01-01T00-00-00").mkdir(parents=True)
 
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
-    monkeypatch.setattr(cli_mod, "run", lambda steps, ctx: None)
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.orchestrator.run", lambda steps, ctx: None)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -134,8 +134,8 @@ def test_extract_creates_session_dir(tmp_path, input_dir, monkeypatch):
 
     sessions_root = tmp_path / "sessions"
     monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(sessions_root))
-    monkeypatch.setattr(cli_mod, "run", lambda steps, ctx: None)
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.orchestrator.run", lambda steps, ctx: None)
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
 
     runner = CliRunner()
     result = runner.invoke(cli_mod.cli, ["extract-graph", str(input_dir)])
@@ -163,7 +163,7 @@ def test_from_step_without_session_or_dirs_errors(tmp_path, input_dir, monkeypat
     import mykg.config as cfg_mod
 
     monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
 
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_context_calculator.py
+++ b/tests/test_context_calculator.py
@@ -28,43 +28,52 @@ from mykg.utility.context_calculator import (
     write_candidate_config,
 )
 
-
 # ---------------------------------------------------------------------------
 # round_to_nice
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("n,expected", [
-    (10000, 10000),
-    (15000, 10000),
-    (19999, 10000),
-    (20000, 20000),
-    (100000, 100000),
-])
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (10000, 10000),
+        (15000, 10000),
+        (19999, 10000),
+        (20000, 20000),
+        (100000, 100000),
+    ],
+)
 def test_round_to_nice_multiples_of_10000(n, expected):
     assert round_to_nice(n) == expected
 
 
-@pytest.mark.parametrize("n,expected", [
-    (1000, 1000),
-    (1500, 1000),
-    (1999, 1000),
-    # 3000 // 2000 = 1 → returns 2000 (2000 step fires before 1000)
-    (3000, 2000),
-    # 9999 // 5000 = 1 → returns 5000 (5000 step fires before 1000)
-    (9999, 5000),
-])
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (1000, 1000),
+        (1500, 1000),
+        (1999, 1000),
+        # 3000 // 2000 = 1 → returns 2000 (2000 step fires before 1000)
+        (3000, 2000),
+        # 9999 // 5000 = 1 → returns 5000 (5000 step fires before 1000)
+        (9999, 5000),
+    ],
+)
 def test_round_to_nice_multiples_of_1000(n, expected):
     assert round_to_nice(n) == expected
 
 
-@pytest.mark.parametrize("n,expected", [
-    (100, 100),
-    (150, 100),
-    (199, 100),
-    (250, 200),
-    (350, 200),
-    (450, 400),
-])
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (100, 100),
+        (150, 100),
+        (199, 100),
+        (250, 200),
+        (350, 200),
+        (450, 400),
+    ],
+)
 def test_round_to_nice_multiples_of_100(n, expected):
     assert round_to_nice(n) == expected
 
@@ -83,6 +92,7 @@ def test_round_to_nice_zero():
 # ---------------------------------------------------------------------------
 # count_chunks
 # ---------------------------------------------------------------------------
+
 
 def test_count_chunks_fits_in_one_window():
     assert count_chunks(500, 1000, 100) == 1
@@ -106,6 +116,7 @@ def test_count_chunks_zero_step_returns_one():
 # ---------------------------------------------------------------------------
 # calculate
 # ---------------------------------------------------------------------------
+
 
 def test_calculate_derives_from_max_output():
     result = calculate(
@@ -184,7 +195,7 @@ def test_calculate_both_supplied_prints_warning(capsys):
     assert result["context_window"] == 32000
 
     # Both values inconsistent — should print a warning
-    result2 = calculate(
+    calculate(
         context_window=32000,
         max_output_tokens=8000,
         input_headroom=20000,  # 8000 + 20000 != 32000
@@ -198,13 +209,16 @@ def test_calculate_both_supplied_prints_warning(capsys):
 # suggest_chunk_divisor
 # ---------------------------------------------------------------------------
 
+
 def test_suggest_chunk_divisor_sweet_spot():
     # Large corpus — should find a divisor whose chunk count falls in 50-500
     total_tokens = 500_000
     window_tokens = 2000
     overlap_tokens = 200
     input_headroom = 20_000
-    divisor, chunks = suggest_chunk_divisor(input_headroom, total_tokens, window_tokens, overlap_tokens)
+    divisor, chunks = suggest_chunk_divisor(
+        input_headroom, total_tokens, window_tokens, overlap_tokens
+    )
     assert 4 <= divisor <= 31
     # The sweet-spot break should fire, giving a chunk count in the right range
     assert 50 <= chunks <= 500
@@ -216,7 +230,9 @@ def test_suggest_chunk_divisor_falls_back_to_closest_to_200():
     window_tokens = 2000
     overlap_tokens = 200
     input_headroom = 20_000
-    divisor, chunks = suggest_chunk_divisor(input_headroom, total_tokens, window_tokens, overlap_tokens)
+    divisor, chunks = suggest_chunk_divisor(
+        input_headroom, total_tokens, window_tokens, overlap_tokens
+    )
     # Should still return a valid divisor
     assert 4 <= divisor <= 31
 
@@ -227,7 +243,9 @@ def test_suggest_chunk_divisor_small_corpus():
     window_tokens = 2000
     overlap_tokens = 200
     input_headroom = 20_000
-    divisor, chunks = suggest_chunk_divisor(input_headroom, total_tokens, window_tokens, overlap_tokens)
+    divisor, chunks = suggest_chunk_divisor(
+        input_headroom, total_tokens, window_tokens, overlap_tokens
+    )
     assert chunks >= 1
     assert divisor >= 4
 
@@ -235,6 +253,7 @@ def test_suggest_chunk_divisor_small_corpus():
 # ---------------------------------------------------------------------------
 # count_corpus_tokens — patch tiktoken so tests don't need the real encoder
 # ---------------------------------------------------------------------------
+
 
 def test_count_corpus_tokens_sums_all_md_files(tmp_path):
     (tmp_path / "a.md").write_text("hello world")
@@ -251,6 +270,7 @@ def test_count_corpus_tokens_sums_all_md_files(tmp_path):
 
     with patch.dict(sys.modules, {"tiktoken": mock_tiktoken}):
         from mykg.utility.context_calculator import count_corpus_tokens as _cct
+
         total, file_count = _cct(tmp_path, "cl100k_base")
 
     assert file_count == 3
@@ -267,6 +287,7 @@ def test_count_corpus_tokens_no_md_files_raises(tmp_path):
 
     with patch.dict(sys.modules, {"tiktoken": mock_tiktoken}):
         from mykg.utility.context_calculator import count_corpus_tokens as _cct
+
         with pytest.raises(FileNotFoundError, match="No .md files"):
             _cct(tmp_path, "cl100k_base")
 
@@ -497,12 +518,15 @@ def test_print_report_validation_mismatch(capsys):
 # main() — argparse entry point
 # ---------------------------------------------------------------------------
 
+
 def test_main_manual_mode_with_context_and_max_output(monkeypatch, capsys):
     monkeypatch.setattr(
-        sys, "argv",
+        sys,
+        "argv",
         ["context_calculator.py", "--context", "32000", "--max-output", "8000"],
     )
     from mykg.utility.context_calculator import main
+
     main()
     out = capsys.readouterr().out
     assert "32000" in out
@@ -511,10 +535,12 @@ def test_main_manual_mode_with_context_and_max_output(monkeypatch, capsys):
 
 def test_main_manual_mode_errors_without_context(monkeypatch, capsys):
     monkeypatch.setattr(
-        sys, "argv",
+        sys,
+        "argv",
         ["context_calculator.py", "--max-output", "8000"],
     )
     from mykg.utility.context_calculator import main
+
     with pytest.raises(SystemExit) as exc_info:
         main()
     assert exc_info.value.code != 0
@@ -549,7 +575,8 @@ profiles:
     monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(
-        sys, "argv",
+        sys,
+        "argv",
         ["context_calculator.py", "--from-config", "--input-dir", str(input_dir)],
     )
 
@@ -561,6 +588,7 @@ profiles:
 
     with patch.dict(sys.modules, {"tiktoken": mock_tiktoken}):
         from mykg.utility.context_calculator import main
+
         main()
 
     out = capsys.readouterr().out

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,6 +1,12 @@
-import json
+from __future__ import annotations
 
-from mykg.exporter import export_edges_jsonl, export_nodes_jsonl, export_ttl
+import json
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+from mykg.exporter import export_edges_jsonl, export_nodes_jsonl, export_obsidian, export_ttl
 
 SCHEMA = {
     "concepts": [
@@ -123,3 +129,169 @@ def test_ttl_escapes_newline_in_literal():
 
     g = Graph()
     g.parse(data=ttl, format="turtle")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# export_obsidian tests
+# ---------------------------------------------------------------------------
+
+_OBS_NODES = [
+    {
+        "id": "person-alice-johnson",
+        "type": "Person",
+        "confidence": 0.94,
+        "source_files": ["team.md"],
+        "attributes": {
+            "name": {"value": "Alice Johnson", "confidence": 1.0},
+            "role": {"value": "Engineer", "confidence": 0.91},
+            "email": {"value": "alice@example.com", "confidence": 1.0},
+        },
+        "aliases": ["Alice", "A. Johnson"],
+    },
+    {
+        "id": "organization-acme-corp",
+        "type": "Organization",
+        "confidence": 0.99,
+        "source_files": ["team.md"],
+        "attributes": {
+            "name": {"value": "Acme Corp", "confidence": 0.99},
+        },
+    },
+    {
+        "id": "person-bob-smith",
+        "type": "Person",
+        "confidence": 0.88,
+        "source_files": ["team.md"],
+        "attributes": {
+            "name": {"value": "Bob Smith", "confidence": 1.0},
+        },
+    },
+]
+
+_OBS_EDGE_METADATA = {
+    "edge-001": {
+        "type": "works_at",
+        "from": "person-alice-johnson",
+        "to": "organization-acme-corp",
+        "confidence": 0.96,
+        "source_files": ["team.md"],
+        "attributes": {"role": {"value": "engineer", "confidence": 0.91}},
+    },
+    "edge-002": {
+        "type": "manages",
+        "from": "person-bob-smith",
+        "to": "person-alice-johnson",
+        "confidence": 0.88,
+        "source_files": ["team.md"],
+        "attributes": {},
+    },
+}
+
+_OBS_SCHEMA = {
+    "concepts": [
+        {"type": "Person", "parent": None, "attributes": ["name", "role", "email"]},
+        {"type": "Organization", "parent": None, "attributes": ["name"]},
+    ],
+    "properties": [
+        {"name": "works_at", "domain": "Person", "range": "Organization", "attributes": ["role"]},
+        {"name": "manages", "domain": "Person", "range": "Person", "attributes": []},
+    ],
+}
+
+
+def _run_obsidian(tmp_path: Path) -> list[str]:
+    """Call export_obsidian with OBSIDIAN_ENABLED patched to True."""
+    with mock.patch("mykg.exporter._cfg") as mock_cfg:
+        mock_cfg.OBSIDIAN_ENABLED = True
+        mock_cfg.JSON_INDENT = 2
+        return export_obsidian(_OBS_NODES, _OBS_EDGE_METADATA, _OBS_SCHEMA, tmp_path)
+
+
+def test_obsidian_returns_empty_when_disabled(tmp_path: Path) -> None:
+    """export_obsidian returns [] when OBSIDIAN_ENABLED is False (or absent)."""
+    with mock.patch("mykg.exporter._cfg") as mock_cfg:
+        mock_cfg.OBSIDIAN_ENABLED = False
+        result = export_obsidian(_OBS_NODES, _OBS_EDGE_METADATA, _OBS_SCHEMA, tmp_path)
+    assert result == []
+
+
+def test_obsidian_creates_type_subdirs(tmp_path: Path) -> None:
+    """Nodes are written under Type/ subdirectories inside obsidian_vault/."""
+    _run_obsidian(tmp_path)
+    vault = tmp_path / "obsidian_vault"
+    assert (vault / "Person").is_dir()
+    assert (vault / "Organization").is_dir()
+
+
+def test_obsidian_creates_node_files(tmp_path: Path) -> None:
+    """One .md file is created per node with the node_id as filename."""
+    _run_obsidian(tmp_path)
+    vault = tmp_path / "obsidian_vault"
+    assert (vault / "Person" / "person-alice-johnson.md").exists()
+    assert (vault / "Organization" / "organization-acme-corp.md").exists()
+    assert (vault / "Person" / "person-bob-smith.md").exists()
+
+
+def test_obsidian_frontmatter_is_valid_yaml(tmp_path: Path) -> None:
+    """YAML frontmatter in entity notes must parse without error."""
+    _run_obsidian(tmp_path)
+    note_path = tmp_path / "obsidian_vault" / "Person" / "person-alice-johnson.md"
+    content = note_path.read_text(encoding="utf-8")
+
+    # Extract frontmatter between the first pair of '---' delimiters
+    parts = content.split("---")
+    assert len(parts) >= 3, "expected YAML frontmatter delimiters"
+    fm = yaml.safe_load(parts[1])
+    assert fm["id"] == "person-alice-johnson"
+    assert fm["type"] == "Person"
+    assert isinstance(fm["confidence"], float)
+    assert "team.md" in fm["sources"]
+
+
+def test_obsidian_outgoing_wikilink(tmp_path: Path) -> None:
+    """Outgoing relationship section contains a wikilink to the target entity."""
+    _run_obsidian(tmp_path)
+    note_path = tmp_path / "obsidian_vault" / "Person" / "person-alice-johnson.md"
+    content = note_path.read_text(encoding="utf-8")
+    assert "[[Acme Corp]]" in content
+    assert "works_at" in content
+
+
+def test_obsidian_incoming_wikilink(tmp_path: Path) -> None:
+    """Incoming relationship section contains a wikilink to the source entity."""
+    _run_obsidian(tmp_path)
+    note_path = tmp_path / "obsidian_vault" / "Person" / "person-alice-johnson.md"
+    content = note_path.read_text(encoding="utf-8")
+    assert "[[Bob Smith]]" in content
+    assert "manages" in content
+
+
+def test_obsidian_index_exists(tmp_path: Path) -> None:
+    """index.md is created at the vault root."""
+    _run_obsidian(tmp_path)
+    assert (tmp_path / "obsidian_vault" / "index.md").exists()
+
+
+def test_obsidian_index_lists_all_nodes(tmp_path: Path) -> None:
+    """index.md wikilinks to every node by display name."""
+    _run_obsidian(tmp_path)
+    index = (tmp_path / "obsidian_vault" / "index.md").read_text(encoding="utf-8")
+    assert "[[Alice Johnson]]" in index
+    assert "[[Acme Corp]]" in index
+    assert "[[Bob Smith]]" in index
+
+
+def test_obsidian_return_value_is_list_of_strings(tmp_path: Path) -> None:
+    """Return value is a list of relative path strings."""
+    result = _run_obsidian(tmp_path)
+    assert isinstance(result, list)
+    assert all(isinstance(p, str) for p in result)
+    assert any(p.startswith("obsidian_vault/") for p in result)
+    assert "obsidian_vault/index.md" in result
+
+
+def test_obsidian_return_value_includes_all_node_paths(tmp_path: Path) -> None:
+    """Return value contains one path per node plus index.md."""
+    result = _run_obsidian(tmp_path)
+    node_paths = [p for p in result if p != "obsidian_vault/index.md"]
+    assert len(node_paths) == len(_OBS_NODES)

--- a/tests/test_merge_orchestrator.py
+++ b/tests/test_merge_orchestrator.py
@@ -157,7 +157,9 @@ def test_run_merge_deduplicates_same_node(tmp_path):
     }
     _, intermediate_dir = _run(tmp_path, raw_a=raw_a, raw_b=raw_b)
     nodes = json.loads((intermediate_dir / "nodes.json").read_text())
-    alice_nodes = [n for n in nodes if n.get("attributes", {}).get("name", {}).get("value") == "Alice"]
+    alice_nodes = [
+        n for n in nodes if n.get("attributes", {}).get("name", {}).get("value") == "Alice"
+    ]
     assert len(alice_nodes) == 1
 
 

--- a/tests/test_merge_pipeline.py
+++ b/tests/test_merge_pipeline.py
@@ -84,7 +84,9 @@ def _make_session(sessions_root: Path, name: str, schema: dict, raw: dict) -> Pa
     return session_root
 
 
-def _make_ctx(tmp_path: Path, schema_a=None, schema_b=None, raw_a=None, raw_b=None) -> tuple[MergeContext, Path, Path]:
+def _make_ctx(
+    tmp_path: Path, schema_a=None, schema_b=None, raw_a=None, raw_b=None
+) -> tuple[MergeContext, Path, Path]:
     sessions_root = tmp_path / "sessions"
     _make_session(sessions_root, "sess-a", schema_a or _SCHEMA_A, raw_a or _RAW_A)
     _make_session(sessions_root, "sess-b", schema_b or _SCHEMA_B, raw_b or _RAW_B)
@@ -112,6 +114,7 @@ def _make_ctx(tmp_path: Path, schema_a=None, schema_b=None, raw_a=None, raw_b=No
 # ---------------------------------------------------------------------------
 # Structural tests
 # ---------------------------------------------------------------------------
+
 
 def test_merge_steps_ordered():
     names = [s.name for s in MERGE_STEPS]
@@ -155,6 +158,7 @@ def test_merge_steps_llm_flags():
 # ---------------------------------------------------------------------------
 # Integration tests (run_merge end-to-end with no LLM adapter)
 # ---------------------------------------------------------------------------
+
 
 def test_run_merge_creates_output_files(tmp_path):
     ctx, output_dir, _ = _make_ctx(tmp_path)
@@ -214,12 +218,40 @@ def test_run_merge_manifest_written(tmp_path):
 
 
 def test_run_merge_deduplicates_same_node(tmp_path):
-    raw_a = {"file_a.md": {"nodes": [{"id": "person-alice", "type": "Person", "confidence": 0.9, "attributes": {"name": {"value": "Alice", "confidence": 0.9}}, "source_files": ["file_a.md"]}], "edges": []}}
-    raw_b = {"file_b.md": {"nodes": [{"id": "person-alice", "type": "Person", "confidence": 0.8, "attributes": {"name": {"value": "Alice", "confidence": 0.8}}, "source_files": ["file_b.md"]}], "edges": []}}
+    raw_a = {
+        "file_a.md": {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "confidence": 0.9,
+                    "attributes": {"name": {"value": "Alice", "confidence": 0.9}},
+                    "source_files": ["file_a.md"],
+                }
+            ],
+            "edges": [],
+        }
+    }
+    raw_b = {
+        "file_b.md": {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "confidence": 0.8,
+                    "attributes": {"name": {"value": "Alice", "confidence": 0.8}},
+                    "source_files": ["file_b.md"],
+                }
+            ],
+            "edges": [],
+        }
+    }
     ctx, _, intermediate_dir = _make_ctx(tmp_path, raw_a=raw_a, raw_b=raw_b)
     run_merge(ctx)
     nodes = json.loads((intermediate_dir / "nodes.json").read_text())
-    alice_nodes = [n for n in nodes if n.get("attributes", {}).get("name", {}).get("value") == "Alice"]
+    alice_nodes = [
+        n for n in nodes if n.get("attributes", {}).get("name", {}).get("value") == "Alice"
+    ]
     assert len(alice_nodes) == 1
 
 
@@ -238,19 +270,23 @@ def test_run_merge_resumable_skips_done_steps(tmp_path):
     run_merge(ctx)
 
     # Re-build ctx pointing at same dirs and run again
-    ctx2, _, _ = _make_ctx.__wrapped__(tmp_path) if hasattr(_make_ctx, "__wrapped__") else (
-        MergeContext(
-            session_a_name="sess-a",
-            session_b_name="sess-b",
-            sessions_root=tmp_path / "sessions",
-            input_dir=tmp_path / "sessions",
-            output_dir=tmp_path / "merged" / "output",
-            intermediate_dir=tmp_path / "merged" / "intermediate",
-            adapter=None,
-            review=False,
-        ),
-        tmp_path / "merged" / "output",
-        tmp_path / "merged" / "intermediate",
+    ctx2, _, _ = (
+        _make_ctx.__wrapped__(tmp_path)
+        if hasattr(_make_ctx, "__wrapped__")
+        else (
+            MergeContext(
+                session_a_name="sess-a",
+                session_b_name="sess-b",
+                sessions_root=tmp_path / "sessions",
+                input_dir=tmp_path / "sessions",
+                output_dir=tmp_path / "merged" / "output",
+                intermediate_dir=tmp_path / "merged" / "intermediate",
+                adapter=None,
+                review=False,
+            ),
+            tmp_path / "merged" / "output",
+            tmp_path / "merged" / "intermediate",
+        )
     )
     run_merge(ctx2)
 
@@ -261,9 +297,11 @@ def test_run_merge_resumable_skips_done_steps(tmp_path):
         allowed = {"done", "failed"} if step.name in _NON_BLOCKING_STEPS else {"done"}
         assert status in allowed, f"Step {step.name!r} expected status in {allowed}, got {status!r}"
 
+
 # ---------------------------------------------------------------------------
 # chunk_node_index tests
 # ---------------------------------------------------------------------------
+
 
 def _add_chunk_index_shards(sessions_root: Path, session_name: str, shards: list[dict]) -> None:
     """Write chunk_index_shards into a session's intermediate directory."""
@@ -281,12 +319,20 @@ def test_merge_raw_writes_chunk_node_index(tmp_path):
     _make_session(sessions_root, "sess-b", _SCHEMA_B, _RAW_B)
 
     # Add chunk index shards to each session
-    _add_chunk_index_shards(sessions_root, "sess-a", [
-        {"_fname": "file_a.md", "data": {"0": ["person-alice"]}},
-    ])
-    _add_chunk_index_shards(sessions_root, "sess-b", [
-        {"_fname": "file_b.md", "data": {"0": ["person-bob"], "1": ["person-charlie"]}},
-    ])
+    _add_chunk_index_shards(
+        sessions_root,
+        "sess-a",
+        [
+            {"_fname": "file_a.md", "data": {"0": ["person-alice"]}},
+        ],
+    )
+    _add_chunk_index_shards(
+        sessions_root,
+        "sess-b",
+        [
+            {"_fname": "file_b.md", "data": {"0": ["person-bob"], "1": ["person-charlie"]}},
+        ],
+    )
 
     merged_root = tmp_path / "merged"
     output_dir = merged_root / "output"

--- a/tests/test_merge_run.py
+++ b/tests/test_merge_run.py
@@ -4,6 +4,7 @@ Focuses on the SchemaUpdatedError restart loop (lines 135–212) and other
 exception paths that are not exercised by the integration tests in
 test_merge_pipeline.py.
 """
+
 from __future__ import annotations
 
 import json
@@ -18,10 +19,10 @@ from mykg.merge_pipeline import MERGE_STEPS
 from mykg.merge_run import _MERGE_SCHEMA_RESTART_INVALIDATE, _log_merge_advisory, run_merge
 from mykg.orchestrator import PipelineHaltError, SchemaUpdatedError, Step
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_ctx(tmp_path: Path, review: bool = False) -> MergeContext:
     intermediate = tmp_path / "intermediate"
@@ -69,6 +70,7 @@ def _schema_updated_error(
 # Test: SchemaUpdatedError restart loop — outputs invalidated
 # ---------------------------------------------------------------------------
 
+
 def test_run_merge_schema_restart_invalidates_outputs(tmp_path):
     """SchemaUpdatedError on orphan_connect causes outputs in
     _MERGE_SCHEMA_RESTART_INVALIDATE to be deleted."""
@@ -108,7 +110,9 @@ def test_run_merge_schema_restart_regenerates_schema_ttl(tmp_path):
 
     schema = {
         "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
-        "properties": [{"name": "new_prop", "domain": "Person", "range": "Person", "attributes": []}],
+        "properties": [
+            {"name": "new_prop", "domain": "Person", "range": "Person", "attributes": []}
+        ],
     }
     (ctx.intermediate_dir / "schema.json").write_text(json.dumps(schema))
     ttl_path = ctx.intermediate_dir / "schema.ttl"
@@ -259,6 +263,7 @@ def test_run_merge_schema_restart_increments_restart_count(tmp_path):
 # Test: schema_hints populated from gap_orphans
 # ---------------------------------------------------------------------------
 
+
 def test_run_merge_sets_schema_hints_on_restart(tmp_path):
     """ctx.schema_hints is populated with orphan data from gap_orphans on SchemaUpdatedError."""
     ctx = _make_ctx(tmp_path)
@@ -306,6 +311,7 @@ def test_run_merge_sets_schema_hints_on_restart(tmp_path):
 # Test: restart limit reached
 # ---------------------------------------------------------------------------
 
+
 def test_run_merge_schema_restart_limit_reached_continues(tmp_path):
     """When schema_restart_count >= MERGE_ORPHAN_SCHEMA_MAX_RESTARTS,
     a warning is logged and the pipeline continues (no exception raised)."""
@@ -337,6 +343,7 @@ def test_run_merge_schema_restart_limit_reached_continues(tmp_path):
 # Test: _log_merge_advisory — fallback hint for unknown step
 # ---------------------------------------------------------------------------
 
+
 def test_run_merge_hint_for_unknown_step_in_advisory(tmp_path):
     """_log_merge_advisory uses a fallback message for unknown step names."""
     ctx = _make_ctx(tmp_path)
@@ -356,6 +363,7 @@ def test_run_merge_hint_for_unknown_step_in_advisory(tmp_path):
 # ---------------------------------------------------------------------------
 # Test: blocking step failure → PipelineHaltError
 # ---------------------------------------------------------------------------
+
 
 def test_run_merge_halt_error_raised_on_blocking_step_failure(tmp_path):
     """A blocking step that fails after all retries raises PipelineHaltError."""
@@ -377,6 +385,7 @@ def test_run_merge_halt_error_raised_on_blocking_step_failure(tmp_path):
 # Test: _log_merge_advisory called on step failure
 # ---------------------------------------------------------------------------
 
+
 def test_run_merge_log_advisory_called_on_step_failure(tmp_path):
     """_log_merge_advisory is invoked when a blocking step fails after all retries."""
     ctx = _make_ctx(tmp_path)
@@ -396,6 +405,7 @@ def test_run_merge_log_advisory_called_on_step_failure(tmp_path):
 # ---------------------------------------------------------------------------
 # Test: non-blocking step continues after failure
 # ---------------------------------------------------------------------------
+
 
 def test_run_merge_non_blocking_step_continues_after_failure(tmp_path):
     """A non-blocking step failure logs a warning but does not halt the pipeline."""
@@ -428,6 +438,7 @@ def test_run_merge_non_blocking_step_continues_after_failure(tmp_path):
 # ---------------------------------------------------------------------------
 # Test: KeyboardInterrupt — state saved as failed before re-raise
 # ---------------------------------------------------------------------------
+
 
 def test_run_merge_keyboard_interrupt_saved_to_state(tmp_path):
     """KeyboardInterrupt during a step saves the step as failed before re-raising."""

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -161,9 +161,7 @@ def test_merge_schemas_deduplicates_same_concept():
 def test_delta_identifies_new_properties():
     original = {
         "concepts": [],
-        "properties": [
-            {"name": "works_at", "domain": "P", "range": "O", "attributes": []}
-        ],
+        "properties": [{"name": "works_at", "domain": "P", "range": "O", "attributes": []}],
     }
     merged = {
         "concepts": [],
@@ -192,9 +190,7 @@ def test_delta_empty_when_no_new_properties():
 
 def test_reextract_none_returns_unchanged(tmp_path):
     raw = {"session_a/f.md": {"nodes": [], "edges": []}}
-    result = reextract_for_merge(
-        "session_a", tmp_path, raw, {}, {}, tmp_path, None, {}, "none"
-    )
+    result = reextract_for_merge("session_a", tmp_path, raw, {}, {}, tmp_path, None, {}, "none")
     assert result is raw
 
 
@@ -204,11 +200,22 @@ def test_reextract_invalid_strategy_raises(tmp_path):
 
 
 def test_reextract_surgical_no_delta_returns_unchanged(tmp_path):
-    original = {"concepts": [], "properties": [{"name": "p", "domain": "A", "range": "B", "attributes": []}]}
+    original = {
+        "concepts": [],
+        "properties": [{"name": "p", "domain": "A", "range": "B", "attributes": []}],
+    }
     merged = original  # identical → delta is empty
     raw = {"session_a/f.md": {"nodes": [], "edges": []}}
     result = reextract_for_merge(
-        "session_a", tmp_path, raw, merged, {}, tmp_path, None, {}, "surgical",
+        "session_a",
+        tmp_path,
+        raw,
+        merged,
+        {},
+        tmp_path,
+        None,
+        {},
+        "surgical",
         original_schema=original,
     )
     assert result is raw
@@ -228,14 +235,14 @@ def test_reextract_surgical_with_delta_calls_pass2(tmp_path):
     shard_dir.mkdir(parents=True)
     prior_data = {"nodes": [{"id": "person-alice"}], "edges": []}
     shard_content = {"_fname": "session_x/notes.md", "data": prior_data}
-    (shard_dir / "session_x_notes_md.json").write_text(
-        json.dumps(shard_content), encoding="utf-8"
-    )
+    (shard_dir / "session_x_notes_md.json").write_text(json.dumps(shard_content), encoding="utf-8")
 
     original_schema = {"concepts": [], "properties": []}
     merged_schema = {
         "concepts": [],
-        "properties": [{"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []}],
+        "properties": [
+            {"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []}
+        ],
     }
     raw_ns = {"session_x/notes.md": {"nodes": [], "edges": []}}
 
@@ -250,11 +257,22 @@ def test_reextract_surgical_with_delta_calls_pass2(tmp_path):
     new_chunk_result = {}
     failed_result = []
 
-    with patch("mykg.merger.run_pass2", return_value=(new_raw_result, new_chunk_result, failed_result)) as mock_pass2, \
-         patch("mykg.merger.chunk_file", return_value=[MagicMock()]) as _mock_chunk:
+    with (
+        patch(
+            "mykg.merger.run_pass2", return_value=(new_raw_result, new_chunk_result, failed_result)
+        ) as mock_pass2,
+        patch("mykg.merger.chunk_file", return_value=[MagicMock()]) as _mock_chunk,
+    ):
         result = reextract_for_merge(
-            "session_x", session_path, raw_ns, merged_schema, {}, intermediate_dir,
-            mock_adapter, {}, "surgical",
+            "session_x",
+            session_path,
+            raw_ns,
+            merged_schema,
+            {},
+            intermediate_dir,
+            mock_adapter,
+            {},
+            "surgical",
             original_schema=original_schema,
         )
 
@@ -311,7 +329,10 @@ def test_load_session_happy_path(tmp_path):
     sessions_root = tmp_path / "sessions"
     intermediate = sessions_root / "my-session" / "intermediate"
     intermediate.mkdir(parents=True)
-    schema = {"concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}], "properties": []}
+    schema = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
     (intermediate / "schema.json").write_text(json.dumps(schema), encoding="utf-8")
     raw = {"file_a.md": {"nodes": [], "edges": []}}
     (intermediate / "raw_extractions.json").write_text(json.dumps(raw), encoding="utf-8")
@@ -359,10 +380,15 @@ def test_harmonize_merged_schema_uses_merge_specific_functions():
     schema = {"concepts": [], "properties": []}
     proposals = [schema, schema]
     adapter = MagicMock()
-    harmonized = {"concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}], "properties": []}
+    harmonized = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
 
-    with patch("mykg.merger.harmonize_schema_for_merge", return_value=harmonized) as mock_harm, \
-         patch("mykg.merger.review_schema_quality_for_merge", return_value=harmonized) as mock_qual:
+    with (
+        patch("mykg.merger.harmonize_schema_for_merge", return_value=harmonized) as mock_harm,
+        patch("mykg.merger.review_schema_quality_for_merge", return_value=harmonized) as mock_qual,
+    ):
         result = harmonize_merged_schema(schema, proposals, adapter)
 
     mock_harm.assert_called_once_with(schema, proposals, adapter)
@@ -372,8 +398,10 @@ def test_harmonize_merged_schema_uses_merge_specific_functions():
 
 def test_harmonize_merged_schema_skips_llm_when_no_adapter():
     schema = {"concepts": [], "properties": []}
-    with patch("mykg.merger.harmonize_schema_for_merge") as mock_harm, \
-         patch("mykg.merger.review_schema_quality_for_merge") as mock_qual:
+    with (
+        patch("mykg.merger.harmonize_schema_for_merge") as mock_harm,
+        patch("mykg.merger.review_schema_quality_for_merge") as mock_qual,
+    ):
         result = harmonize_merged_schema(schema, [], None)
 
     mock_harm.assert_not_called()
@@ -388,7 +416,9 @@ def test_build_source_map_same_filename(tmp_path):
         intermediate = sessions_root / name / "intermediate"
         intermediate.mkdir(parents=True)
         (intermediate / "schema.json").write_text(json.dumps({"concepts": [], "properties": []}))
-        (intermediate / "raw_extractions.json").write_text(json.dumps({"notes.md": {"nodes": [], "edges": []}}))
+        (intermediate / "raw_extractions.json").write_text(
+            json.dumps({"notes.md": {"nodes": [], "edges": []}})
+        )
         return load_session(name, sessions_root)
 
     sa = _make("sess-a")
@@ -440,18 +470,14 @@ def test_read_prep_mode_active_profile_takes_precedence(tmp_path):
 
 def test_read_prep_mode_key_missing_returns_unknown(tmp_path):
     """When mykg_config.yaml exists but prep_mode key is absent, return 'unknown'."""
-    (tmp_path / "mykg_config.yaml").write_text(
-        "pipeline:\n  pass2: {}\n", encoding="utf-8"
-    )
+    (tmp_path / "mykg_config.yaml").write_text("pipeline:\n  pass2: {}\n", encoding="utf-8")
     result = _read_prep_mode(tmp_path)
     assert result == "unknown"
 
 
 def test_read_prep_mode_invalid_yaml_returns_unknown(tmp_path):
     """When YAML is unparseable, return 'unknown' without raising."""
-    (tmp_path / "mykg_config.yaml").write_text(
-        ":\n  bad: [unterminated\n", encoding="utf-8"
-    )
+    (tmp_path / "mykg_config.yaml").write_text(":\n  bad: [unterminated\n", encoding="utf-8")
     result = _read_prep_mode(tmp_path)
     assert result == "unknown"
 
@@ -494,9 +520,7 @@ def test_load_session_corrupt_manifest_skipped_gracefully(tmp_path):
     """A corrupt file_manifest.json is skipped; manifest stays empty dict."""
     sessions_root = tmp_path / "sessions"
     _, intermediate = _make_minimal_session(sessions_root, "my-session")
-    (intermediate / "file_manifest.json").write_text(
-        "TOTALLY BAD JSON ][", encoding="utf-8"
-    )
+    (intermediate / "file_manifest.json").write_text("TOTALLY BAD JSON ][", encoding="utf-8")
     session = load_session("my-session", sessions_root)
     assert session.manifest == {}
 
@@ -529,9 +553,7 @@ def test_copy_shard_dir_skips_corrupt_shard_continues(tmp_path):
     dst = tmp_path / "dst_shards"
     src.mkdir()
     (src / "bad.json").write_text("NOT JSON {{", encoding="utf-8")
-    (src / "good.json").write_text(
-        json.dumps({"_fname": "good.md", "data": {}}), encoding="utf-8"
-    )
+    (src / "good.json").write_text(json.dumps({"_fname": "good.md", "data": {}}), encoding="utf-8")
 
     _copy_shard_dir(src, dst, "session_a")
 
@@ -562,7 +584,7 @@ def test_copy_shard_dir_long_filename_uses_sha1_hash(tmp_path):
     # Verify it follows the sha1 pattern: session_a_<16hex chars>.json
     assert filename.startswith("session_a_")
     assert filename.endswith(".json")
-    hex_part = filename[len("session_a_"):-len(".json")]
+    hex_part = filename[len("session_a_") : -len(".json")]
     assert len(hex_part) == 16
     assert all(c in "0123456789abcdef" for c in hex_part)
 
@@ -580,9 +602,7 @@ def test_copy_shard_dir_creates_dst_dir(tmp_path):
     src = tmp_path / "src_shards"
     dst = tmp_path / "deep" / "nested" / "dst_shards"
     src.mkdir()
-    (src / "shard.json").write_text(
-        json.dumps({"_fname": "f.md", "data": {}}), encoding="utf-8"
-    )
+    (src / "shard.json").write_text(json.dumps({"_fname": "f.md", "data": {}}), encoding="utf-8")
     _copy_shard_dir(src, dst, "session_a")
     assert dst.is_dir()
 
@@ -633,9 +653,7 @@ def test_namespace_shards_processes_both_subdirs(tmp_path):
     for subdir in ("raw_extractions_shards", "chunk_index_shards"):
         d = tmp_path / subdir
         d.mkdir()
-        (d / "shard.json").write_text(
-            json.dumps({"_fname": "f.md", "data": {}}), encoding="utf-8"
-        )
+        (d / "shard.json").write_text(json.dumps({"_fname": "f.md", "data": {}}), encoding="utf-8")
 
     _namespace_shards(tmp_path, "session_b")
 
@@ -676,7 +694,9 @@ def test_build_targeted_top_k_zero_returns_empty_dict():
         merged_schema=_make_schema_with_props(
             [{"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []}]
         ),
-        prior_extractions={"f.md": {"nodes": [{"id": "person-alice", "type": "Person"}], "edges": []}},
+        prior_extractions={
+            "f.md": {"nodes": [{"id": "person-alice", "type": "Person"}], "edges": []}
+        },
         prior_chunk_index=prior_chunk_index,
         top_k=0,
     )
@@ -727,7 +747,7 @@ def test_build_targeted_normal_selects_top_k_chunks():
     }
     prior_chunk_index = {
         "f.md": {
-            "1": ["person-alice"],       # score=1 for works_at
+            "1": ["person-alice"],  # score=1 for works_at
             "2": ["person-alice", "org-acme"],  # score=2 for works_at — top chunk
         }
     }
@@ -787,15 +807,19 @@ def test_build_targeted_multiple_new_properties_union_chunks():
     }
     prior_chunk_index = {
         "f.md": {
-            "1": ["person-c"],        # relevant for works_at (Person domain)
-            "2": ["place-e"],         # relevant for located_in (Place domain)
-            "3": ["org-d"],           # relevant for works_at (Organization range) + located_in (Organization range)
+            "1": ["person-c"],  # relevant for works_at (Person domain)
+            "2": ["place-e"],  # relevant for located_in (Place domain)
+            "3": [
+                "org-d"
+            ],  # relevant for works_at (Organization range) + located_in (Organization range)
         }
     }
-    merged_schema = _make_schema_with_props([
-        {"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []},
-        {"name": "located_in", "domain": "Place", "range": "Organization", "attributes": []},
-    ])
+    merged_schema = _make_schema_with_props(
+        [
+            {"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []},
+            {"name": "located_in", "domain": "Place", "range": "Organization", "attributes": []},
+        ]
+    )
     result = _build_targeted_reextract_chunks(
         delta={"works_at", "located_in"},
         merged_schema=merged_schema,
@@ -813,9 +837,7 @@ def test_build_targeted_multiple_new_properties_union_chunks():
 
 def test_build_targeted_chunk_idx_non_numeric_skipped():
     """Non-numeric chunk index keys in prior_chunk_index are silently skipped."""
-    prior_extractions = {
-        "f.md": {"nodes": [{"id": "person-x", "type": "Person"}], "edges": []}
-    }
+    prior_extractions = {"f.md": {"nodes": [{"id": "person-x", "type": "Person"}], "edges": []}}
     prior_chunk_index = {
         "f.md": {
             "not_a_number": ["person-x"],

--- a/tests/test_pass2.py
+++ b/tests/test_pass2.py
@@ -468,7 +468,15 @@ def test_normalize_scalars_tolerates_null_items_in_nodes():
     from mykg.pass2 import _normalize_scalars
 
     extraction = {
-        "nodes": [None, {"id": "person-alice", "type": "Person", "confidence": 1.0, "attributes": {"name": "Alice"}}],
+        "nodes": [
+            None,
+            {
+                "id": "person-alice",
+                "type": "Person",
+                "confidence": 1.0,
+                "attributes": {"name": "Alice"},
+            },
+        ],
         "edges": [],
     }
     result = _normalize_scalars(extraction)
@@ -496,7 +504,10 @@ def test_backfill_tolerates_null_items_in_nodes():
     from mykg.pass2 import _backfill_extraction
 
     extraction = {
-        "nodes": [None, {"id": "org-acme", "type": "Organization", "confidence": 0.9, "attributes": {}}],
+        "nodes": [
+            None,
+            {"id": "org-acme", "type": "Organization", "confidence": 0.9, "attributes": {}},
+        ],
         "edges": [],
     }
     result = _backfill_extraction(extraction, SCHEMA, FLAT_SCHEMA)
@@ -539,7 +550,9 @@ def test_extract_chunk_filters_nulls_via_run_pass2():
         "edges": VALID_EXTRACTION["edges"],
     }
     adapter = MockAdapter(json.dumps(extraction_with_nulls))
-    results, _, _failed = run_pass2({"test.md": "Alice works at Acme."}, SCHEMA, FLAT_SCHEMA, adapter)
+    results, _, _failed = run_pass2(
+        {"test.md": "Alice works at Acme."}, SCHEMA, FLAT_SCHEMA, adapter
+    )
     assert "test.md" in results
     for node in results["test.md"]["nodes"]:
         assert node is not None

--- a/tests/test_pass2_batch.py
+++ b/tests/test_pass2_batch.py
@@ -171,17 +171,19 @@ MINIMAL_SCHEMA = {
 }
 MINIMAL_FLAT = {"Person": ["name"]}
 
-VALID_EXTRACTION = json.dumps({
-    "nodes": [
-        {
-            "id": "person-alice",
-            "type": "Person",
-            "confidence": 0.9,
-            "attributes": {"name": {"value": "Alice", "confidence": 0.9}},
-        }
-    ],
-    "edges": [],
-})
+VALID_EXTRACTION = json.dumps(
+    {
+        "nodes": [
+            {
+                "id": "person-alice",
+                "type": "Person",
+                "confidence": 0.9,
+                "attributes": {"name": {"value": "Alice", "confidence": 0.9}},
+            }
+        ],
+        "edges": [],
+    }
+)
 
 
 class _MockAdapter:

--- a/tests/test_pass2_batch_retry.py
+++ b/tests/test_pass2_batch_retry.py
@@ -1,4 +1,5 @@
 """Tests for in-run retry of failed batches in run_pass2_batched."""
+
 import unittest.mock as mock
 from unittest.mock import MagicMock
 
@@ -12,20 +13,26 @@ def test_failed_batches_are_retried():
         "a.md": "# A\ncontent about Alice",
         "b.md": "# B\ncontent about Bob",
     }
-    schema = {"concepts": [{"type": "Person", "attributes": ["name"], "parent": None}], "properties": []}
+    schema = {
+        "concepts": [{"type": "Person", "attributes": ["name"], "parent": None}],
+        "properties": [],
+    }
     flat = {"Person": ["name"]}
 
     extract_calls = []
 
     def counting_extract(batch, *args, **kwargs):
         extract_calls.append(len(batch))
-        if len(extract_calls) <= 2:   # first round: both batches fail
+        if len(extract_calls) <= 2:  # first round: both batches fail
             raise RuntimeError("simulated timeout")
         return {"nodes": [], "edges": []}  # retry succeeds
 
     with mock.patch.object(p2_mod, "_extract_batch", side_effect=counting_extract):
         results, _, _, _ = run_pass2_batched(
-            files, schema, flat, MagicMock(),
+            files,
+            schema,
+            flat,
+            MagicMock(),
             batch_token_target=8,  # small enough to force one file per batch
             batch_retry_max=1,
             max_workers=2,
@@ -53,7 +60,10 @@ def test_retry_disabled_when_batch_retry_max_is_zero():
 
     with mock.patch.object(p2_mod, "_extract_batch", side_effect=always_fail):
         run_pass2_batched(
-            files, schema, flat, MagicMock(),
+            files,
+            schema,
+            flat,
+            MagicMock(),
             batch_token_target=100_000,
             batch_retry_max=0,
             max_workers=1,
@@ -78,11 +88,16 @@ def test_retry_runs_n_rounds_per_batch_retry_max():
 
     with mock.patch.object(p2_mod, "_extract_batch", side_effect=fail_twice_then_succeed):
         results, _, _, _ = run_pass2_batched(
-            files, schema, flat, MagicMock(),
+            files,
+            schema,
+            flat,
+            MagicMock(),
             batch_token_target=100_000,
             batch_retry_max=2,
             max_workers=1,
         )
 
-    assert len(extract_calls) == 3, f"Expected 3 calls (1 initial + 2 retries) but got {len(extract_calls)}"
+    assert len(extract_calls) == 3, (
+        f"Expected 3 calls (1 initial + 2 retries) but got {len(extract_calls)}"
+    )
     assert "a.md" in results

--- a/tests/test_pass2_concat.py
+++ b/tests/test_pass2_concat.py
@@ -1,8 +1,10 @@
 from mykg.pass2_concat import build_concat_batches, make_virtual_files
 
 # A single ASCII word is roughly 1 token with cl100k_base, so "word " * N ≈ N tokens.
-SMALL = "word " * 20   # ~21 tokens — well below any reasonable target
-LARGE = "word " * 2200  # ~2201 tokens — safely above the 2000-token pass-through threshold used in tests
+SMALL = "word " * 20  # ~21 tokens — well below any reasonable target
+LARGE = (
+    "word " * 2200
+)  # ~2201 tokens — safely above the 2000-token pass-through threshold used in tests
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +137,9 @@ def test_entry_has_token_metadata():
 def test_make_virtual_files_single_file_unchanged():
     """A single-file concat entry passes content through without any delimiters."""
     fc = {"note.md": "Hello world"}
-    concat_map = {"note.md": {"files": ["note.md"], "file_tokens": {"note.md": 2}, "total_tokens": 2}}
+    concat_map = {
+        "note.md": {"files": ["note.md"], "file_tokens": {"note.md": 2}, "total_tokens": 2}
+    }
     result = make_virtual_files(fc, concat_map)
     assert result == {"note.md": "Hello world"}
 

--- a/tests/test_schema_merge.py
+++ b/tests/test_schema_merge.py
@@ -368,7 +368,9 @@ def test_merge_proposals_skips_non_dict_property():
 
 _SESSION_SCHEMAS = [
     {
-        "concepts": [{"type": "Document", "parent": None, "attributes": ["name", "date", "subject"]}],
+        "concepts": [
+            {"type": "Document", "parent": None, "attributes": ["name", "date", "subject"]}
+        ],
         "properties": [],
     },
     {
@@ -379,7 +381,11 @@ _SESSION_SCHEMAS = [
 
 _MERGED_SCHEMA_FOR_MERGE = {
     "concepts": [
-        {"type": "Document", "parent": None, "attributes": ["name", "date", "subject", "document_type"]}
+        {
+            "type": "Document",
+            "parent": None,
+            "attributes": ["name", "date", "subject", "document_type"],
+        }
     ],
     "properties": [],
 }
@@ -494,7 +500,10 @@ def test_review_schema_quality_rejects_drastic_reduction():
     """review_schema_quality must fall back when LLM drops >50% of concepts."""
     adapter = MagicMock()
     # 1 concept out of 4 original is 25% — below the 50% floor
-    tiny = {"concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}], "properties": []}
+    tiny = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
     adapter.complete.return_value = json.dumps(tiny)
     result = review_schema_quality(_MULTI_CONCEPT_SCHEMA, adapter)
     assert result is _MULTI_CONCEPT_SCHEMA
@@ -538,7 +547,10 @@ def test_review_quality_for_merge_rejects_empty_concepts():
 def test_review_quality_for_merge_rejects_drastic_reduction():
     """review_schema_quality_for_merge must fall back when LLM drops >50% of concepts."""
     adapter = MagicMock()
-    tiny = {"concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}], "properties": []}
+    tiny = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
     adapter.complete.return_value = json.dumps(tiny)
     result = review_schema_quality_for_merge(_MULTI_CONCEPT_SCHEMA, adapter)
     assert result is _MULTI_CONCEPT_SCHEMA

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -68,7 +68,9 @@ def sessions_root(tmp_path, monkeypatch):
 _SHARD_DIRS = ("raw_extractions_shards", "chunk_index_shards")
 
 
-def _populate_step_files(steps, intermediate_dir: Path, output_dir: Path, *, extras: list[str] | None = None) -> None:
+def _populate_step_files(
+    steps, intermediate_dir: Path, output_dir: Path, *, extras: list[str] | None = None
+) -> None:
     """Write a placeholder file for every step output, create shard dirs, and write the approval flag.
 
     extras: additional filenames written into intermediate_dir (e.g. pass2_concat_map.json).
@@ -85,7 +87,7 @@ def _populate_step_files(steps, intermediate_dir: Path, output_dir: Path, *, ext
 
     (intermediate_dir / "schema_approved.flag").write_text("approved")
 
-    for fname in (extras or []):
+    for fname in extras or []:
         (intermediate_dir / fname).write_text("{}")
 
 
@@ -634,7 +636,7 @@ def test_approve_schema_via_session_option(sessions_root, monkeypatch):
     import mykg.cli as cli_mod
     import mykg.exporter as exp_mod
 
-    inter = (sessions_root / "my-session" / "intermediate")
+    inter = sessions_root / "my-session" / "intermediate"
     inter.mkdir(parents=True)
     (inter / "schema.json").write_text(json.dumps(_minimal_schema()))
     monkeypatch.setattr(
@@ -654,7 +656,7 @@ def test_approve_schema_generates_ttl_and_flag(sessions_root, monkeypatch):
     import mykg.cli as cli_mod
     import mykg.exporter as exp_mod
 
-    inter = (sessions_root / "gen-session" / "intermediate")
+    inter = sessions_root / "gen-session" / "intermediate"
     inter.mkdir(parents=True)
     (inter / "schema.json").write_text(json.dumps(_minimal_schema()))
     monkeypatch.setattr(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -188,8 +188,8 @@ def test_extract_auto_creates_session(tmp_path, input_dir, monkeypatch):
     import mykg.config as cfg_mod
 
     monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
-    monkeypatch.setattr(cli_mod, "run", lambda steps, ctx: None)
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.orchestrator.run", lambda steps, ctx: None)
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
 
     (input_dir / "doc.md").write_text("test")
 
@@ -219,8 +219,8 @@ def test_extract_log_file_placed_in_session(tmp_path, input_dir, monkeypatch):
     import mykg.config as cfg_mod
 
     monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
-    monkeypatch.setattr(cli_mod, "run", lambda steps, ctx: None)
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.orchestrator.run", lambda steps, ctx: None)
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
 
     (input_dir / "doc.md").write_text("test")
 
@@ -256,8 +256,8 @@ def test_extract_session_uses_existing_dirs(tmp_path, input_dir, monkeypatch):
         captured["output_dir"] = ctx.output_dir
         captured["intermediate_dir"] = ctx.intermediate_dir
 
-    monkeypatch.setattr(cli_mod, "run", fake_run)
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.orchestrator.run", fake_run)
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
 
     runner = CliRunner()
     result = runner.invoke(
@@ -280,7 +280,7 @@ def test_extract_session_nonexistent_raises(tmp_path, input_dir, monkeypatch):
     import mykg.config as cfg_mod
 
     monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
 
     runner = CliRunner()
     result = runner.invoke(cli_mod.cli, ["extract-graph", str(input_dir), "--session", "ghost"])
@@ -305,7 +305,7 @@ def test_extract_session_with_output_dir_raises(tmp_path, input_dir, monkeypatch
     (sess / "intermediate").mkdir(parents=True)
     (sess / "output").mkdir(parents=True)
 
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
 
     runner = CliRunner()
     result = runner.invoke(
@@ -340,8 +340,8 @@ def test_extract_session_refreshes_input_copy(tmp_path, input_dir, monkeypatch):
     (sess / "output").mkdir(parents=True)
     (sess / "input").mkdir(parents=True)
 
-    monkeypatch.setattr(cli_mod, "run", lambda steps, ctx: None)
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.orchestrator.run", lambda steps, ctx: None)
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
 
     (input_dir / "new_doc.md").write_text("new content")
 
@@ -598,7 +598,7 @@ def test_merge_graphs_creates_merged_session_folder(sessions_root, monkeypatch):
     (sessions_root / "sess-b").mkdir()
 
     fake_run_merge = MagicMock()
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
     monkeypatch.setattr(merge_orch_mod, "run_merge_graphs", fake_run_merge)
 
     runner = CliRunner()
@@ -615,7 +615,7 @@ def test_merge_graphs_with_named_output_session(sessions_root, monkeypatch):
     (sessions_root / "sess-b").mkdir()
 
     fake_run_merge = MagicMock()
-    monkeypatch.setattr(cli_mod, "load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
     monkeypatch.setattr(merge_orch_mod, "run_merge_graphs", fake_run_merge)
 
     runner = CliRunner()

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -349,7 +349,9 @@ def test_run_validate_graph_does_not_raise_on_tbox_errors(tmp_path):
         "abox_checks": {"errors": []},
     }
 
-    with patch("mykg.steps.step_validate_graph.validate_knowledge_graph_ttl", return_value=tbox_result):
+    with patch(
+        "mykg.steps.step_validate_graph.validate_knowledge_graph_ttl", return_value=tbox_result
+    ):
         # Should not raise
         run_validate_graph(ctx)
 
@@ -358,8 +360,9 @@ def test_run_validate_graph_does_not_raise_on_tbox_errors(tmp_path):
 
 def test_run_validate_graph_calls_export_obsidian_when_enabled(tmp_path, monkeypatch):
     """run_validate_graph calls export_obsidian when OBSIDIAN_ENABLED is True."""
-    import mykg.config as cfg_mod
     from unittest.mock import patch
+
+    import mykg.config as cfg_mod
 
     monkeypatch.setattr(cfg_mod, "OBSIDIAN_ENABLED", True)
     monkeypatch.setattr(cfg_mod, "OBSIDIAN_VAULT_DIR", "obsidian_vault")
@@ -387,8 +390,9 @@ def test_run_validate_graph_calls_export_obsidian_when_enabled(tmp_path, monkeyp
 
 def test_run_validate_graph_skips_export_obsidian_when_disabled(tmp_path, monkeypatch):
     """run_validate_graph does not call export_obsidian when OBSIDIAN_ENABLED is False."""
-    import mykg.config as cfg_mod
     from unittest.mock import patch
+
+    import mykg.config as cfg_mod
 
     monkeypatch.setattr(cfg_mod, "OBSIDIAN_ENABLED", False)
 

--- a/tests/test_walkthrough.py
+++ b/tests/test_walkthrough.py
@@ -340,37 +340,125 @@ def _make_merge_sessions(tmp_path: Path):
     # --- session A ---
     _write(
         sess_a / "intermediate" / "nodes.json",
-        [{"id": "person-alice", "type": "Person", "confidence": 1.0, "attributes": {"name": {"value": "Alice", "confidence": 1.0}}, "source_files": ["a.md"]}],
+        [
+            {
+                "id": "person-alice",
+                "type": "Person",
+                "confidence": 1.0,
+                "attributes": {"name": {"value": "Alice", "confidence": 1.0}},
+                "source_files": ["a.md"],
+            }
+        ],
     )
     _write(
         sess_a / "intermediate" / "edge_metadata.json",
-        {"edge-a1": {"type": "works_at", "from": "person-alice", "to": "org-x", "confidence": 0.9, "method": "llm_extraction", "attributes": {}, "source_files": ["a.md"]}},
+        {
+            "edge-a1": {
+                "type": "works_at",
+                "from": "person-alice",
+                "to": "org-x",
+                "confidence": 0.9,
+                "method": "llm_extraction",
+                "attributes": {},
+                "source_files": ["a.md"],
+            }
+        },
     )
     _write(
         sess_a / "intermediate" / "schema.json",
-        {"concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}], "properties": [{"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []}]},
+        {
+            "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+            "properties": [
+                {"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []}
+            ],
+        },
     )
     _write(
         sess_a / "intermediate" / "raw_extractions.json",
-        {"a.md": {"nodes": [{"id": "person-alice", "type": "Person", "confidence": 1.0, "attributes": {}, "source_files": []}], "edges": [{"type": "works_at", "from": "person-alice", "to": "org-x", "confidence": 0.9, "attributes": {}}]}},
+        {
+            "a.md": {
+                "nodes": [
+                    {
+                        "id": "person-alice",
+                        "type": "Person",
+                        "confidence": 1.0,
+                        "attributes": {},
+                        "source_files": [],
+                    }
+                ],
+                "edges": [
+                    {
+                        "type": "works_at",
+                        "from": "person-alice",
+                        "to": "org-x",
+                        "confidence": 0.9,
+                        "attributes": {},
+                    }
+                ],
+            }
+        },
     )
 
     # --- session B ---
     _write(
         sess_b / "intermediate" / "nodes.json",
-        [{"id": "org-acme", "type": "Organization", "confidence": 1.0, "attributes": {"name": {"value": "Acme", "confidence": 1.0}}, "source_files": ["b.md"]}],
+        [
+            {
+                "id": "org-acme",
+                "type": "Organization",
+                "confidence": 1.0,
+                "attributes": {"name": {"value": "Acme", "confidence": 1.0}},
+                "source_files": ["b.md"],
+            }
+        ],
     )
     _write(
         sess_b / "intermediate" / "edge_metadata.json",
-        {"edge-b1": {"type": "works_at", "from": "person-bob", "to": "org-acme", "confidence": 0.8, "method": "llm_extraction", "attributes": {}, "source_files": ["b.md"]}},
+        {
+            "edge-b1": {
+                "type": "works_at",
+                "from": "person-bob",
+                "to": "org-acme",
+                "confidence": 0.8,
+                "method": "llm_extraction",
+                "attributes": {},
+                "source_files": ["b.md"],
+            }
+        },
     )
     _write(
         sess_b / "intermediate" / "schema.json",
-        {"concepts": [{"type": "Organization", "parent": None, "attributes": ["name"]}], "properties": [{"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []}]},
+        {
+            "concepts": [{"type": "Organization", "parent": None, "attributes": ["name"]}],
+            "properties": [
+                {"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []}
+            ],
+        },
     )
     _write(
         sess_b / "intermediate" / "raw_extractions.json",
-        {"b.md": {"nodes": [{"id": "org-acme", "type": "Organization", "confidence": 1.0, "attributes": {}, "source_files": []}], "edges": [{"type": "works_at", "from": "person-bob", "to": "org-acme", "confidence": 0.8, "attributes": {}}]}},
+        {
+            "b.md": {
+                "nodes": [
+                    {
+                        "id": "org-acme",
+                        "type": "Organization",
+                        "confidence": 1.0,
+                        "attributes": {},
+                        "source_files": [],
+                    }
+                ],
+                "edges": [
+                    {
+                        "type": "works_at",
+                        "from": "person-bob",
+                        "to": "org-acme",
+                        "confidence": 0.8,
+                        "attributes": {},
+                    }
+                ],
+            }
+        },
     )
 
     # --- merged session ---
@@ -381,8 +469,18 @@ def _make_merge_sessions(tmp_path: Path):
                 "session_a": {"name": "sess-a", "prep_mode": "per_file"},
                 "session_b": {"name": "sess-b", "prep_mode": "per_file"},
             },
-            "session_a/a.md": {"original_session": "sess-a", "alias": "session_a", "sha256": "aaa", "role": "input_a"},
-            "session_b/b.md": {"original_session": "sess-b", "alias": "session_b", "sha256": "bbb", "role": "input_b"},
+            "session_a/a.md": {
+                "original_session": "sess-a",
+                "alias": "session_a",
+                "sha256": "aaa",
+                "role": "input_a",
+            },
+            "session_b/b.md": {
+                "original_session": "sess-b",
+                "alias": "session_b",
+                "sha256": "bbb",
+                "role": "input_b",
+            },
         },
     )
     _write(
@@ -414,30 +512,132 @@ def _make_merge_sessions(tmp_path: Path):
     _write(
         merged / "intermediate" / "raw_extractions.json",
         {
-            "session_a/a.md": {"nodes": [{"id": "person-alice", "type": "Person", "confidence": 1.0, "attributes": {}, "source_files": []}], "edges": [{"type": "works_at", "from": "person-alice", "to": "org-acme", "confidence": 0.9, "attributes": {}}]},
-            "session_b/b.md": {"nodes": [{"id": "org-acme", "type": "Organization", "confidence": 1.0, "attributes": {}, "source_files": []}], "edges": [{"type": "works_at", "from": "person-bob", "to": "org-acme", "confidence": 0.8, "attributes": {}}, {"type": "new_prop", "from": "person-alice", "to": "org-acme", "confidence": 0.7, "attributes": {}}]},
+            "session_a/a.md": {
+                "nodes": [
+                    {
+                        "id": "person-alice",
+                        "type": "Person",
+                        "confidence": 1.0,
+                        "attributes": {},
+                        "source_files": [],
+                    }
+                ],
+                "edges": [
+                    {
+                        "type": "works_at",
+                        "from": "person-alice",
+                        "to": "org-acme",
+                        "confidence": 0.9,
+                        "attributes": {},
+                    }
+                ],
+            },
+            "session_b/b.md": {
+                "nodes": [
+                    {
+                        "id": "org-acme",
+                        "type": "Organization",
+                        "confidence": 1.0,
+                        "attributes": {},
+                        "source_files": [],
+                    }
+                ],
+                "edges": [
+                    {
+                        "type": "works_at",
+                        "from": "person-bob",
+                        "to": "org-acme",
+                        "confidence": 0.8,
+                        "attributes": {},
+                    },
+                    {
+                        "type": "new_prop",
+                        "from": "person-alice",
+                        "to": "org-acme",
+                        "confidence": 0.7,
+                        "attributes": {},
+                    },
+                ],
+            },
         },
     )
     _write(
         merged / "intermediate" / "nodes.json",
         [
-            {"id": "person-alice", "type": "Person", "confidence": 1.0, "attributes": {"name": {"value": "Alice", "confidence": 1.0}}, "source_files": ["session_a/a.md"]},
-            {"id": "org-acme", "type": "Organization", "confidence": 1.0, "attributes": {"name": {"value": "Acme", "confidence": 1.0}}, "source_files": ["session_b/b.md"]},
+            {
+                "id": "person-alice",
+                "type": "Person",
+                "confidence": 1.0,
+                "attributes": {"name": {"value": "Alice", "confidence": 1.0}},
+                "source_files": ["session_a/a.md"],
+            },
+            {
+                "id": "org-acme",
+                "type": "Organization",
+                "confidence": 1.0,
+                "attributes": {"name": {"value": "Acme", "confidence": 1.0}},
+                "source_files": ["session_b/b.md"],
+            },
         ],
     )
     _write(
         merged / "intermediate" / "edge_metadata.json",
         {
-            "edge-a1": {"type": "works_at", "from": "person-alice", "to": "org-acme", "confidence": 0.9, "method": "llm_extraction", "attributes": {}, "source_files": ["session_a/a.md"]},
-            "edge-b1": {"type": "works_at", "from": "org-acme", "to": "person-alice", "confidence": 0.8, "method": "llm_extraction", "attributes": {}, "source_files": ["session_b/b.md"]},
+            "edge-a1": {
+                "type": "works_at",
+                "from": "person-alice",
+                "to": "org-acme",
+                "confidence": 0.9,
+                "method": "llm_extraction",
+                "attributes": {},
+                "source_files": ["session_a/a.md"],
+            },
+            "edge-b1": {
+                "type": "works_at",
+                "from": "org-acme",
+                "to": "person-alice",
+                "confidence": 0.8,
+                "method": "llm_extraction",
+                "attributes": {},
+                "source_files": ["session_b/b.md"],
+            },
         },
     )
-    _write(merged / "intermediate" / "merge_log.json", [
-        {"event": "node_merge", "id": "person-alice"},
-        {"event": "edge_merge", "id": "edge-a1"},
-    ])
-    _write(merged / "intermediate" / "orphan_candidates.json", {"groups": [{"orphan_ids": ["person-bob"], "connected_node_ids": ["org-acme"], "filename": "b.md", "chunk_idx": 0}], "schema_gap_orphans": []})
-    _write(merged / "intermediate" / "orphan_connections.json", {"edge-orphan-1": {"type": "works_at", "from": "person-bob", "to": "org-acme", "confidence": 0.7, "method": "orphan_inferred", "attributes": {}, "source_files": []}})
+    _write(
+        merged / "intermediate" / "merge_log.json",
+        [
+            {"event": "node_merge", "id": "person-alice"},
+            {"event": "edge_merge", "id": "edge-a1"},
+        ],
+    )
+    _write(
+        merged / "intermediate" / "orphan_candidates.json",
+        {
+            "groups": [
+                {
+                    "orphan_ids": ["person-bob"],
+                    "connected_node_ids": ["org-acme"],
+                    "filename": "b.md",
+                    "chunk_idx": 0,
+                }
+            ],
+            "schema_gap_orphans": [],
+        },
+    )
+    _write(
+        merged / "intermediate" / "orphan_connections.json",
+        {
+            "edge-orphan-1": {
+                "type": "works_at",
+                "from": "person-bob",
+                "to": "org-acme",
+                "confidence": 0.7,
+                "method": "orphan_inferred",
+                "attributes": {},
+                "source_files": [],
+            }
+        },
+    )
 
     return sessions_root, merged, sess_a, sess_b
 
@@ -491,7 +691,15 @@ def test_node_edge_trace_reextract_calls_from_llm_log(tmp_path):
     _, merged, _, _ = _make_merge_sessions(tmp_path)
     # Write an llm.log with a pass2/reextract call
     (merged / "llm.log").write_text(
-        json.dumps({"context": "pass2 reextract chunk 1", "input_tokens": 100, "output_tokens": 50, "duration_s": 2.0}) + "\n"
+        json.dumps(
+            {
+                "context": "pass2 reextract chunk 1",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "duration_s": 2.0,
+            }
+        )
+        + "\n"
     )
     result = _section_node_edge_trace(merged)
     assert result is not None
@@ -620,7 +828,10 @@ def test_extraction_summary_includes_name_normalization_when_present(tmp_path):
     (session / "intermediate").mkdir(parents=True)
     _write(
         session / "intermediate" / "name_normalization.json",
-        {"metadata": {"aliases_mapped": 5}, "mappings": {"Person": {"Bob": "Alice"}, "Org": {"Corp": "Company"}}},
+        {
+            "metadata": {"aliases_mapped": 5},
+            "mappings": {"Person": {"Bob": "Alice"}, "Org": {"Corp": "Company"}},
+        },
     )
     result = _section_extraction_summary(session, [], {})
     assert "Name normalization" in result
@@ -641,7 +852,11 @@ def test_extraction_summary_includes_dedup_counts_from_merge_log(tmp_path):
     (session / "intermediate").mkdir(parents=True)
     _write(
         session / "intermediate" / "merge_log.json",
-        [{"event": "node_merge", "id": "x"}, {"event": "node_merge", "id": "y"}, {"event": "edge_merge", "id": "e1"}],
+        [
+            {"event": "node_merge", "id": "x"},
+            {"event": "node_merge", "id": "y"},
+            {"event": "edge_merge", "id": "e1"},
+        ],
     )
     result = _section_extraction_summary(session, [], {})
     assert "Deduplication" in result
@@ -654,9 +869,24 @@ def test_extraction_summary_retry_rate_shown_when_chunks_dispatched(tmp_path):
     (session / "intermediate").mkdir(parents=True)
     # Simulate log lines with chunk dispatch and a retry
     log_lines = [
-        {"ts": "10:00:01", "level": "INFO", "logger": "mykg.pass2", "message": "Processing chunk 1/5"},
-        {"ts": "10:00:02", "level": "INFO", "logger": "mykg.pass2", "message": "Processing chunk 2/5"},
-        {"ts": "10:00:03", "level": "WARNING", "logger": "mykg.pass2", "message": "chunk 1 — JSON parse error — retrying"},
+        {
+            "ts": "10:00:01",
+            "level": "INFO",
+            "logger": "mykg.pass2",
+            "message": "Processing chunk 1/5",
+        },
+        {
+            "ts": "10:00:02",
+            "level": "INFO",
+            "logger": "mykg.pass2",
+            "message": "Processing chunk 2/5",
+        },
+        {
+            "ts": "10:00:03",
+            "level": "WARNING",
+            "logger": "mykg.pass2",
+            "message": "chunk 1 — JSON parse error — retrying",
+        },
     ]
     result = _section_extraction_summary(session, log_lines, {})
     assert "Retry rate" in result


### PR DESCRIPTION
## Summary

- **Obsidian vault export** — new `export_obsidian()` function writes one wikilinked Markdown note per entity to `output/obsidian_vault/`; enabled by default; `--obsidian-vault` CLI flag for per-run override
- **Second brain positioning** — README updated to describe Obsidian vault as a second brain for AI coding assistants (Claude Code, Cursor, Copilot)
- **Ruff format + lint** — 29 files reformatted, 15 lint issues fixed
- **Test fixes** — 12 failing tests fixed by patching `mykg.orchestrator.run` and `mykg.llm.config.load_adapter` directly (both are lazy imports inside the CLI function body)
- **Version bump** — 0.2.5 → 0.2.6

## Test plan
- [x] 687 tests passing, 0 failures
- [x] 87% coverage
- [x] Obsidian vault verified end-to-end on session `2026-05-25T16-29-16` (24 notes written)
- [x] Published to PyPI as `mykg==0.2.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)