### PR TITLE
docs: agent-mode usage in README + architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,78 @@ profiles:
 
 ---
 
+## Claude Code skill as backend (agent mode)
+
+Agent mode is a different way to run myKG inside Claude Code: instead of `claude -p` subprocesses, the pipeline writes LLM tasks to a session-local inbox folder and a Claude Code **skill** dispatches subagents to answer them. Pick agent mode over `claude-cli` when you want parallel subagent dispatch from inside an active Claude Code session.
+
+### Why pick agent mode
+
+- **No API key needed.** Uses your existing Claude Pro/Max plan via the skill subagents — same as `claude-cli`, but without invoking the `claude -p` binary.
+- **Inspectable LLM I/O.** Every prompt lands as `intermediate/agent_inbox/<id>.task.json` and every answer as `intermediate/agent_outbox/<id>.answer.json`. Replay or edit any step by hand.
+- **Parallel by default.** The skill dispatches up to `pass2.max_workers` subagents per wave in a single message — not serial like `claude-cli`. Pass-2 chunks complete in parallel waves.
+
+### Install the skill
+
+```bash
+pip install mykg          # or: uv tool install mykg
+
+# Symlink the bundled skill into your Claude Code skills folder
+ln -s "$(python -c 'import mykg, pathlib; print(pathlib.Path(mykg.__file__).parent / "data" / "skills" / "mykg")')" ~/.claude/skills/mykg
+
+# Restart Claude Code (or re-open the project) so the skill loader picks up the new entry
+```
+
+### Configure the profile
+
+```bash
+mykg init --profile agent-claude-code
+```
+
+This writes a `mykg_config.yaml` with `profile: agent-claude-code` selected. The `agent:` block configures the inbox/outbox paths and poll interval:
+
+```yaml
+profile: agent-claude-code
+
+profiles:
+  agent-claude-code:
+    provider: agent
+    agent:
+      inbox_dir: agent_inbox        # relative to <session>/intermediate/
+      outbox_dir: agent_outbox
+      poll_interval_seconds: 2
+    pipeline:
+      pass2:
+        max_workers: 8              # how many subagents the skill dispatches per wave
+```
+
+### Invoke from inside Claude Code
+
+In an active Claude Code session, type:
+
+```
+/mykg ./my_notes                              # fresh run on a Markdown corpus
+/mykg ./my_notes --review                     # pause after Pass 1 for schema review
+/mykg --session 2026-06-02T17-30-00 --continue   # resume a session that hit the wave budget
+```
+
+### What the skill does on screen
+
+1. Confirms `mykg_config.yaml` has `profile: agent-claude-code` — aborts with a clear message if not.
+2. Launches `mykg extract-graph` in the background via `nohup` so it survives the skill turn.
+3. Watches `<session>/intermediate/agent_inbox/` for `*.task.json` files.
+4. Dispatches one Agent-tool subagent per unanswered task (parallel calls in one message, up to `pass2.max_workers` per wave).
+5. Exits when the pipeline subprocess exits, when `output/knowledge_graph.ttl` appears, or after **20 watch waves** — at which point it tells you to re-invoke `/mykg --session <name> --continue`.
+
+### Limitations and notes
+
+- The skill is bounded at **20 waves per invocation** to avoid runaway Claude Code sessions. Long pipelines may need multiple `/mykg --session <name> --continue` invocations.
+- The pipeline subprocess survives via `nohup`, so closing your Claude Code session does not kill it — the run continues in the background and you can re-attach by re-invoking the skill with `--continue`.
+- For non-Claude-Code hosts (Copilot CLI, Cursor, custom scripts), nothing prevents you from writing your own drainer against the same `agent_inbox`/`agent_outbox` contract — the protocol is just JSON files on disk.
+
+Full design and contract: [docs/agent-mode.md](docs/agent-mode.md). Skill source: [src/mykg/data/skills/mykg/SKILL.md](src/mykg/data/skills/mykg/SKILL.md).
+
+---
+
 ## Configuration
 
 All configuration lives in a single `mykg_config.yaml` file discovered automatically from the working directory (or any parent). There are no hardcoded defaults in the code — the YAML is the sole source of truth.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,8 @@ This document explains how **myKG** works at a conceptual level: the pipelines, 
 
 Both pipelines run as a sequence of named steps. All intermediate state is written to disk after every step, so any step can be re-entered without repeating upstream work.
 
+The LLM layer is provider-pluggable: six adapters ship out of the box (Anthropic, OpenAI, Ollama, OpenRouter, Claude CLI, and **Agent**). The Agent provider is unusual — instead of calling an HTTP API or a subprocess, it writes LLM tasks to a session-local inbox folder and polls an outbox for answers supplied by a Claude Code skill running on the user's side. The 12 pipeline steps and the orchestrator do not know which adapter is active.
+
 <p align="center">
   <img src="diagrams/system-overview.png" width="80%" style="vertical-align:middle;">
 </p>
@@ -293,7 +295,7 @@ The pipeline applies two tiers of automatic correction before asking for human i
 
 ## LLM Provider Support
 
-The pipeline is fully decoupled from any specific LLM provider. A single abstract adapter interface — accepting a system prompt and a user prompt, returning a string — is all that pipeline logic depends on. Five provider implementations ship out of the box:
+The pipeline is fully decoupled from any specific LLM provider. A single abstract adapter interface — accepting a system prompt and a user prompt, returning a string — is all that pipeline logic depends on. Six provider implementations ship out of the box:
 
 | Provider | Notes |
 |---|---|
@@ -302,8 +304,19 @@ The pipeline is fully decoupled from any specific LLM provider. A single abstrac
 | Ollama | Local inference; no API key required |
 | OpenRouter | Access many models via a single API key |
 | Claude CLI | Uses the `claude -p` subprocess; no API key; billing via Claude Pro/Max plan; serial only |
+| Agent (Claude Code skill) | LLM answers produced by a Claude Code skill via filesystem inbox/outbox; pipeline is otherwise unchanged. See [`docs/agent-mode.md`](agent-mode.md) |
 
 All provider parameters — model, context window, token limits, timeout, base URL — are set in `mykg_config.yaml`. There are no hardcoded defaults in adapter code. A 429 rate-limit response is treated as a misconfiguration signal (reduce worker count), not a transient error to silently retry indefinitely.
+
+### Agent provider — adapter that polls a filesystem
+
+The Agent provider is the sixth `LLMAdapter` subclass, not a fork of the orchestrator. The 12 pipeline steps, all 14 LLM call sites, every `prompts/*.txt` template, and the `ThreadPoolExecutor` parallelism in `pass1` / `pass2` / `orphan_connect` are unchanged. Only the implementation of `LLMAdapter.complete(system, user) → str` differs: instead of making an HTTP request, it writes a JSON task envelope to disk and polls for the response. This keeps the entire correctness story of mykg's deterministic pipeline — re-entry, sentinel-based completion checks, retry-once + LLM feedback — applicable verbatim to agent mode.
+
+The request/response contract lives entirely on the filesystem under each session's `intermediate/` directory. The adapter writes `agent_inbox/<task_id>.task.json` (containing the system prompt, user prompt, step name, and a context label) atomically via the `.tmp` + `rename` pattern. The skill on the other side reads the task, dispatches a subagent, and writes the answer envelope to `agent_outbox/<task_id>.answer.json` — again atomically. After the answer file is fully renamed, the skill creates a zero-byte sentinel at `agent_outbox/<task_id>.done`. The adapter polls only for the sentinel, never for the answer file, so it can never observe a half-written response.
+
+The `task_id` is `sha256(system + user + context_label)`, computed deterministically. Identical inputs produce identical IDs, so a duplicate `complete()` call within a session short-circuits to the existing answer file with no inbox write and no skill dispatch. Re-runs after a partial crash automatically resume from whatever answers are already on disk — the same content-addressed property the rest of mykg's intermediate state relies on.
+
+`ThreadPoolExecutor` parallelism is preserved transparently. With `pass2.max_workers: 8`, eight pipeline threads each call `adapter.complete()` simultaneously; each thread writes its own task to the inbox and independently polls for its own `.done` sentinel. The skill drains them in parallel waves — up to `pass2.max_workers` subagents per wave, dispatched in a single Claude Code response so they run concurrently. From the orchestrator's perspective the only observable difference vs. an HTTP adapter is wall-clock latency.
 
 ---
 
@@ -319,6 +332,7 @@ All provider parameters — model, context window, token limits, timeout, base U
 | **Session isolation** | Each run lives in a timestamped folder containing its own inputs, intermediate state, outputs, and logs | Runs never interfere; any run can be resumed or re-entered independently without touching other sessions |
 | **Single config file** | `mykg_config.yaml` is the sole source of truth for all parameters | No hardcoded literals in pipeline or adapter code; switching provider, model, or tuning parameters requires only a config change |
 | **Pydantic for all data models** | All structured data between pipeline stages uses Pydantic BaseModel | Free JSON serialization, field validation, and type coercion at every pipeline boundary |
+| **Filesystem-backed agent provider** | Sixth `LLMAdapter` subclass that writes JSON tasks to a session-local inbox and polls a `.done` sentinel | Lets a Claude Code skill — or any other host with file access — supply LLM answers without modifying the 12-step pipeline, the orchestrator, or any of the 14 LLM call sites. The contract is JSON files on disk; testable with a mock drainer in `tmp_path` |
 
 ### Schema and Ontology
 


### PR DESCRIPTION
## Summary

PR #12 added the `agent-claude-code` provider but only got one link in the README providers table and **zero coverage in `docs/architecture.md`**. This PR closes both gaps. No code changes.

- **[README.md](README.md)** — new "Claude Code skill as backend (agent mode)" section placed right after the "Claude Code as backend" (`claude-cli`) section so the contrast is unmissable. Covers: why pick agent mode, install steps (`pip install` + symlink + restart Claude Code), configuring the profile with `mykg init --profile agent-claude-code`, slash-command invocation syntax (`/mykg <dir>`, `/mykg --session <name> --continue`), what the skill does on screen, and limitations (20-wave budget, nohup-survival, non-Claude-Code host extension path). Links to [docs/agent-mode.md](docs/agent-mode.md) and [src/mykg/data/skills/mykg/SKILL.md](src/mykg/data/skills/mykg/SKILL.md).
- **[docs/architecture.md](docs/architecture.md)** — three targeted edits:
  - One sentence in **System Overview** noting the LLM layer is provider-pluggable and that Agent is one of six providers where answers come from a filesystem inbox/outbox.
  - 6th row in the **LLM Provider Support** table plus a new "Agent provider — adapter that polls a filesystem" subsection (4 paragraphs) explaining why agent mode is an adapter not a fork, the inbox/outbox contract, content-addressed `task_id` determinism, and how `ThreadPoolExecutor` parallelism is preserved transparently.
  - One row in **Key Design Decisions → Architecture and Pipeline** titled "Filesystem-backed agent provider".

## Test plan

- [x] `git pull origin main` before editing so all referenced files are visible locally.
- [x] All four cross-references (`docs/agent-mode.md`, `src/mykg/data/skills/mykg/SKILL.md`) resolve to real files on `main`.
- [x] Full regression: `uv run pytest tests/ -q --no-cov` → **718 passed, 0 failed**.
- [ ] Render README.md and docs/architecture.md on GitHub to confirm the new section flows correctly inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the new filesystem-backed Agent provider and Claude Code skill workflow for running myKG in agent mode, without changing core pipeline or code.

Documentation:
- Add README section describing how to run myKG via the Claude Code skill in agent mode, including installation, configuration, invocation patterns, and limitations.
- Extend architecture documentation to cover the Agent provider as a filesystem-polling LLM adapter, its inbox/outbox contract, deterministic task IDs, and preserved parallelism.
- Update architecture decision table and LLM provider support matrix to include the Agent provider as the sixth pluggable LLM adapter.