### PR TITLE
agent-mode: minimal agent provider + skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ The wizard walks you through three prompts:
 | Ollama | `ollama-local` | — | Local inference, no key needed |
 | OpenRouter | `openrouter-free` | `OPENROUTER_API_KEY` | Access many models via one key |
 | Claude CLI | `claude-cli` | — | Uses `claude -p` subprocess; serial only |
+| Agent (Claude Code skill) | `agent-claude-code` | — | LLM answers come from a Claude Code skill via filesystem inbox/outbox — see [docs/agent-mode.md](docs/agent-mode.md) |
 
 Switch provider by setting `profile:` at the top of [`mykg_config.yaml`](mykg_config.yaml).
 

--- a/docs/agent-mode.md
+++ b/docs/agent-mode.md
@@ -1,0 +1,159 @@
+# Agent mode
+
+Agent mode is a sixth LLM backend for mykg in which LLM answers are produced not by an HTTP API or a subprocess but by a **Claude Code skill** running inside your coding assistant. The pipeline writes task envelopes to a session-local inbox folder; a skill drains the inbox, dispatches subagents, and writes answers back to an outbox folder. The pipeline polls the outbox for a `.done` sentinel before returning each `complete()` call.
+
+This is useful when:
+
+- you do not want to manage API keys or pay per-token fees, but you do have a Claude Code subscription
+- you want to inspect, edit, or replay LLM responses at the filesystem level — every prompt is a `.task.json` and every answer is a `.answer.json` on disk
+- you want the host coding assistant's tool palette (file reads, code execution, web fetch) available implicitly inside LLM responses
+
+The 12-step pipeline, all 14 LLM call sites, all `prompts/*.txt` templates, the orchestrator, and the existing five adapters are **unchanged**. Agent mode is a thin filesystem-backed adapter that conforms to the existing `LLMAdapter` interface.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────┐                ┌────────────────────┐
+│ /mykg skill          │ ── runs ───▶  │ mykg extract-graph │
+│ (Claude Code)        │                │ (subprocess)       │
+│                      │                └─────────┬──────────┘
+│ loop:                │                          │
+│   ls inbox/*.json    │                          │ adapter.complete(s,u)
+│   for each task:     │                          ▼
+│     dispatch subagent│ ←── reads ─── intermediate/agent_inbox/<id>.task.json
+│     write answer     │ ── writes ──▶ intermediate/agent_outbox/<id>.done
+│   sleep 2s           │                          │
+└──────────────────────┘                          │ poll loop sees .done
+                                                  │ reads answer, returns
+                                                  ▼
+                                          step.fn() continues
+```
+
+Two directories per session, one sentinel file per task. The adapter writes-and-polls; the skill scans-and-dispatches.
+
+---
+
+## The contract
+
+All paths are relative to the session's `intermediate/` directory.
+
+**Task envelope** — `agent_inbox/<task_id>.task.json` — written by `AgentAdapter.complete()`, read by the skill:
+
+```json
+{
+  "task_id": "abc123…",
+  "step": "pass2",
+  "context_label": "pass2:doc.md:chunk5",
+  "system": "<full system prompt text>",
+  "user":   "<full user prompt text>",
+  "max_tokens": 10000,
+  "timeout_seconds": 1800,
+  "created_at": "2026-06-02T17:30:00Z"
+}
+```
+
+**Answer envelope** — `agent_outbox/<task_id>.answer.json` — written by the skill subagent:
+
+```json
+{
+  "task_id": "abc123…",
+  "answer": "<the raw JSON string the pipeline expects>"
+}
+```
+
+**Sentinel** — `agent_outbox/<task_id>.done` — zero-byte file created by the skill **after** the answer file. The adapter polls for this, not for `.answer.json`, so it never reads a half-written response.
+
+**Atomicity rule** (both sides) — write to `<name>.tmp` then `os.rename` to the final name. Never write directly to the final path.
+
+**`task_id`** — `sha256(system + "\n--user--\n" + user + "\n--ctx--\n" + context_label).hexdigest()`. Same inputs → same id → the existing answer is re-used (intra-session cache). Re-runs after a partial crash automatically pick up where they left off.
+
+---
+
+## Setting it up
+
+### 1. Activate the profile
+
+In `mykg_config.yaml`, set:
+
+```yaml
+profile: agent-claude-code
+```
+
+The `agent-claude-code` profile is bundled in both `mykg_config.yaml` (repo root) and `src/mykg/data/mykg_config.yaml` (packaging template). No API key is required.
+
+### 2. Install the skill
+
+Symlink the skill directory into your user-level skills folder:
+
+```bash
+ln -s "$(pwd)/src/mykg/data/skills/mykg" ~/.claude/skills/mykg
+```
+
+Restart Claude Code (or re-open the project) so the skill loader picks up the new entry.
+
+### 3. Invoke
+
+In Claude Code, type:
+
+```
+/mykg ./my_notes
+```
+
+The skill:
+
+1. Confirms the active profile is `agent-claude-code`.
+2. Launches `mykg extract-graph ./my_notes` in the background via `nohup`.
+3. Watches `<session>/intermediate/agent_inbox/` for `*.task.json` files.
+4. Dispatches one Agent-tool subagent per unanswered task (parallel calls per wave, up to the `pass2.max_workers` configured in the profile).
+5. Sleeps 2 seconds between waves.
+6. Exits when the pipeline subprocess exits, when `output/knowledge_graph.ttl` appears, or after 20 watch waves.
+
+To resume after a 20-wave timeout, re-invoke:
+
+```
+/mykg --session 2026-06-02T17-30-00 --continue
+```
+
+The full skill body lives in `src/mykg/data/skills/mykg/SKILL.md`. It includes a CLI reference table for all six `mykg` subcommands and the exact subagent prompt template.
+
+---
+
+## Timeout and retry story
+
+Agent mode uses the **same orchestrator retry path** as every other adapter. There is no agent-specific retry layer.
+
+- The adapter's `complete()` polls the `.done` sentinel until `timeout_seconds` (default 1800). If no sentinel appears, it raises `TimeoutError`.
+- A `TimeoutError` propagates to the orchestrator, which (for `is_llm_step=True` steps) automatically retries once.
+- On the third attempt, the orchestrator's feedback path mutates the system prompt — producing a different `task_id` and therefore a different inbox file. The wasted second attempt cache-hits on the prior bad answer and costs one extra 2-second poll tick.
+
+If the skill crashes or the user kills Claude Code, in-flight tasks stay in the inbox. The pipeline blocks until `timeout_seconds`, then fails the step. Re-invoking `/mykg --session <name> --continue` resurrects the inbox-watch loop and the pipeline resumes.
+
+---
+
+## Caching and re-runs
+
+- Within a single session: a duplicate `complete()` call with identical `(system, user, context_label)` re-uses the existing `.answer.json` immediately — no inbox write, no skill dispatch.
+- Across sessions: each session has its own `intermediate/agent_inbox/` and `agent_outbox/`. There is no cross-session cache by design.
+- To force a re-prompt for a single task, delete the corresponding `<task_id>.done` (and optionally the `.answer.json`) before the next pipeline run.
+
+---
+
+## What stays unchanged
+
+- The 12 pipeline steps in `src/mykg/pipeline.py`.
+- All 14 LLM call sites across `pass1.py`, `pass2.py`, `name_normalizer.py`, `schema_merge.py`, `orphan_connector.py`, and `feedback.py`.
+- All `prompts/*.txt` template files.
+- The orchestrator's retry-once + feedback path.
+- `ThreadPoolExecutor` parallelism in `pass1`, `pass2`, and `orphan_connect` — `max_workers` blocking threads each call `complete()` in parallel; the skill drains them in parallel waves.
+- The five existing adapters (`anthropic`, `openai`, `openrouter`, `ollama`, `claude-cli`) — agent mode is additive.
+
+---
+
+## Limitations
+
+- The skill loop is bounded at 20 waves per invocation to avoid runaway Claude Code sessions. Long pipelines require multiple `/mykg --continue` invocations.
+- The agent provider does not record token counts in `llm.log` — the skill subagent's token usage is not visible to mykg.
+- The skill produces best-effort JSON; the pipeline's own validators (TBox check, schema validate, ABox check) catch malformed output and trigger the existing feedback path.
+- There is no heartbeat. A dead skill leaves in-flight pipeline threads blocked until `timeout_seconds`. If the user wants faster failure, Ctrl-C the pipeline subprocess and re-launch.

--- a/mykg_config.yaml
+++ b/mykg_config.yaml
@@ -2,7 +2,7 @@
 # myKG — Knowledge Graph Extractor
 # =============================================================================
 # ACTIVE PROFILE — change this one line to switch provider and all settings.
-# Available: ollama-local | anthropic-claude | openai | openrouter-free | claude-cli
+# Available: ollama-local | anthropic-claude | openai | openrouter-free | claude-cli | agent-claude-code
 # =============================================================================
 profile: openrouter-free
 
@@ -683,3 +683,126 @@ profiles:
         surgical_top_k_chunks_per_property: 0  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+
+  # ---------------------------------------------------------------------------
+  agent-claude-code:
+  # Agent mode (D49) — LLM answers are produced by a Claude Code skill via a
+  # filesystem inbox/outbox. The pipeline writes a task envelope to
+  # intermediate/<inbox_dir>/, the skill drains the inbox using subagents, and
+  # writes <id>.answer.json + <id>.done to intermediate/<outbox_dir>/.
+  #
+  # Install the skill once:
+  #   ln -s "$(pwd)/src/mykg/data/skills/mykg" ~/.claude/skills/mykg
+  # Then in Claude Code:  /mykg <input_dir>
+  #
+  # No API key required — the skill uses the host coding assistant's own
+  # reasoning. See docs/agent-mode.md for the full contract.
+  # ---------------------------------------------------------------------------
+    provider: agent
+    llm_retry:
+      max_retries: 1
+    llm:
+      max_output_tokens: 10000  # passed through to the task envelope; the skill enforces it
+      timeout: 1800             # seconds the pipeline will wait for a .done sentinel
+      retry_429_max: 0          # agent provider does not hit API rate limits
+      retry_429_base_delay: 2.0
+    agent:
+      inbox_dir: agent_inbox            # relative to session intermediate/
+      outbox_dir: agent_outbox          # relative to session intermediate/
+      poll_interval_seconds: 2          # how often the adapter checks for the .done sentinel
+    pipeline:
+      ingest:
+        max_workers: 8
+      preprocess:
+        enabled: true
+        subdir: _preprocessed
+        extra_args: []
+        timeout_seconds: 1800
+        uv_path: uv
+        uv_python_version: "3.12"
+        mineru_spec: mineru[all]
+        install_timeout_seconds: 1800
+        extensions:
+          - .pdf
+          - .docx
+          - .doc
+          - .pptx
+          - .png
+          - .jpg
+          - .jpeg
+          - .html
+          - .htm
+      chunking:
+        window_tokens: 2500
+        overlap_tokens: 250
+        tiktoken_encoding: cl100k_base
+      pass1:
+        batch_token_target: 10000
+        max_workers: 4                # the skill dispatches up to this many subagents per wave
+        per_file_batching: false
+      pass2:
+        max_workers: 4
+        stateful_chunks: true
+        prep_mode: batch_chunks
+        concat_batch_token_target: 10000
+        batch_token_target: 10000
+        batch_per_file: false
+        batch_retry_max: 1
+      normalize_names:
+        enabled: true
+        max_names_per_type: 2000
+      orphan_pass:
+        enabled: true
+        min_cooccurrence: 1
+        top_k_per_orphan: 5
+        confidence_base: 0.5
+        confidence_weight: 0.5
+        max_workers: 4
+        schema_max_restarts: 0
+        excerpt_window: 4000
+        excerpt_context: 1500
+        excerpt_max_total: 16000
+        blank_recovery_enabled: true
+        connected_sample_size: 200
+      assembly:
+        confidence_agg: mean
+        edge_id_prefix: "edge-"
+        edge_id_hex_length: 6
+        edge_dedup_separator: "|"
+        confidence_fallback: 0.0
+        confidence_scalar_omitted: 0.5
+      export:
+        schema_namespace: "http://mykg.local/schema/"
+        data_namespace: "http://mykg.local/data/"
+        rdf_namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        rdfs_namespace: "http://www.w3.org/2000/01/rdf-schema#"
+        schema_prefix_label: ex
+        data_prefix_label: data
+        comment_width: 42
+        skos_namespace: "http://www.w3.org/2004/02/skos/core#"
+        networkx_enabled: true
+        obsidian_enabled: false
+        obsidian_vault_dir: obsidian_vault
+      error_gate:
+        enabled: false
+        threshold: 3
+      feedback:
+        max_file_chars: 64000
+      paths:
+        output_dir: output
+        intermediate_dir: intermediate
+        sessions_dir: sessions
+      output:
+        json_indent: 2
+      logging:
+        max_bytes: 10485760
+        backup_count: 3
+        capture_prompts: true
+        error_output_max_chars: 500
+      report:
+        enabled: true
+      merge_graphs:
+        reextraction_strategy: none
+        surgical_top_k_chunks_per_property: 0
+        human_review: false
+        orphan_pass_max_restarts: 0

--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -390,7 +390,7 @@ def extract_graph(
     error_gate = (
         ErrorGate(threshold=_cfg().ERROR_GATE_THRESHOLD) if _cfg().ERROR_GATE_ENABLED else None
     )
-    adapter = load_adapter(error_gate=error_gate)
+    adapter = load_adapter(error_gate=error_gate, intermediate_dir=intermediate_dir)
     logging.getLogger(__name__).info("LLM endpoint: %s", adapter.endpoint_label())
 
     base = None
@@ -573,7 +573,7 @@ def merge_graphs(
     if from_step:
         _delete_merge_from_step(from_step, intermediate_dir, output_dir)
 
-    adapter = load_adapter()
+    adapter = load_adapter(intermediate_dir=intermediate_dir)
 
     base = None
     if base_schema:

--- a/src/mykg/config.py
+++ b/src/mykg/config.py
@@ -66,6 +66,8 @@ def _apply_profile(raw: dict) -> dict:
         result["llm"] = profile["llm"]
     if "llm_retry" in profile:
         result["llm_retry"] = profile["llm_retry"]
+    if "agent" in profile:
+        result["agent"] = profile["agent"]
     return result
 
 
@@ -256,3 +258,14 @@ MERGE_SURGICAL_TOP_K_CHUNKS_PER_PROPERTY: int = _get_opt(
     "merge_graphs", "surgical_top_k_chunks_per_property", 0
 )
 MERGE_ORPHAN_SCHEMA_MAX_RESTARTS: int = _get_opt("merge_graphs", "orphan_pass_max_restarts", 1)
+
+# ---------------------------------------------------------------------------
+# Agent provider (D49) — inbox/outbox filesystem contract with host skill
+# ---------------------------------------------------------------------------
+# These are only consumed when the active profile sets `provider: agent`.
+# Defaults are used when the active profile has no `agent:` block (other
+# providers do not need them).
+_agent = RAW.get("agent") or {}
+AGENT_INBOX_DIR: str = _agent.get("inbox_dir", "agent_inbox")
+AGENT_OUTBOX_DIR: str = _agent.get("outbox_dir", "agent_outbox")
+AGENT_POLL_INTERVAL_SECONDS: float = float(_agent.get("poll_interval_seconds", 2))

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -2,7 +2,7 @@
 # myKG — Knowledge Graph Extractor
 # =============================================================================
 # ACTIVE PROFILE — change this one line to switch provider and all settings.
-# Available: ollama-local | anthropic-claude | openai | openrouter-free | claude-cli
+# Available: ollama-local | anthropic-claude | openai | openrouter-free | claude-cli | agent-claude-code
 # =============================================================================
 profile: openrouter-free
 
@@ -683,3 +683,126 @@ profiles:
         surgical_top_k_chunks_per_property: 0  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+
+  # ---------------------------------------------------------------------------
+  agent-claude-code:
+  # Agent mode (D49) — LLM answers are produced by a Claude Code skill via a
+  # filesystem inbox/outbox. The pipeline writes a task envelope to
+  # intermediate/<inbox_dir>/, the skill drains the inbox using subagents, and
+  # writes <id>.answer.json + <id>.done to intermediate/<outbox_dir>/.
+  #
+  # Install the skill once:
+  #   ln -s "$(pwd)/src/mykg/data/skills/mykg" ~/.claude/skills/mykg
+  # Then in Claude Code:  /mykg <input_dir>
+  #
+  # No API key required — the skill uses the host coding assistant's own
+  # reasoning. See docs/agent-mode.md for the full contract.
+  # ---------------------------------------------------------------------------
+    provider: agent
+    llm_retry:
+      max_retries: 1
+    llm:
+      max_output_tokens: 10000  # passed through to the task envelope; the skill enforces it
+      timeout: 1800             # seconds the pipeline will wait for a .done sentinel
+      retry_429_max: 0          # agent provider does not hit API rate limits
+      retry_429_base_delay: 2.0
+    agent:
+      inbox_dir: agent_inbox            # relative to session intermediate/
+      outbox_dir: agent_outbox          # relative to session intermediate/
+      poll_interval_seconds: 2          # how often the adapter checks for the .done sentinel
+    pipeline:
+      ingest:
+        max_workers: 8
+      preprocess:
+        enabled: true
+        subdir: _preprocessed
+        extra_args: []
+        timeout_seconds: 1800
+        uv_path: uv
+        uv_python_version: "3.12"
+        mineru_spec: mineru[all]
+        install_timeout_seconds: 1800
+        extensions:
+          - .pdf
+          - .docx
+          - .doc
+          - .pptx
+          - .png
+          - .jpg
+          - .jpeg
+          - .html
+          - .htm
+      chunking:
+        window_tokens: 2500
+        overlap_tokens: 250
+        tiktoken_encoding: cl100k_base
+      pass1:
+        batch_token_target: 10000
+        max_workers: 4                # the skill dispatches up to this many subagents per wave
+        per_file_batching: false
+      pass2:
+        max_workers: 4
+        stateful_chunks: true
+        prep_mode: batch_chunks
+        concat_batch_token_target: 10000
+        batch_token_target: 10000
+        batch_per_file: false
+        batch_retry_max: 1
+      normalize_names:
+        enabled: true
+        max_names_per_type: 2000
+      orphan_pass:
+        enabled: true
+        min_cooccurrence: 1
+        top_k_per_orphan: 5
+        confidence_base: 0.5
+        confidence_weight: 0.5
+        max_workers: 4
+        schema_max_restarts: 0
+        excerpt_window: 4000
+        excerpt_context: 1500
+        excerpt_max_total: 16000
+        blank_recovery_enabled: true
+        connected_sample_size: 200
+      assembly:
+        confidence_agg: mean
+        edge_id_prefix: "edge-"
+        edge_id_hex_length: 6
+        edge_dedup_separator: "|"
+        confidence_fallback: 0.0
+        confidence_scalar_omitted: 0.5
+      export:
+        schema_namespace: "http://mykg.local/schema/"
+        data_namespace: "http://mykg.local/data/"
+        rdf_namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        rdfs_namespace: "http://www.w3.org/2000/01/rdf-schema#"
+        schema_prefix_label: ex
+        data_prefix_label: data
+        comment_width: 42
+        skos_namespace: "http://www.w3.org/2004/02/skos/core#"
+        networkx_enabled: true
+        obsidian_enabled: false
+        obsidian_vault_dir: obsidian_vault
+      error_gate:
+        enabled: false
+        threshold: 3
+      feedback:
+        max_file_chars: 64000
+      paths:
+        output_dir: output
+        intermediate_dir: intermediate
+        sessions_dir: sessions
+      output:
+        json_indent: 2
+      logging:
+        max_bytes: 10485760
+        backup_count: 3
+        capture_prompts: true
+        error_output_max_chars: 500
+      report:
+        enabled: true
+      merge_graphs:
+        reextraction_strategy: none
+        surgical_top_k_chunks_per_property: 0
+        human_review: false
+        orphan_pass_max_restarts: 0

--- a/src/mykg/data/skills/README.md
+++ b/src/mykg/data/skills/README.md
@@ -1,0 +1,13 @@
+# mykg skills — install
+
+The `mykg/` directory ships with the mykg Python package and contains a Claude Code skill that drives the pipeline when the active profile is `agent-claude-code` (provider: `agent`).
+
+To install, symlink the skill directory into your user-level skills folder:
+
+```bash
+ln -s "$(pwd)/src/mykg/data/skills/mykg" ~/.claude/skills/mykg
+```
+
+After symlinking, restart Claude Code (or re-open the project). The skill activates on `/mykg <input_dir>` or `/mykg --session <name> --continue`. See `src/mykg/data/skills/mykg/SKILL.md` for the full contract and the watch-loop logic.
+
+The skill assumes you have already set `profile: agent-claude-code` in `mykg_config.yaml`. See `docs/agent-mode.md` for the end-to-end story.

--- a/src/mykg/data/skills/mykg/SKILL.md
+++ b/src/mykg/data/skills/mykg/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: mykg
+description: Run the mykg knowledge-graph extractor in agent mode. Launches the mykg pipeline as a subprocess against a directory of Markdown files, then watches an inbox folder for LLM tasks and dispatches subagents to answer them. Use whenever the user types `/mykg <input_dir>` or asks to extract a knowledge graph in agent mode.
+---
+
+# mykg — agent mode runner
+
+This skill drives the **mykg** knowledge-graph extractor when the active profile is `agent-claude-code`. In that profile, `mykg` does not call any LLM API directly — instead it writes task envelopes to a session-local `intermediate/agent_inbox/` directory and polls for `.done` sentinels in `intermediate/agent_outbox/`. This skill is the agent on the other side of that contract: it watches the inbox, dispatches one Agent-tool subagent per task, and writes the answers back.
+
+The pipeline code, the orchestrator, all prompts, and all 12 pipeline steps are **unchanged**. Only the LLM delivery mechanism is different.
+
+---
+
+## When to invoke
+
+Trigger this skill when the user:
+
+- types `/mykg <input_dir>` to start a fresh run on a Markdown corpus
+- types `/mykg --session <name> --continue` to resume a session whose pipeline subprocess died or whose 20-wave budget was exhausted
+- asks to "run mykg in agent mode" or "extract a knowledge graph using subagents"
+
+Do **not** invoke this skill when the user wants a normal API-backed run (`provider: anthropic`, `openai`, etc.) — for those, the user runs `mykg extract-graph` themselves directly.
+
+---
+
+## CLI reference
+
+The mykg CLI has 6 subcommands. The skill normally only needs `extract-graph`, but the table is here for forwarding flags accurately.
+
+| Subcommand | Purpose | Key flags |
+| --- | --- | --- |
+| `mykg init` | Create a starter `mykg_config.yaml` in the current directory. | `--force`, `--profile <name>`, `--model <id>`, `--api-key <key>` |
+| `mykg extract-graph <input_dir>` | Run the 12-step pipeline on a Markdown corpus. | `--session <name>`, `--from-step <step>`, `--review`, `--base-schema <ttl>`, `--thesaurus <ttl>`, `--workers <N>`, `--confidence-agg mean\|max`, `--append`, `--obsidian-vault`, `--verbose`, `--log-file <path>`, `--output-dir <path>`, `--intermediate-dir <path>` |
+| `mykg approve-schema` | Release the human-review gate after editing `schema.json`. | `--session <name>`, `--intermediate-dir <path>`, `--verbose`, `--log-file <path>` |
+| `mykg walkthrough <session-name>` | Re-generate `walkthrough.md` for an existing session. | `--log-file <path>` |
+| `mykg merge-graphs <session-a> <session-b>` | Merge two completed sessions into a new unified session. | `--from-step <step>`, `--session-name <name>`, `--verbose`, `--log-file <path>`, `--base-schema <ttl>`, `--thesaurus <ttl>`, `--human-review` |
+| `mykg parse-docs <input> <output>` | Convert PDFs/DOCX/images to Markdown via MinerU. | passes through extra args to mineru |
+
+Pipeline step names (for `--from-step`): `preprocess`, `ingest`, `pass1`, `schema_validate`, `human_review`, `schema_flatten`, `pass2`, `normalize_names`, `assemble`, `orphan_score`, `orphan_connect`, `validate_graph`.
+
+---
+
+## What you do — overview
+
+1. **Parse the user's invocation.** Determine `input_dir`, optional `--session <name>`, and any pass-through flags from the `/mykg ...` arguments.
+2. **Confirm agent mode is active.** Check that `mykg_config.yaml` has `profile: agent-claude-code` (or instruct the user to change it). If not, abort with a clear message.
+3. **Launch the pipeline.** Run `mykg extract-graph` in the background via `nohup` so it survives this skill turn. Capture the session directory.
+4. **Watch the inbox.** Loop scanning `<session>/intermediate/agent_inbox/`, dispatch one Agent-tool subagent per unanswered task (parallel calls in one response, up to the configured worker count), sleep 2 seconds between waves.
+5. **Exit cleanly.** Stop when the pipeline subprocess exits, when `output/knowledge_graph.ttl` appears, or after **20 watch waves**. If the pipeline is still running after 20 waves, tell the user to re-invoke `/mykg --session <name> --continue` to resume.
+
+---
+
+## Step 1 — parse the invocation
+
+The user typed something like one of:
+
+```
+/mykg ./docs
+/mykg ~/notes --review --workers 8
+/mykg --session 2026-06-02T17-30-00 --continue
+/mykg ./corpus --from-step pass2 --session 2026-06-02T17-30-00
+```
+
+Extract:
+- `INPUT_DIR` (or empty for `--continue`)
+- `SESSION_NAME` (from `--session`)
+- `EXTRA_FLAGS` (everything else — forward verbatim)
+
+---
+
+## Step 2 — confirm active profile
+
+Run this Bash block to verify `agent-claude-code` is the active profile:
+
+```bash
+grep -E '^profile:\s' mykg_config.yaml
+```
+
+The output must be `profile: agent-claude-code`. If it is not, stop and tell the user:
+
+> Active profile is not `agent-claude-code`. Edit `mykg_config.yaml` and set `profile: agent-claude-code`, then re-run `/mykg`.
+
+---
+
+## Step 3 — launch the pipeline (fresh run)
+
+For a fresh run (no `--session` or `--session` but no existing session dir), launch:
+
+```bash
+SESSIONS_DIR=$(grep -E '^\s+sessions_dir:' mykg_config.yaml | head -1 | awk '{print $2}' || echo sessions)
+mkdir -p "$SESSIONS_DIR"
+
+# Auto-generated session timestamp; mykg will pick the same name and create the dir.
+nohup uv run mykg extract-graph "$INPUT_DIR" $EXTRA_FLAGS \
+  > /tmp/mykg_run.out 2>&1 &
+echo $! > /tmp/mykg.pid
+
+# Wait briefly for the session folder to materialise.
+for i in $(seq 1 30); do
+  SESSION_ROOT=$(ls -td "$SESSIONS_DIR"/* 2>/dev/null | head -1)
+  if [ -n "$SESSION_ROOT" ] && [ -d "$SESSION_ROOT/intermediate/agent_inbox" ]; then
+    echo "Session: $SESSION_ROOT"
+    break
+  fi
+  sleep 1
+done
+```
+
+For a `--continue` run on an existing session:
+
+```bash
+SESSION_ROOT="$SESSIONS_DIR/$SESSION_NAME"
+if [ ! -d "$SESSION_ROOT" ]; then
+  echo "Session $SESSION_NAME not found under $SESSIONS_DIR" >&2
+  exit 1
+fi
+nohup uv run mykg extract-graph "$INPUT_DIR" --session "$SESSION_NAME" $EXTRA_FLAGS \
+  > /tmp/mykg_run.out 2>&1 &
+echo $! > /tmp/mykg.pid
+```
+
+Capture:
+- `SESSION_ROOT` — the absolute path of the session directory.
+- `INBOX_DIR=$SESSION_ROOT/intermediate/agent_inbox`
+- `OUTBOX_DIR=$SESSION_ROOT/intermediate/agent_outbox`
+- `MYKG_PID=$(cat /tmp/mykg.pid)`
+
+---
+
+## Step 4 — the watch loop
+
+This is the main body. Up to **20 waves**, each wave does:
+
+1. Scan the inbox for `*.task.json` files that do **not** have a matching `.done` in the outbox.
+2. For each task (up to `MAX_TASKS_PER_WAVE = 8`), make one Agent-tool subagent call **in parallel within a single message**.
+3. Check `MYKG_PID` is still alive. If not, exit.
+4. Sleep 2 seconds before the next wave.
+
+```bash
+# Once per wave:
+ls -1 "$INBOX_DIR"/*.task.json 2>/dev/null | while read TASK_PATH; do
+  TASK_ID=$(basename "$TASK_PATH" .task.json)
+  DONE_PATH="$OUTBOX_DIR/$TASK_ID.done"
+  if [ ! -f "$DONE_PATH" ]; then
+    echo "$TASK_PATH"
+  fi
+done | head -8
+```
+
+For every line printed above, **dispatch one Agent tool call** using the subagent prompt template below. All dispatches in a single wave **must go in the same assistant message** so they run in parallel.
+
+Between waves:
+
+```bash
+if ! kill -0 "$MYKG_PID" 2>/dev/null; then
+  echo "Pipeline subprocess exited."
+  break
+fi
+if [ -f "$SESSION_ROOT/output/knowledge_graph.ttl" ]; then
+  echo "Pipeline produced knowledge_graph.ttl — done."
+  break
+fi
+sleep 2
+```
+
+Track the wave count yourself. After 20 waves, tell the user:
+
+> Watch budget exhausted after 20 waves. Pipeline is still running (PID `$MYKG_PID`). Re-invoke `/mykg --session <name> --continue` to keep draining the inbox.
+
+---
+
+## Step 5 — subagent prompt template
+
+Each Agent-tool dispatch in step 4 uses **exactly this prompt** (substitute `$TASK_PATH` and `$OUTBOX_DIR`):
+
+```
+You are an mykg agent-mode worker. Your only job is to answer the LLM task in
+the file shown below and write the result atomically to the outbox.
+
+Task file:   $TASK_PATH
+Outbox dir:  $OUTBOX_DIR
+
+Procedure:
+
+1. Read the JSON file at $TASK_PATH. It has these fields:
+   - task_id: a 64-char sha256 hex string
+   - step: which pipeline step (e.g. "pass1", "pass2", "normalize_names")
+   - context_label: short label for debugging
+   - system: the system prompt the pipeline wants you to respond to
+   - user: the user prompt
+   - max_tokens: integer
+   - timeout_seconds: integer
+
+2. Treat the `system` field as the instructions you must follow and the `user`
+   field as the user message. Produce the response the pipeline expects — for
+   pass1 that is a JSON object with `concepts` and `properties`; for pass2 that
+   is `{nodes: [...], edges: [...]}`; for normalize_names that is a mappings
+   object; for orphan_connect that is an array of edges. The `system` prompt
+   itself tells you the exact schema in detail. Output **only** the JSON
+   (no prose, no markdown fences).
+
+3. Write the answer JSON to a string and build the answer envelope:
+   {"task_id": "<the task_id from the task file>", "answer": "<your JSON string>"}
+
+4. Write the answer atomically:
+   a. Write the envelope JSON to $OUTBOX_DIR/<task_id>.answer.json.tmp
+   b. Rename it to $OUTBOX_DIR/<task_id>.answer.json (atomic on POSIX)
+   c. Touch $OUTBOX_DIR/<task_id>.done  (zero-byte sentinel)
+
+   The pipeline polls for the `.done` sentinel — never write `.done` before
+   the `.answer.json` file is fully on disk.
+
+5. Report a one-line summary: which step, which context_label, how big the
+   answer was. Do not write anything else to the outbox.
+
+If the system+user prompt is genuinely ambiguous or you cannot produce valid
+JSON, still write a best-effort response — the pipeline has its own retry +
+feedback path and will repair downstream. Never leave a task unanswered: a
+missing `.done` sentinel will block the pipeline until its 1800-second
+timeout.
+```
+
+---
+
+## Step 6 — final report
+
+When the loop exits, print:
+
+```bash
+echo "Session:  $SESSION_ROOT"
+echo "PID:      $MYKG_PID (alive: $(kill -0 $MYKG_PID 2>/dev/null && echo yes || echo no))"
+echo "Inbox:    $(ls -1 $INBOX_DIR/*.task.json 2>/dev/null | wc -l) total tasks"
+echo "Answered: $(ls -1 $OUTBOX_DIR/*.done 2>/dev/null | wc -l)"
+if [ -f "$SESSION_ROOT/output/knowledge_graph.ttl" ]; then
+  echo "Output:   $SESSION_ROOT/output/knowledge_graph.ttl"
+fi
+```
+
+---
+
+## Notes for the implementer
+
+- **Atomicity matters.** Always write `<id>.answer.json.tmp` then `mv` it to the final name *before* touching `<id>.done`. The adapter polls the `.done` sentinel, not the answer file.
+- **Caching is automatic.** If you accidentally answer the same task twice the second write overwrites — the adapter only reads the most recent answer once `.done` exists.
+- **Do not validate.** The pipeline has its own retry + LLM-feedback path. If your JSON is malformed, the pipeline catches it and dispatches a corrective task on its own.
+- **Stay parallel.** Within a wave, multiple Agent-tool calls in one assistant message run concurrently. Sequential dispatch defeats the purpose.
+- **Stay bounded.** 20 waves is a hard limit. If a run needs more, the user re-invokes `/mykg --session <name> --continue`.

--- a/src/mykg/llm/agent_adapter.py
+++ b/src/mykg/llm/agent_adapter.py
@@ -1,0 +1,169 @@
+"""Agent-mode LLM adapter — produces answers via filesystem inbox/outbox.
+
+The adapter writes a task envelope to ``<intermediate>/<inbox>/<task_id>.task.json``
+and polls ``<outbox>/<task_id>.done`` for a sentinel file. A skill running in the
+host coding assistant (e.g. Claude Code) drains the inbox, dispatches subagents,
+and writes ``<task_id>.answer.json`` + ``<task_id>.done`` atomically.
+
+The full contract is documented in ``docs/agent-mode.md`` and CLAUDE.md (D49).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from mykg.llm.adapter import LLMAdapter
+from mykg.logging import get, record_llm_call
+
+if TYPE_CHECKING:
+    from mykg.llm.error_gate import ErrorGate
+
+
+log = get("mykg.llm.agent")
+
+
+class TaskEnvelope(BaseModel):
+    """Task envelope written by the adapter to the inbox."""
+
+    task_id: str
+    step: str = ""
+    context_label: str = ""
+    system: str
+    user: str
+    max_tokens: int
+    timeout_seconds: int
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+class AnswerEnvelope(BaseModel):
+    """Answer envelope written by the skill subagent to the outbox."""
+
+    task_id: str
+    answer: str
+
+
+class AgentAdapter(LLMAdapter):
+    """Filesystem-based adapter that delegates to a host-side agent skill.
+
+    See ``src/mykg/data/skills/mykg/SKILL.md`` for the skill side of the contract.
+    """
+
+    def __init__(
+        self,
+        inbox_dir: Path,
+        outbox_dir: Path,
+        poll_interval: float,
+        timeout: int,
+        max_tokens: int,
+        error_gate: ErrorGate | None = None,
+    ):
+        self._inbox = Path(inbox_dir)
+        self._outbox = Path(outbox_dir)
+        self._poll_interval = float(poll_interval)
+        self._timeout = int(timeout)
+        self._max_tokens = int(max_tokens)
+        self._error_gate = error_gate
+
+        self._inbox.mkdir(parents=True, exist_ok=True)
+        self._outbox.mkdir(parents=True, exist_ok=True)
+
+    def endpoint_label(self) -> str:
+        return f"agent / claude-code (inbox={self._inbox})"
+
+    @staticmethod
+    def _make_task_id(system: str, user: str, context_label: str) -> str:
+        h = hashlib.sha256()
+        h.update(system.encode("utf-8"))
+        h.update(b"\n--user--\n")
+        h.update(user.encode("utf-8"))
+        h.update(b"\n--ctx--\n")
+        h.update(context_label.encode("utf-8"))
+        return h.hexdigest()
+
+    @staticmethod
+    def _atomic_write_json(path: Path, payload: dict) -> None:
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2))
+        tmp.replace(path)
+
+    def complete(
+        self,
+        system: str,
+        user: str,
+        context_label: str = "",
+        max_tokens: int | None = None,
+        timeout: int | None = None,
+    ) -> str:
+        effective_max_tokens = max_tokens if max_tokens is not None else self._max_tokens
+        effective_timeout = timeout if timeout is not None else self._timeout
+
+        task_id = self._make_task_id(system, user, context_label)
+        task_path = self._inbox / f"{task_id}.task.json"
+        answer_path = self._outbox / f"{task_id}.answer.json"
+        done_path = self._outbox / f"{task_id}.done"
+
+        t0 = time.monotonic()
+
+        # Cache hit: re-use an existing answer from a prior run or duplicate task.
+        if done_path.exists() and answer_path.exists():
+            return self._finish(answer_path, context_label, system, user, t0)
+
+        # Existing call sites use space-separated labels like "pass1 batch 0/1",
+        # "pass2 chunk 3", "orphan stage2 …", "schema_harmonize" — first token wins.
+        step_label = context_label.split(None, 1)[0] if context_label else ""
+
+        envelope = TaskEnvelope(
+            task_id=task_id,
+            step=step_label,
+            context_label=context_label,
+            system=system,
+            user=user,
+            max_tokens=effective_max_tokens,
+            timeout_seconds=effective_timeout,
+        )
+        self._atomic_write_json(task_path, envelope.model_dump())
+        log.info("agent: wrote task %s (step=%s)", task_id[:12], step_label or "?")
+
+        deadline = time.monotonic() + effective_timeout
+        while time.monotonic() < deadline:
+            if done_path.exists():
+                return self._finish(answer_path, context_label, system, user, t0)
+            time.sleep(self._poll_interval)
+
+        exc = TimeoutError(
+            f"agent task {task_id[:12]} timed out after {effective_timeout}s "
+            f"(inbox={self._inbox}, no .done sentinel appeared)"
+        )
+        if self._error_gate is not None:
+            self._error_gate.record_error(exc)
+        raise exc
+
+    def _finish(
+        self,
+        answer_path: Path,
+        context_label: str,
+        system: str,
+        user: str,
+        t0: float,
+    ) -> str:
+        """Read the answer, log the call, return the (fence-stripped) string."""
+        answer = json.loads(answer_path.read_text()).get("answer", "")
+        record_llm_call(
+            provider="agent",
+            model="claude-code",
+            context_label=context_label,
+            input_tokens=0,
+            output_tokens=0,
+            duration_s=time.monotonic() - t0,
+            raw_response=answer,
+            system_prompt=system,
+            user_prompt=user,
+        )
+        return self.strip_code_fences(answer)

--- a/src/mykg/llm/config.py
+++ b/src/mykg/llm/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import mykg.config as _cfg
@@ -10,11 +11,18 @@ if TYPE_CHECKING:
     from mykg.llm.error_gate import ErrorGate
 
 
-def load_adapter(_raw: dict | None = None, error_gate: ErrorGate | None = None) -> LLMAdapter:
+def load_adapter(
+    _raw: dict | None = None,
+    error_gate: ErrorGate | None = None,
+    intermediate_dir: Path | None = None,
+) -> LLMAdapter:
     """Build an LLM adapter from mykg_config.yaml.
 
     mykg_config.yaml is loaded by mykg.config at import time via auto-discovery.
     _raw is an escape hatch for tests that need to supply a custom config dict.
+
+    intermediate_dir is required only when provider == "agent" — the agent
+    adapter writes to <intermediate>/<inbox_dir>/ and <intermediate>/<outbox_dir>/.
     """
     cfg = _raw if _raw is not None else _cfg.RAW
     provider = cfg.get("provider", "")
@@ -96,6 +104,37 @@ def load_adapter(_raw: dict | None = None, error_gate: ErrorGate | None = None) 
             timeout=section["timeout"],
             model=section.get("model", "auto"),
             effort=section.get("effort", "auto"),
+            error_gate=error_gate,
+        )
+
+    if provider == "agent":
+        from mykg.llm.agent_adapter import AgentAdapter
+
+        agent_section = cfg.get("agent")
+        if agent_section is None:
+            raise ValueError(
+                "provider 'agent' requires an 'agent:' block in the active profile "
+                "(set inbox_dir, outbox_dir, poll_interval_seconds)"
+            )
+
+        if intermediate_dir is None:
+            raise ValueError(
+                "provider 'agent' requires intermediate_dir to be supplied to "
+                "load_adapter() — pass the session's intermediate path"
+            )
+
+        inbox_name = agent_section.get("inbox_dir", _cfg.AGENT_INBOX_DIR)
+        outbox_name = agent_section.get("outbox_dir", _cfg.AGENT_OUTBOX_DIR)
+        poll_interval = agent_section.get(
+            "poll_interval_seconds", _cfg.AGENT_POLL_INTERVAL_SECONDS
+        )
+
+        return AgentAdapter(
+            inbox_dir=Path(intermediate_dir) / inbox_name,
+            outbox_dir=Path(intermediate_dir) / outbox_name,
+            poll_interval=poll_interval,
+            timeout=section["timeout"],
+            max_tokens=section["max_output_tokens"],
             error_gate=error_gate,
         )
 

--- a/tests/fixtures/agent_corpus/history.md
+++ b/tests/fixtures/agent_corpus/history.md
@@ -1,0 +1,4 @@
+# History
+
+Acme Corp was founded in 2010.
+Bob joined in 2015 and Alice in 2018.

--- a/tests/fixtures/agent_corpus/people.md
+++ b/tests/fixtures/agent_corpus/people.md
@@ -1,0 +1,4 @@
+# People
+
+Alice is a software engineer at Acme Corp.
+Bob manages the infrastructure team at Acme Corp.

--- a/tests/fixtures/agent_corpus/projects.md
+++ b/tests/fixtures/agent_corpus/projects.md
@@ -1,0 +1,4 @@
+# Projects
+
+Acme Corp is building a distributed database called Prometheus.
+Alice leads the Prometheus project.

--- a/tests/fixtures/mock_skill.py
+++ b/tests/fixtures/mock_skill.py
@@ -1,0 +1,216 @@
+"""Mock skill — drains the agent-mode inbox with canned answers.
+
+Used by ``tests/test_agent_mode_live.py``. Runs as a background thread (or
+standalone subprocess); polls ``intermediate/agent_inbox/`` for ``*.task.json``
+files, reads the ``step`` field of each envelope, returns a canned JSON answer
+that matches the step's expected schema, and writes ``<id>.answer.json`` plus
+``<id>.done`` to ``intermediate/agent_outbox/`` atomically.
+
+Canned answers are intentionally minimal — just enough to let the pipeline
+complete every step without LLM errors. The goal is to verify the inbox/outbox
+contract works end-to-end, not to produce a high-quality graph.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Canned answers per pipeline step
+# ---------------------------------------------------------------------------
+
+
+def _pass1_answer() -> str:
+    """Minimal valid schema with one concept and one property."""
+    return json.dumps(
+        {
+            "concepts": [
+                {"type": "Person", "parent": None, "attributes": ["name"]},
+                {"type": "Organization", "parent": None, "attributes": ["name"]},
+            ],
+            "properties": [
+                {
+                    "name": "works_at",
+                    "domain": "Person",
+                    "range": "Organization",
+                    "attributes": [],
+                }
+            ],
+        }
+    )
+
+
+def _pass2_answer() -> str:
+    """Minimal valid extraction — one Person, one Organization, one edge."""
+    return json.dumps(
+        {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "attributes": {
+                        "name": {"value": "Alice", "confidence": 0.95}
+                    },
+                    "confidence": 0.95,
+                },
+                {
+                    "id": "organization-acme-corp",
+                    "type": "Organization",
+                    "attributes": {
+                        "name": {"value": "Acme Corp", "confidence": 0.95}
+                    },
+                    "confidence": 0.95,
+                },
+            ],
+            "edges": [
+                {
+                    "type": "works_at",
+                    "from": "person-alice",
+                    "to": "organization-acme-corp",
+                    "attributes": {},
+                    "confidence": 0.9,
+                }
+            ],
+        }
+    )
+
+
+def _normalize_answer() -> str:
+    """Minimal normalization map — no aliases to resolve."""
+    return json.dumps({"mappings": {}})
+
+
+def _orphan_chunk_answer() -> str:
+    return json.dumps({"edges": []})
+
+
+def _orphan_pair_answer() -> str:
+    return json.dumps({"answer": "no"})
+
+
+def _orphan_schema_gap_answer() -> str:
+    return json.dumps({"new_properties": []})
+
+
+def _schema_merge_answer() -> str:
+    """Harmonize / quality steps — pass schema through unchanged-ish."""
+    return _pass1_answer()
+
+
+def _feedback_schema_answer() -> str:
+    return _pass1_answer()
+
+
+_DISPATCH = {
+    "pass1": _pass1_answer,
+    "pass2": _pass2_answer,
+    "normalize_names": _normalize_answer,
+    "normalize": _normalize_answer,
+    "schema_harmonize": _schema_merge_answer,
+    "schema_quality_review": _schema_merge_answer,
+    "merge_schema_harmonize": _schema_merge_answer,
+    "merge_schema_quality_review": _schema_merge_answer,
+    "orphan": _orphan_pair_answer,
+    "feedback": _feedback_schema_answer,
+}
+
+
+def _route(envelope: dict) -> str:
+    step = (envelope.get("step") or "").lower()
+    context_label = (envelope.get("context_label") or "").lower()
+
+    if step in _DISPATCH:
+        return _DISPATCH[step]()
+
+    # Fallbacks by inspecting context_label keywords.
+    if "chunk_recovery" in context_label or "schema-gap" in context_label:
+        return _orphan_chunk_answer() if "chunk" in context_label else _orphan_schema_gap_answer()
+    if "stage2" in context_label or "confirm" in context_label:
+        return _orphan_pair_answer()
+    if "harmoniz" in context_label or "quality" in context_label:
+        return _schema_merge_answer()
+    if "feedback" in context_label:
+        return _feedback_schema_answer()
+    if "normaliz" in context_label:
+        return _normalize_answer()
+    if "pass1" in context_label:
+        return _pass1_answer()
+    if "pass2" in context_label:
+        return _pass2_answer()
+
+    # Last resort — return a valid-looking pass2 answer.
+    return _pass2_answer()
+
+
+# ---------------------------------------------------------------------------
+# Watcher loop
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, payload: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(payload)
+    tmp.replace(path)
+
+
+def handle_task(task_path: Path, outbox: Path) -> None:
+    envelope = json.loads(task_path.read_text())
+    task_id = envelope["task_id"]
+    answer_path = outbox / f"{task_id}.answer.json"
+    done_path = outbox / f"{task_id}.done"
+    if done_path.exists():
+        return
+    answer_text = _route(envelope)
+    payload = json.dumps({"task_id": task_id, "answer": answer_text})
+    _atomic_write(answer_path, payload)
+    # Touch the .done sentinel last (after answer file is fully on disk).
+    done_path.touch()
+
+
+def run_watcher(
+    inbox: Path,
+    outbox: Path,
+    stop_after_seconds: float,
+    poll_interval: float = 0.2,
+) -> int:
+    """Drain the inbox until stop_after_seconds elapse. Returns task count handled."""
+    inbox.mkdir(parents=True, exist_ok=True)
+    outbox.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + stop_after_seconds
+    handled = 0
+    while time.monotonic() < deadline:
+        for task_path in sorted(inbox.glob("*.task.json")):
+            task_id = task_path.name.removesuffix(".task.json")
+            if (outbox / f"{task_id}.done").exists():
+                continue
+            try:
+                handle_task(task_path, outbox)
+                handled += 1
+            except json.JSONDecodeError:
+                # Half-written task file — try again next pass.
+                continue
+        time.sleep(poll_interval)
+    return handled
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Mock mykg agent-mode skill")
+    parser.add_argument("--inbox", required=True, type=Path)
+    parser.add_argument("--outbox", required=True, type=Path)
+    parser.add_argument("--seconds", type=float, default=60.0)
+    parser.add_argument("--poll", type=float, default=0.2)
+    args = parser.parse_args(argv)
+    handled = run_watcher(
+        args.inbox, args.outbox, args.seconds, poll_interval=args.poll
+    )
+    print(f"mock_skill: handled {handled} tasks", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agent_adapter.py
+++ b/tests/test_agent_adapter.py
@@ -1,0 +1,155 @@
+"""Tests for ``mykg.llm.agent_adapter.AgentAdapter``."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from mykg.llm.agent_adapter import AgentAdapter
+
+
+def _make_adapter(tmp_path: Path, **overrides) -> AgentAdapter:
+    kwargs = {
+        "inbox_dir": tmp_path / "agent_inbox",
+        "outbox_dir": tmp_path / "agent_outbox",
+        "poll_interval": 0.05,
+        "timeout": 5,
+        "max_tokens": 1000,
+    }
+    kwargs.update(overrides)
+    return AgentAdapter(**kwargs)
+
+
+def _write_answer_atomic(outbox: Path, task_id: str, answer: str) -> None:
+    """Mimics the skill's atomic write contract."""
+    answer_path = outbox / f"{task_id}.answer.json"
+    done_path = outbox / f"{task_id}.done"
+    tmp = answer_path.with_suffix(answer_path.suffix + ".tmp")
+    tmp.write_text(json.dumps({"task_id": task_id, "answer": answer}))
+    tmp.replace(answer_path)
+    done_path.touch()
+
+
+def test_task_id_is_deterministic_sha256():
+    """Same (system, user, context_label) → same task_id; different inputs → different ids."""
+    a = AgentAdapter._make_task_id("sys", "usr", "ctx")
+    b = AgentAdapter._make_task_id("sys", "usr", "ctx")
+    c = AgentAdapter._make_task_id("sys", "usr", "ctx-different")
+    d = AgentAdapter._make_task_id("sys-different", "usr", "ctx")
+
+    assert a == b
+    assert a != c
+    assert a != d
+    assert len(a) == 64  # hex sha256
+    assert all(ch in "0123456789abcdef" for ch in a)
+
+
+def test_endpoint_label_includes_inbox_path(tmp_path):
+    adapter = _make_adapter(tmp_path)
+    label = adapter.endpoint_label()
+    assert "agent" in label
+    assert "claude-code" in label
+    assert str(tmp_path / "agent_inbox") in label
+
+
+def test_complete_writes_task_and_returns_answer(tmp_path):
+    adapter = _make_adapter(tmp_path, timeout=10)
+
+    system = "you are a JSON producer"
+    user = "produce a tiny JSON object"
+    context_label = "pass1 batch 0/1"
+
+    expected_task_id = AgentAdapter._make_task_id(system, user, context_label)
+    expected_answer = '{"concepts": [], "properties": []}'
+
+    def responder():
+        # Wait for the inbox file to appear, then write the answer.
+        inbox_file = tmp_path / "agent_inbox" / f"{expected_task_id}.task.json"
+        for _ in range(200):
+            if inbox_file.exists():
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("inbox file never appeared")
+
+        envelope = json.loads(inbox_file.read_text())
+        assert envelope["task_id"] == expected_task_id
+        assert envelope["step"] == "pass1"
+        assert envelope["system"] == system
+        assert envelope["user"] == user
+        assert envelope["context_label"] == context_label
+        _write_answer_atomic(tmp_path / "agent_outbox", expected_task_id, expected_answer)
+
+    t = threading.Thread(target=responder, daemon=True)
+    t.start()
+
+    result = adapter.complete(system, user, context_label=context_label)
+    t.join(timeout=5)
+
+    assert result == expected_answer
+
+
+def test_complete_cache_hit_skips_write(tmp_path):
+    """If the answer already exists in the outbox, complete() returns it without polling."""
+    adapter = _make_adapter(tmp_path, timeout=2)
+    task_id = AgentAdapter._make_task_id("s", "u", "ctx")
+    cached_answer = '{"cached": true}'
+
+    _write_answer_atomic(tmp_path / "agent_outbox", task_id, cached_answer)
+    assert not (tmp_path / "agent_inbox" / f"{task_id}.task.json").exists()
+
+    t0 = time.monotonic()
+    result = adapter.complete("s", "u", context_label="ctx")
+    elapsed = time.monotonic() - t0
+
+    assert result == cached_answer
+    # Cache hit should be near-instant — no inbox write, no poll.
+    assert elapsed < 1.0
+    assert not (tmp_path / "agent_inbox" / f"{task_id}.task.json").exists()
+
+
+def test_complete_timeout_raises(tmp_path):
+    adapter = _make_adapter(tmp_path, timeout=1, poll_interval=0.05)
+
+    t0 = time.monotonic()
+    with pytest.raises(TimeoutError) as exc_info:
+        adapter.complete("s", "u", context_label="ctx")
+    elapsed = time.monotonic() - t0
+
+    assert "timed out" in str(exc_info.value)
+    # Should have waited approximately the timeout (within poll-interval tolerance).
+    assert 0.9 <= elapsed <= 2.5
+
+
+def test_atomic_write_via_tmp_rename(tmp_path):
+    """The task envelope must be written through a .tmp + rename to avoid half-written reads."""
+    adapter = _make_adapter(tmp_path, timeout=10)
+    task_id = AgentAdapter._make_task_id("s", "u", "")
+
+    inbox_dir = tmp_path / "agent_inbox"
+
+    saw_tmp = threading.Event()
+    saw_final = threading.Event()
+
+    def watcher():
+        for _ in range(400):
+            for p in inbox_dir.glob("*.tmp"):
+                saw_tmp.set()
+            if (inbox_dir / f"{task_id}.task.json").exists():
+                saw_final.set()
+                _write_answer_atomic(tmp_path / "agent_outbox", task_id, '"ok"')
+                return
+            time.sleep(0.005)
+
+    t = threading.Thread(target=watcher, daemon=True)
+    t.start()
+    adapter.complete("s", "u", context_label="")
+    t.join(timeout=5)
+
+    assert saw_final.is_set()
+    # No .tmp file should be left behind.
+    assert not list(inbox_dir.glob("*.tmp"))

--- a/tests/test_agent_mode_live.py
+++ b/tests/test_agent_mode_live.py
@@ -1,0 +1,168 @@
+"""Live end-to-end test for agent-mode.
+
+Drives the mykg pipeline against ``AgentAdapter`` while a mock skill (running
+in a background thread) drains the session inbox and writes canned answers
+matched to the ``step`` field of each task envelope.
+
+This verifies the inbox/outbox contract end-to-end without requiring a real
+Claude Code session or a real LLM API key.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+# Ensure tests/fixtures/ is importable for mock_skill.
+sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
+
+from mock_skill import run_watcher  # noqa: E402
+
+from mykg.llm.config import load_adapter  # noqa: E402
+from mykg.orchestrator import PipelineContext, run  # noqa: E402
+from mykg.pipeline import STEPS  # noqa: E402
+
+
+def _agent_raw_config() -> dict:
+    return {
+        "provider": "agent",
+        "llm_retry": {"max_retries": 1},
+        "llm": {
+            "max_output_tokens": 4000,
+            "timeout": 30,
+            "retry_429_max": 0,
+            "retry_429_base_delay": 1.0,
+        },
+        "agent": {
+            "inbox_dir": "agent_inbox",
+            "outbox_dir": "agent_outbox",
+            "poll_interval_seconds": 0.1,
+        },
+        "pipeline": {
+            "ingest": {"max_workers": 1},
+            "chunking": {
+                "window_tokens": 1000,
+                "overlap_tokens": 100,
+                "tiktoken_encoding": "cl100k_base",
+            },
+            "pass1": {"batch_token_target": 4000, "max_workers": 1, "per_file_batching": False},
+            "pass2": {"max_workers": 1, "stateful_chunks": False, "prep_mode": "per_file"},
+            "normalize_names": {"enabled": False},
+            "orphan_pass": {"enabled": False},
+            "error_gate": {"enabled": False},
+            "logging": {"max_bytes": 10485760, "backup_count": 3, "capture_prompts": False},
+            "assembly": {"confidence_agg": "mean"},
+            "export": {"networkx_enabled": False},
+            "paths": {"sessions_dir": "sessions"},
+        },
+    }
+
+
+@pytest.fixture
+def agent_corpus(tmp_path):
+    src = Path(__file__).parent / "fixtures" / "agent_corpus"
+    dest = tmp_path / "input"
+    dest.mkdir()
+    for f in src.iterdir():
+        if f.is_file() and f.suffix == ".md":
+            shutil.copy(f, dest / f.name)
+    return dest
+
+
+def test_agent_mode_pipeline_with_mock_skill(tmp_path, agent_corpus):
+    intermediate_dir = tmp_path / "intermediate"
+    output_dir = tmp_path / "output"
+    intermediate_dir.mkdir()
+    output_dir.mkdir()
+
+    inbox = intermediate_dir / "agent_inbox"
+    outbox = intermediate_dir / "agent_outbox"
+
+    # Spawn the mock skill in a background thread BEFORE building the adapter,
+    # so when the pipeline starts writing tasks, the watcher is already polling.
+    stop_event = threading.Event()
+
+    def _watcher_loop():
+        while not stop_event.is_set():
+            # Drain in 1-second windows so we can react to stop quickly.
+            run_watcher(inbox, outbox, stop_after_seconds=1.0, poll_interval=0.1)
+
+    watcher = threading.Thread(target=_watcher_loop, daemon=True)
+    watcher.start()
+
+    try:
+        adapter = load_adapter(_raw=_agent_raw_config(), intermediate_dir=intermediate_dir)
+        ctx = PipelineContext(
+            input_dir=agent_corpus,
+            output_dir=output_dir,
+            intermediate_dir=intermediate_dir,
+            adapter=adapter,
+            base_schema=None,
+            thesaurus=None,
+            review=False,
+        )
+        run(STEPS, ctx)
+    finally:
+        stop_event.set()
+        watcher.join(timeout=2.0)
+
+    # --- Assertions ----------------------------------------------------------
+    # The pipeline produced its primary outputs.
+    nodes_path = output_dir / "nodes.jsonl"
+    edges_path = output_dir / "edges.jsonl"
+    ttl_path = output_dir / "knowledge_graph.ttl"
+    schema_path = intermediate_dir / "schema.json"
+
+    assert schema_path.exists(), "schema.json not produced — pass1 did not complete"
+    schema = json.loads(schema_path.read_text())
+    assert isinstance(schema.get("concepts"), list)
+    assert isinstance(schema.get("properties"), list)
+
+    assert nodes_path.exists(), "nodes.jsonl not produced"
+    node_lines = [l for l in nodes_path.read_text().splitlines() if l.strip()]
+    assert node_lines, "nodes.jsonl is empty"
+    for line in node_lines:
+        node = json.loads(line)
+        assert "id" in node and "type" in node
+
+    assert edges_path.exists(), "edges.jsonl not produced"
+    assert ttl_path.exists(), "knowledge_graph.ttl not produced"
+
+    # Validate TTL is parseable.
+    from rdflib import Graph
+
+    g = Graph()
+    g.parse(data=ttl_path.read_text(), format="turtle")
+
+    # Inbox/outbox sanity — at least one task was answered.
+    answered = list(outbox.glob("*.done"))
+    assert answered, "mock skill did not answer any tasks"
+
+
+def test_mock_skill_canned_answers_are_valid_json():
+    """The canned answers themselves must be valid JSON the pipeline can parse."""
+    from mock_skill import (
+        _normalize_answer,
+        _orphan_chunk_answer,
+        _orphan_pair_answer,
+        _orphan_schema_gap_answer,
+        _pass1_answer,
+        _pass2_answer,
+    )
+
+    pass1 = json.loads(_pass1_answer())
+    assert "concepts" in pass1 and "properties" in pass1
+    assert all(c.get("type") for c in pass1["concepts"])
+
+    pass2 = json.loads(_pass2_answer())
+    assert "nodes" in pass2 and "edges" in pass2
+
+    json.loads(_normalize_answer())
+    json.loads(_orphan_chunk_answer())
+    json.loads(_orphan_pair_answer())
+    json.loads(_orphan_schema_gap_answer())

--- a/tests/test_config_agent_profile.py
+++ b/tests/test_config_agent_profile.py
@@ -1,0 +1,97 @@
+"""Tests for the agent-claude-code profile and ``provider: agent`` loading."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+import mykg.config as _cfg
+from mykg.llm.agent_adapter import AgentAdapter
+from mykg.llm.config import load_adapter
+
+
+def _load_agent_profile() -> dict:
+    """Load the agent-claude-code profile flattened to top-level keys."""
+    repo_root = Path(__file__).parent.parent
+    raw = yaml.safe_load((repo_root / "mykg_config.yaml").read_text())
+    profile = raw["profiles"]["agent-claude-code"]
+    cfg = deepcopy(raw)
+    for key in ("provider", "llm", "llm_retry", "pipeline", "agent"):
+        if key in profile:
+            cfg[key] = profile[key]
+    return cfg
+
+
+def test_agent_profile_is_present_in_root_yaml():
+    repo_root = Path(__file__).parent.parent
+    raw = yaml.safe_load((repo_root / "mykg_config.yaml").read_text())
+    assert "agent-claude-code" in raw["profiles"]
+    profile = raw["profiles"]["agent-claude-code"]
+    assert profile["provider"] == "agent"
+    assert "agent" in profile, "profile must declare an 'agent:' block"
+    assert profile["agent"]["inbox_dir"]
+    assert profile["agent"]["outbox_dir"]
+    assert profile["agent"]["poll_interval_seconds"]
+
+
+def test_agent_profile_is_present_in_packaged_template():
+    """Invariant 17 — both YAML files must stay structurally in sync."""
+    repo_root = Path(__file__).parent.parent
+    packaged = yaml.safe_load(
+        (repo_root / "src" / "mykg" / "data" / "mykg_config.yaml").read_text()
+    )
+    assert "agent-claude-code" in packaged["profiles"]
+    profile = packaged["profiles"]["agent-claude-code"]
+    assert profile["provider"] == "agent"
+    assert "agent" in profile
+
+
+def test_agent_profile_structurally_matches_root_and_packaged():
+    """Both files must contain the same set of keys under the agent profile."""
+    repo_root = Path(__file__).parent.parent
+    root = yaml.safe_load((repo_root / "mykg_config.yaml").read_text())["profiles"][
+        "agent-claude-code"
+    ]
+    packaged = yaml.safe_load(
+        (repo_root / "src" / "mykg" / "data" / "mykg_config.yaml").read_text()
+    )["profiles"]["agent-claude-code"]
+    assert set(root.keys()) == set(packaged.keys())
+    assert set(root["agent"].keys()) == set(packaged["agent"].keys())
+    assert set(root["pipeline"].keys()) == set(packaged["pipeline"].keys())
+
+
+def test_agent_constants_exposed_in_config_module():
+    assert hasattr(_cfg, "AGENT_INBOX_DIR")
+    assert hasattr(_cfg, "AGENT_OUTBOX_DIR")
+    assert hasattr(_cfg, "AGENT_POLL_INTERVAL_SECONDS")
+    # Defaults must be safe-ish strings/numbers — even when the active profile is not agent.
+    assert isinstance(_cfg.AGENT_INBOX_DIR, str)
+    assert isinstance(_cfg.AGENT_OUTBOX_DIR, str)
+    assert isinstance(_cfg.AGENT_POLL_INTERVAL_SECONDS, (int, float))
+
+
+def test_load_adapter_constructs_agent_adapter(tmp_path):
+    cfg = _load_agent_profile()
+    adapter = load_adapter(_raw=cfg, intermediate_dir=tmp_path)
+    assert isinstance(adapter, AgentAdapter)
+    label = adapter.endpoint_label()
+    assert "agent" in label
+    # Inbox/outbox dirs should be under the supplied intermediate_dir.
+    assert (tmp_path / cfg["agent"]["inbox_dir"]).exists()
+    assert (tmp_path / cfg["agent"]["outbox_dir"]).exists()
+
+
+def test_load_adapter_agent_requires_intermediate_dir():
+    cfg = _load_agent_profile()
+    with pytest.raises(ValueError, match="intermediate_dir"):
+        load_adapter(_raw=cfg)
+
+
+def test_load_adapter_agent_requires_agent_block(tmp_path):
+    cfg = _load_agent_profile()
+    del cfg["agent"]
+    with pytest.raises(ValueError, match="agent"):
+        load_adapter(_raw=cfg, intermediate_dir=tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "mykg"
-version = "0.2.15"
+version = "0.2.16"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Adds a 6th LLM provider, **`provider: agent`**, where a Claude Code skill supplies LLM answers via a filesystem inbox/outbox under `intermediate/`. The deterministic 12-step pipeline, the orchestrator, every Step registration, all 14 LLM call sites, every `prompts/*.txt` template, and the existing config profiles stay **unchanged** — only the delivery of LLM answers changes, through a new `AgentAdapter` that conforms to the existing `LLMAdapter` interface.

### Phases

- **Phase 1 — `AgentAdapter`** ([src/mykg/llm/agent_adapter.py](src/mykg/llm/agent_adapter.py), [src/mykg/llm/config.py](src/mykg/llm/config.py), [src/mykg/cli.py](src/mykg/cli.py)): atomic task envelope write, `.done`-sentinel poll, `task_id = sha256(system + user + context_label)` for re-run resumability. `load_adapter()` gained an `intermediate_dir` parameter; both CLI entry points (`extract-graph`, `merge-graphs`) pass it.
- **Phase 2 — `agent-claude-code` profile** added to both [mykg_config.yaml](mykg_config.yaml) and [src/mykg/data/mykg_config.yaml](src/mykg/data/mykg_config.yaml) in lockstep (Invariant 17). `AGENT_INBOX_DIR` / `AGENT_OUTBOX_DIR` / `AGENT_POLL_INTERVAL_SECONDS` constants exposed via [src/mykg/config.py](src/mykg/config.py).
- **Phase 3 — `/mykg` skill** at [src/mykg/data/skills/mykg/SKILL.md](src/mykg/data/skills/mykg/SKILL.md) — full mykg CLI reference, 20-wave launch+watch loop, embedded subagent prompt template. Install instructions in [src/mykg/data/skills/README.md](src/mykg/data/skills/README.md) (one-line symlink).
- **Phase 4 — Docs**: [docs/agent-mode.md](docs/agent-mode.md) (architecture, contract, setup, timeout/retry/caching semantics) + providers-table link in [README.md](README.md). `CLAUDE.md` D49 update intentionally omitted — the file is gitignored (commit `ed0df74`).
- **Phase 5 — Live e2e test**: [tests/test_agent_mode_live.py](tests/test_agent_mode_live.py) drives `run(STEPS, ctx)` against `AgentAdapter` while a background mock-skill thread ([tests/fixtures/mock_skill.py](tests/fixtures/mock_skill.py)) drains the inbox with step-routed canned answers, asserts a valid `knowledge_graph.ttl`.

## Test plan

- [x] Full regression: `uv run pytest tests/ -q --no-cov` → **714 passed, 4 skipped, 15 new** (6 adapter + 7 config + 2 e2e).
- [x] Phase 1 focused: `uv run pytest tests/test_agent_adapter.py -v`.
- [x] Phase 2 focused: `uv run pytest tests/test_config_agent_profile.py -v`.
- [x] Phase 5 e2e: `uv run pytest tests/test_agent_mode_live.py -v`.
- [ ] Optional manual skill smoke test: `ln -s "\$(pwd)/src/mykg/data/skills/mykg" ~/.claude/skills/mykg` then run `/mykg tests/fixtures/agent_corpus/` in Claude Code; verify `output/knowledge_graph.ttl` is produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a filesystem-backed agent LLM provider that delegates mykg LLM calls to an external Claude Code skill and wire it into the existing pipeline via config and CLI.

New Features:
- Introduce an AgentAdapter LLM backend that exchanges prompts and answers via an inbox/outbox directory contract.
- Add an agent-claude-code configuration profile, including agent-specific settings and paths, alongside the existing LLM providers.
- Provide a Claude Code /mykg skill definition and installation guidance to drive agent-mode runs from within the coding assistant.

Enhancements:
- Extend adapter loading and CLI wiring to pass the session intermediate directory into the LLM adapter when using the agent provider.
- Expose agent-related configuration constants (inbox, outbox, poll interval) via the main config module for reuse across the codebase.

Documentation:
- Document agent mode architecture, contract, setup, and behavior in a new agent-mode guide and link it from the provider overview in the README.
- Add skill installation documentation describing how to enable the /mykg Claude Code skill.

Tests:
- Add unit tests for the AgentAdapter behavior and task-id semantics.
- Add tests covering the agent-claude-code profile wiring, including config invariants and adapter construction.
- Introduce a live end-to-end test that runs the pipeline against AgentAdapter using a mock skill plus supporting fixtures and canned corpus.