### PR TITLE
chore: enable preprocess by default; silence pajek attr warnings

### DIFF
--- a/mykg_config.yaml
+++ b/mykg_config.yaml
@@ -183,7 +183,7 @@ profiles:
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
       preprocess:
-        enabled: false                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
         subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
         extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
@@ -315,7 +315,7 @@ profiles:
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
       preprocess:
-        enabled: false                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
         subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
         extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
@@ -445,7 +445,7 @@ profiles:
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
       preprocess:
-        enabled: false                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
         subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
         extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
@@ -578,7 +578,7 @@ profiles:
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
       preprocess:
-        enabled: false                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
         subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
         extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -183,7 +183,7 @@ profiles:
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
       preprocess:
-        enabled: false                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
         subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
         extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
@@ -315,7 +315,7 @@ profiles:
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
       preprocess:
-        enabled: false                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
         subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
         extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
@@ -445,7 +445,7 @@ profiles:
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
       preprocess:
-        enabled: false                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
         subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
         extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
@@ -578,7 +578,7 @@ profiles:
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
       preprocess:
-        enabled: false                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
         subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
         extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)

--- a/src/mykg/exporter.py
+++ b/src/mykg/exporter.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import html as _html
 import json
 import re
+import warnings
 from collections import defaultdict
 from pathlib import Path
 
@@ -657,7 +658,16 @@ def export_networkx(nodes: list[dict], edge_metadata: dict, output_dir: Path) ->
     nx.write_gexf(G, str(nx_dir / "knowledge_graph.gexf"))
     written.append("knowledge_graph.gexf")
 
-    nx.write_pajek(G, str(nx_dir / "knowledge_graph.net"))
+    # Pajek format drops non-string and empty attributes by design — silence the
+    # per-attribute UserWarnings that networkx.readwrite.pajek emits for each one.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"(Node|Edge) attribute .* is not processed\..*",
+            category=UserWarning,
+            module=r"networkx\.readwrite\.pajek",
+        )
+        nx.write_pajek(G, str(nx_dir / "knowledge_graph.net"))
     written.append("knowledge_graph.net")
 
     with open(nx_dir / "knowledge_graph.json", "w") as f:

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "mykg"
-version = "0.2.13"
+version = "0.2.14"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Flip `preprocess.enabled` from `false` to `true` across all four profiles in both `mykg_config.yaml` and `src/mykg/data/mykg_config.yaml` so PDF/DOCX/image inputs are converted via MinerU out of the box
- Silence per-attribute `UserWarning`s emitted by `networkx.readwrite.pajek` in `export_networkx` — the Pajek format drops non-string and empty attributes by design, so the warnings are noise
- Pick up `uv.lock` bump to 0.2.14

## Test plan
- [ ] `mykg extract-graph` on a corpus containing non-md inputs picks up the converted files via the default config
- [ ] NetworkX export completes without flooding the log with pajek attribute warnings
- [ ] `knowledge_graph.net` is still written and loadable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable MinerU preprocessing by default and quiet noisy Pajek export warnings.

Enhancements:
- Enable MinerU-based preprocessing for non-markdown inputs by default across all profiles in both primary and embedded configs.
- Silence NetworkX Pajek exporter attribute warnings when writing knowledge_graph.net to reduce log noise.

Build:
- Update uv.lock to the latest recorded version.