### PR TITLE
test: increase coverage from 87% to 94%

### DIFF
--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -375,3 +375,203 @@ def test_coerce_attr_scalar_uses_fallback():
     result = _coerce_attr("raw_string")
     assert result["value"] == "raw_string"
     assert result["confidence"] == _cfg.CONFIDENCE_FALLBACK
+
+
+# ---------------------------------------------------------------------------
+# Extended Unit 12 — assembler edge paths
+# ---------------------------------------------------------------------------
+
+
+def test_node_dedup_confidence_one_string_concat():
+    """Two sources with confidence=1.0 different strings concatenate with '; '."""
+    from mykg.assembler import deduplicate_nodes
+
+    raw = {
+        "a.md": {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "confidence": 1.0,
+                    "attributes": {"role": {"value": "engineer", "confidence": 1.0}},
+                }
+            ],
+            "edges": [],
+        },
+        "b.md": {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "confidence": 1.0,
+                    "attributes": {"role": {"value": "manager", "confidence": 1.0}},
+                }
+            ],
+            "edges": [],
+        },
+    }
+    nodes, merge_log = deduplicate_nodes(raw)
+    assert len(nodes) == 1
+    val = nodes[0]["attributes"]["role"]["value"]
+    assert "engineer" in val and "manager" in val and ";" in val
+    assert merge_log and "concatenated_attributes" in merge_log[0]
+
+
+def test_edge_dedup_confidence_one_string_concat():
+    """Edge attribute concat when both have confidence=1.0 with different strings."""
+    from mykg.assembler import deduplicate_edges
+
+    raw = {
+        "a.md": {
+            "nodes": [],
+            "edges": [
+                {
+                    "type": "works_at",
+                    "from": "p-1",
+                    "to": "o-1",
+                    "confidence": 1.0,
+                    "attributes": {"role": {"value": "engineer", "confidence": 1.0}},
+                }
+            ],
+        },
+        "b.md": {
+            "nodes": [],
+            "edges": [
+                {
+                    "type": "works_at",
+                    "from": "p-1",
+                    "to": "o-1",
+                    "confidence": 1.0,
+                    "attributes": {"role": {"value": "manager", "confidence": 1.0}},
+                }
+            ],
+        },
+    }
+    edges, merge_log = deduplicate_edges(raw)
+    edge = next(iter(edges.values()))
+    val = edge["attributes"]["role"]["value"]
+    assert "engineer" in val and "manager" in val and ";" in val
+    assert merge_log and "concatenated_attributes" in merge_log[0]
+
+
+def test_node_dedup_alias_union():
+    """Aliases from two sources are unioned (D29)."""
+    from mykg.assembler import deduplicate_nodes
+
+    raw = {
+        "a.md": {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "confidence": 1.0,
+                    "attributes": {"name": {"value": "Alice", "confidence": 1.0}},
+                    "aliases": ["Ali"],
+                }
+            ],
+            "edges": [],
+        },
+        "b.md": {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "confidence": 1.0,
+                    "attributes": {"name": {"value": "Alice", "confidence": 1.0}},
+                    "aliases": ["A.", "Liz"],
+                }
+            ],
+            "edges": [],
+        },
+    }
+    nodes, _ = deduplicate_nodes(raw)
+    assert sorted(nodes[0]["aliases"]) == ["A.", "Ali", "Liz"]
+
+
+def test_node_dedup_no_aliases_field_absent():
+    """Nodes with no aliases get no aliases key in the merged output (per D29)."""
+    from mykg.assembler import deduplicate_nodes
+
+    raw = {
+        "a.md": {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "confidence": 1.0,
+                    "attributes": {"name": {"value": "Alice", "confidence": 1.0}},
+                }
+            ],
+            "edges": [],
+        },
+    }
+    nodes, _ = deduplicate_nodes(raw)
+    assert "aliases" not in nodes[0]
+
+
+def test_edge_dedup_with_non_dict_attrs():
+    """Edges with non-dict attributes coerce gracefully."""
+    from mykg.assembler import deduplicate_edges
+
+    raw = {
+        "a.md": {
+            "nodes": [],
+            "edges": [
+                {
+                    "type": "works_at",
+                    "from": "p-1",
+                    "to": "o-1",
+                    "confidence": 0.9,
+                    "attributes": "not-a-dict",
+                }
+            ],
+        },
+        "b.md": {
+            "nodes": [],
+            "edges": [
+                {
+                    "type": "works_at",
+                    "from": "p-1",
+                    "to": "o-1",
+                    "confidence": 0.9,
+                    "attributes": {"role": {"value": "engineer", "confidence": 0.8}},
+                }
+            ],
+        },
+    }
+    edges, _ = deduplicate_edges(raw)
+    edge = next(iter(edges.values()))
+    assert isinstance(edge["attributes"], dict)
+
+
+def test_dedup_nodes_with_non_dict_attrs():
+    """Node with non-dict attributes still merges without error."""
+    from mykg.assembler import deduplicate_nodes
+
+    raw = {
+        "a.md": {
+            "nodes": [
+                {
+                    "id": "p-1",
+                    "type": "Person",
+                    "confidence": 0.9,
+                    "attributes": {"name": {"value": "Alice", "confidence": 0.9}},
+                },
+            ],
+            "edges": [],
+        },
+        "b.md": {
+            "nodes": [
+                {
+                    "id": "p-1",
+                    "type": "Person",
+                    "confidence": 0.5,
+                    "attributes": "not-a-dict",
+                },
+            ],
+            "edges": [],
+        },
+    }
+    nodes, _ = deduplicate_nodes(raw)
+    assert len(nodes) == 1
+    assert nodes[0]["attributes"]["name"]["value"] == "Alice"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -174,3 +174,414 @@ def test_from_step_without_session_or_dirs_errors(tmp_path, input_dir, monkeypat
     assert result.exit_code != 0
     out = _output(result)
     assert "--session" in out or "session" in out.lower() or "--from-step" in out
+
+
+# ---------------------------------------------------------------------------
+# Extended Unit 3 coverage
+# ---------------------------------------------------------------------------
+
+
+def test_extract_obsidian_vault_flag_mutates_config(tmp_path, input_dir, monkeypatch):
+    """--obsidian-vault flag flips mykg.config.OBSIDIAN_ENABLED to True."""
+    import mykg.cli as cli_mod
+    import mykg.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setattr(cfg_mod, "OBSIDIAN_ENABLED", False)
+    monkeypatch.setattr("mykg.orchestrator.run", lambda steps, ctx: None)
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli, ["extract-graph", str(input_dir), "--obsidian-vault"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert cfg_mod.OBSIDIAN_ENABLED is True
+
+
+def test_extract_base_schema_argument(tmp_path, input_dir, monkeypatch):
+    """--base-schema parses the TTL file and feeds it into PipelineContext."""
+    import mykg.cli as cli_mod
+    import mykg.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setattr("mykg.orchestrator.run", lambda steps, ctx: None)
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr(
+        "mykg.base_schema.parse_base_schema",
+        lambda content: {"concepts": [], "properties": []},
+    )
+
+    base_ttl = tmp_path / "base.ttl"
+    base_ttl.write_text("# fake ttl\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["extract-graph", str(input_dir), "--base-schema", str(base_ttl)],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_extract_thesaurus_argument(tmp_path, input_dir, monkeypatch):
+    import mykg.cli as cli_mod
+    import mykg.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setattr("mykg.orchestrator.run", lambda steps, ctx: None)
+    monkeypatch.setattr("mykg.llm.config.load_adapter", lambda **kw: MagicMock())
+    monkeypatch.setattr(
+        "mykg.thesaurus.parse_thesaurus",
+        lambda content, source=None: {"terms": []},
+    )
+
+    thes = tmp_path / "thes.ttl"
+    thes.write_text("@prefix skos: <http://www.w3.org/2004/02/skos/core#> .\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["extract-graph", str(input_dir), "--thesaurus", str(thes)],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_resolve_from_step_aliases():
+    from mykg.cli import _resolve_from_step
+
+    assert _resolve_from_step("orphan_connect_fullsweep") == ("orphan_connect", False)
+    assert _resolve_from_step("orphan_connect_incremental") == ("orphan_connect", True)
+    assert _resolve_from_step("pass2") == ("pass2", False)
+
+
+def test_delete_from_step_unknown_step_raises(tmp_path):
+    """Unknown step name -> ClickException."""
+    import click
+
+    from mykg.cli import _delete_from_step
+
+    with pytest.raises(click.ClickException) as exc_info:
+        _delete_from_step("does_not_exist", tmp_path, tmp_path)
+    assert "Unknown step" in str(exc_info.value.message)
+
+
+def test_delete_from_step_pass2_clears_shards(tmp_path):
+    """Re-running from pass2 must wipe shard directories."""
+    from mykg.cli import _delete_from_step
+
+    intermediate = tmp_path / "intermediate"
+    output = tmp_path / "output"
+    intermediate.mkdir()
+    output.mkdir()
+
+    # Create shard dirs and a concat_map
+    for shard_name in ("raw_extractions_shards", "chunk_index_shards"):
+        d = intermediate / shard_name
+        d.mkdir()
+        (d / "foo.json").write_text("{}")
+    (intermediate / "pass2_concat_map.json").write_text("{}")
+
+    _delete_from_step("pass2", intermediate, output)
+
+    assert not (intermediate / "raw_extractions_shards").exists()
+    assert not (intermediate / "chunk_index_shards").exists()
+    assert not (intermediate / "pass2_concat_map.json").exists()
+
+
+def test_delete_from_step_validate_graph_clears_obsidian(tmp_path, monkeypatch):
+    """Re-running from validate_graph deletes obsidian_vault directory."""
+    import mykg.config as cfg_mod
+
+    from mykg.cli import _delete_from_step
+
+    monkeypatch.setattr(cfg_mod, "OBSIDIAN_VAULT_DIR", "obsidian_vault")
+
+    intermediate = tmp_path / "intermediate"
+    output = tmp_path / "output"
+    intermediate.mkdir()
+    output.mkdir()
+
+    obs = output / "obsidian_vault"
+    obs.mkdir()
+    (obs / "Person.md").write_text("test")
+
+    _delete_from_step("validate_graph", intermediate, output)
+
+    assert not obs.exists()
+
+
+def test_delete_from_step_after_human_review_clears_approval_flag(tmp_path):
+    """Stepping from a step after human_review wipes the approval flag."""
+    from mykg.cli import _delete_from_step
+
+    intermediate = tmp_path / "intermediate"
+    output = tmp_path / "output"
+    intermediate.mkdir()
+    output.mkdir()
+
+    (intermediate / "schema_approved.flag").write_text("approved")
+
+    _delete_from_step("schema_flatten", intermediate, output)
+
+    assert not (intermediate / "schema_approved.flag").exists()
+
+
+def test_delete_from_step_orphan_connect_incremental_preserves_files(tmp_path):
+    """Incremental sweep preserves orphan_connections.json and orphan_log.json."""
+    from mykg.cli import _delete_from_step
+
+    intermediate = tmp_path / "intermediate"
+    output = tmp_path / "output"
+    intermediate.mkdir()
+    output.mkdir()
+
+    (intermediate / "orphan_connections.json").write_text("{}")
+    (intermediate / "orphan_log.json").write_text("[]")
+
+    _delete_from_step("orphan_connect", intermediate, output, incremental=True)
+
+    # Both files must be preserved (incremental sweep).
+    assert (intermediate / "orphan_connections.json").exists()
+    assert (intermediate / "orphan_log.json").exists()
+
+
+def test_delete_merge_from_step_unknown_raises(tmp_path):
+    import click
+
+    from mykg.cli import _delete_merge_from_step
+
+    with pytest.raises(click.ClickException) as exc:
+        _delete_merge_from_step("does_not_exist", tmp_path, tmp_path)
+    assert "Unknown merge step" in str(exc.value.message)
+
+
+def test_delete_merge_from_step_clears_shards(tmp_path):
+    from mykg.cli import _delete_merge_from_step
+
+    intermediate = tmp_path / "intermediate"
+    output = tmp_path / "output"
+    intermediate.mkdir()
+    output.mkdir()
+
+    for shard_name in ("raw_extractions_shards", "chunk_index_shards"):
+        d = intermediate / shard_name
+        d.mkdir()
+        (d / "foo.json").write_text("{}")
+
+    _delete_merge_from_step("merge_reextract", intermediate, output)
+
+    assert not (intermediate / "raw_extractions_shards").exists()
+    assert not (intermediate / "chunk_index_shards").exists()
+
+
+def test_delete_merge_from_step_clears_flag(tmp_path):
+    from mykg.cli import _delete_merge_from_step
+
+    intermediate = tmp_path / "intermediate"
+    output = tmp_path / "output"
+    intermediate.mkdir()
+    output.mkdir()
+    (intermediate / "schema_approved.flag").write_text("approved")
+
+    _delete_merge_from_step("schema_flatten", intermediate, output)
+
+    assert not (intermediate / "schema_approved.flag").exists()
+
+
+def test_merge_graphs_self_merge_errors(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+    import mykg.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["merge-graphs", "session-a", "session-a"],
+    )
+
+    assert result.exit_code != 0
+    out = _output(result)
+    assert "Cannot merge a session with itself" in out
+
+
+def test_merge_graphs_missing_session_errors(tmp_path, monkeypatch):
+    """Two distinct session names, but they don't exist on disk -> sys.exit(1)."""
+    import mykg.cli as cli_mod
+    import mykg.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["merge-graphs", "session-a", "session-b"],
+    )
+
+    assert result.exit_code != 0
+    out = _output(result)
+    assert "not found" in out
+
+
+def test_walkthrough_cmd_missing_session(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+    import mykg.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["walkthrough", "--session", "does-not-exist"],
+    )
+
+    assert result.exit_code != 0
+    out = _output(result)
+    assert "Session not found" in out or "not found" in out
+
+
+def test_parse_docs_subcommand_mineru_success(tmp_path, monkeypatch):
+    """parse-docs invokes ephemeral_mineru_venv + subprocess.run cleanly."""
+    import subprocess
+    from contextlib import contextmanager
+
+    import mykg.cli as cli_mod
+
+    input_dir = tmp_path / "in"
+    input_dir.mkdir()
+    (input_dir / "a.pdf").write_text("fake pdf")
+    out_dir = tmp_path / "out"
+
+    @contextmanager
+    def fake_venv(*a, **kw):
+        yield tmp_path / "fake_mineru"
+
+    monkeypatch.setattr("mykg.uv_venv.ephemeral_mineru_venv", fake_venv)
+
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+
+    def fake_run(cmd, check=False, timeout=None):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["parse-docs", "--input", str(input_dir), "--output", str(out_dir)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Done" in result.output
+    assert "-p" in captured["cmd"]
+
+
+def test_parse_docs_subcommand_timeout(tmp_path, monkeypatch):
+    import subprocess
+    from contextlib import contextmanager
+
+    import mykg.cli as cli_mod
+
+    input_dir = tmp_path / "in"
+    input_dir.mkdir()
+    (input_dir / "a.pdf").write_text("fake")
+    out_dir = tmp_path / "out"
+
+    @contextmanager
+    def fake_venv(*a, **kw):
+        yield tmp_path / "fake_mineru"
+
+    monkeypatch.setattr("mykg.uv_venv.ephemeral_mineru_venv", fake_venv)
+
+    def fake_run(cmd, check=False, timeout=None):
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["parse-docs", "--input", str(input_dir), "--output", str(out_dir)],
+    )
+
+    assert result.exit_code != 0
+    out = _output(result)
+    assert "timed out" in out
+
+
+def test_parse_docs_subcommand_nonzero_exit(tmp_path, monkeypatch):
+    import subprocess
+    from contextlib import contextmanager
+
+    import mykg.cli as cli_mod
+
+    input_dir = tmp_path / "in"
+    input_dir.mkdir()
+    (input_dir / "a.pdf").write_text("fake")
+    out_dir = tmp_path / "out"
+
+    @contextmanager
+    def fake_venv(*a, **kw):
+        yield tmp_path / "fake_mineru"
+
+    monkeypatch.setattr("mykg.uv_venv.ephemeral_mineru_venv", fake_venv)
+
+    class FakeProc:
+        returncode = 17
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: FakeProc())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["parse-docs", "--input", str(input_dir), "--output", str(out_dir)],
+    )
+
+    assert result.exit_code != 0
+    out = _output(result)
+    assert "exited with code 17" in out
+
+
+def test_main_invokes_cli(monkeypatch):
+    """mykg.cli.main() is the entry point used by the `mykg` console script."""
+    called = {}
+
+    def fake_cli(*a, **kw):
+        called["yes"] = True
+
+    monkeypatch.setattr("mykg.cli.cli", fake_cli)
+
+    from mykg.cli import main
+
+    main()
+    assert called.get("yes") is True
+
+
+def test_approve_schema_session_and_intermediate_dir_mutex(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+    import mykg.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "sessions"))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "approve-schema",
+            "--session",
+            "foo",
+            "--intermediate-dir",
+            str(tmp_path / "intermediate"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    out = _output(result)
+    assert "cannot be combined" in out

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,376 @@
+"""Tests for `mykg init` command.
+
+Covers profile selection, model patching, API key writing, --reinstall-skill
+short-circuit, and existing-config behaviour. Mocks _install_agent_skill so
+tests never touch ~/.claude/.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture(autouse=True)
+def _mock_install_agent_skill(monkeypatch):
+    """Block all real skill-install side-effects across this whole test module."""
+    monkeypatch.setattr("mykg.cli._install_agent_skill", lambda *a, **kw: None)
+
+
+def _runner_in(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return CliRunner()
+
+
+def test_init_default_creates_config_with_openrouter_profile(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    # default profile, default model, skip API key (empty input)
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init", "--profile", "openrouter-free", "--model", "openrouter/free", "--api-key", ""],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = (tmp_path / "mykg_config.yaml").read_text()
+    assert "profile: openrouter-free" in cfg
+
+
+def test_init_interactive_prompt_selects_profile(tmp_path, monkeypatch):
+    """When --profile omitted, init prompts. Feed '2' to pick anthropic-claude."""
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    # Choice 2 = anthropic-claude (second entry in _PROFILE_META)
+    # Press Enter for model default, paste no API key.
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init"],
+        input="2\n\n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = (tmp_path / "mykg_config.yaml").read_text()
+    assert "profile: anthropic-claude" in cfg
+
+
+def test_init_invalid_interactive_choice_falls_back_to_default(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    # Provide "abc" which is not parseable as int. Fall back to openrouter-free.
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init"],
+        input="abc\n\n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "Invalid choice" in out
+    cfg = (tmp_path / "mykg_config.yaml").read_text()
+    assert "profile: openrouter-free" in cfg
+
+
+def test_init_invalid_interactive_index_falls_back_to_default(tmp_path, monkeypatch):
+    """An out-of-range index also triggers the fallback message."""
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init"],
+        input="999\n\n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Invalid choice" in result.output
+
+
+def test_init_unknown_profile_errors(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init", "--profile", "does-not-exist"],
+    )
+
+    # Note: this branch echoes and returns without raising.
+    assert result.exit_code == 0
+    assert "Unknown profile" in result.output
+
+
+def test_init_existing_config_without_force(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+
+    (tmp_path / "mykg_config.yaml").write_text("profile: openrouter-free\n")
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(cli_mod.cli, ["init"])
+
+    assert result.exit_code == 0
+    assert "already exists" in result.output
+
+
+def test_init_existing_config_with_force_overwrites(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+
+    (tmp_path / "mykg_config.yaml").write_text("# manually edited\n")
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init", "--force", "--profile", "ollama-local", "--model", "llama3.3"],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = (tmp_path / "mykg_config.yaml").read_text()
+    assert "profile: ollama-local" in cfg
+
+
+def test_init_reinstall_skill_on_existing_agent_config(tmp_path, monkeypatch):
+    """--reinstall-skill on existing agent config should short-circuit."""
+    import mykg.cli as cli_mod
+
+    (tmp_path / "mykg_config.yaml").write_text(
+        "profile: agent-claude-code\nllm:\n  agent-claude-code: {}\n"
+    )
+
+    called = {}
+
+    def _fake_install(*, force: bool = False):
+        called["force"] = force
+
+    monkeypatch.setattr("mykg.cli._install_agent_skill", _fake_install)
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(cli_mod.cli, ["init", "--reinstall-skill"])
+
+    assert result.exit_code == 0, result.output
+    assert called.get("force") is True
+
+
+def test_init_reinstall_skill_on_non_agent_config_warns(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+
+    (tmp_path / "mykg_config.yaml").write_text("profile: openrouter-free\n")
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(cli_mod.cli, ["init", "--reinstall-skill"])
+
+    assert result.exit_code == 0
+    assert "only meaningful" in result.output.lower()
+
+
+def test_init_reinstall_skill_existing_config_unreadable(tmp_path, monkeypatch):
+    """When existing file exists but read_text raises OSError, branch handles it."""
+    import mykg.cli as cli_mod
+
+    cfg_path = tmp_path / "mykg_config.yaml"
+    cfg_path.write_text("profile: agent-claude-code\n")
+
+    # Patch read_text on the specific Path instance via Path.read_text broadly:
+    real_read_text = Path.read_text
+
+    def fail_read_text(self, *a, **kw):
+        if self.name == "mykg_config.yaml":
+            raise OSError("simulated unreadable")
+        return real_read_text(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(cli_mod.cli, ["init", "--reinstall-skill"])
+
+    # Falls through the OSError branch; existing config doesn't contain agent profile
+    # because we read empty string. Then prints "only meaningful" warning.
+    assert result.exit_code == 0
+
+
+def test_init_profile_no_api_key_required(tmp_path, monkeypatch):
+    """ollama-local has key_var=None — branch prints 'No API key required'."""
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init", "--profile", "ollama-local", "--model", "llama3.3"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "No API key required" in result.output
+
+
+def test_init_writes_api_key_to_env(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "init",
+            "--profile",
+            "anthropic-claude",
+            "--model",
+            "claude-sonnet-4-5",
+            "--api-key",
+            "sk-ant-test-12345",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    env = (tmp_path / ".env.mykg").read_text()
+    assert "ANTHROPIC_API_KEY=sk-ant-test-12345" in env
+
+
+def test_init_skips_when_api_key_blank(tmp_path, monkeypatch):
+    """Empty api_key + empty interactive input -> 'Skipped' message."""
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init", "--profile", "openai", "--model", "gpt-4o", "--api-key", ""],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Skipped" in result.output
+
+
+def test_init_detects_existing_env_key(tmp_path, monkeypatch):
+    """If .env.mykg already has a non-empty key, init says 'already set'."""
+    import mykg.cli as cli_mod
+
+    (tmp_path / ".env.mykg").write_text("ANTHROPIC_API_KEY=existing-key\n")
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init", "--profile", "anthropic-claude", "--model", "claude-sonnet-4-5"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "already set" in result.output
+
+
+def test_init_claude_cli_profile_no_api_key(tmp_path, monkeypatch):
+    """claude-cli profile has no key_var; should hit the no-api-key branch."""
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init", "--profile", "claude-cli", "--model", "sonnet"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "No API key required" in result.output
+
+
+def test_init_agent_claude_code_profile_runs_install(tmp_path, monkeypatch):
+    import mykg.cli as cli_mod
+
+    called = {}
+    monkeypatch.setattr(
+        "mykg.cli._install_agent_skill",
+        lambda *, force=False: called.setdefault("force", force),
+    )
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        ["init", "--profile", "agent-claude-code"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "force" in called
+    # The agent-claude-code branch follows _print_next_steps and triggers install.
+
+
+def test_init_openai_profile_writes_model(tmp_path, monkeypatch):
+    """Patch model line in openai profile via --model override."""
+    import mykg.cli as cli_mod
+
+    runner = _runner_in(tmp_path, monkeypatch)
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "init",
+            "--profile",
+            "openai",
+            "--model",
+            "gpt-4o-mini",
+            "--api-key",
+            "sk-test-openai",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = (tmp_path / "mykg_config.yaml").read_text()
+    # The patched model line should appear inside the openai profile block.
+    assert "gpt-4o-mini" in cfg
+
+
+def test_patch_profile_model_matched():
+    """_patch_profile_model replaces the right model line."""
+    from mykg.cli import _patch_profile_model
+
+    content = """profile: openai
+
+llm:
+  openrouter-free:
+      model: openrouter/free
+      max_tokens: 4000
+  openai:
+      model: gpt-4o
+      max_tokens: 4000
+"""
+    out = _patch_profile_model(content, "openai", "gpt-4o-mini")
+    assert "model: gpt-4o-mini" in out
+    # openrouter-free was not touched
+    assert "openrouter/free" in out
+
+
+def test_patch_profile_model_not_found_returns_unchanged():
+    """If the requested profile is not in the YAML, content is returned unchanged."""
+    from mykg.cli import _patch_profile_model
+
+    content = "profile: openai\n\nllm:\n  openrouter-free:\n      model: openrouter/free\n"
+    out = _patch_profile_model(content, "does-not-exist", "whatever")
+    assert out == content
+
+
+def test_write_env_key_updates_existing(tmp_path):
+    from mykg.cli import _write_env_key
+
+    env = tmp_path / ".env.mykg"
+    env.write_text("FOO=old\nBAR=keep\n")
+    _write_env_key(env, "FOO", "new")
+    lines = env.read_text().splitlines()
+    assert "FOO=new" in lines
+    assert "BAR=keep" in lines
+
+
+def test_write_env_key_appends_new(tmp_path):
+    from mykg.cli import _write_env_key
+
+    env = tmp_path / ".env.mykg"
+    env.write_text("EXISTING=value\n")
+    _write_env_key(env, "NEW", "val2")
+    lines = env.read_text().splitlines()
+    assert "EXISTING=value" in lines
+    assert "NEW=val2" in lines
+
+
+def test_write_env_key_creates_file_if_missing(tmp_path):
+    from mykg.cli import _write_env_key
+
+    env = tmp_path / ".env.mykg"
+    assert not env.exists()
+    _write_env_key(env, "K", "v")
+    assert env.exists()
+    assert "K=v" in env.read_text()

--- a/tests/test_cli_skill_install.py
+++ b/tests/test_cli_skill_install.py
@@ -1,0 +1,499 @@
+"""Tests for `_install_agent_skill`, `_claude_skills_dir`, `_manual_copy_hint`,
+and `_print_next_steps` in mykg.cli.
+
+These tests do not touch ~/.claude/ — every test uses an isolated temp dir
+via $CLAUDE_CONFIG_DIR or monkeypatching ``_claude_skills_dir``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import click
+import pytest
+
+
+def _make_fake_source(tmp_path: Path) -> Path:
+    """Create a fake bundled-skill source directory."""
+    source = tmp_path / "src_skill" / "mykg"
+    source.mkdir(parents=True)
+    (source / "SKILL.md").write_text("# fake skill\n")
+    return source
+
+
+def _patch_source(monkeypatch, tmp_path):
+    """Make _install_agent_skill use a fake bundled-source dir."""
+    source = _make_fake_source(tmp_path)
+
+    class _FakeMykg:
+        __file__ = str(tmp_path / "src_skill" / "__init__.py")
+        __version__ = "9.9.9"
+
+    # Build the layout that _install_agent_skill expects:
+    # Path(mykg.__file__).parent / "data" / "skills" / "mykg" must exist.
+    real_init = tmp_path / "mykg_pkg"
+    skill_pkg = real_init / "data" / "skills" / "mykg"
+    skill_pkg.mkdir(parents=True)
+    (skill_pkg / "SKILL.md").write_text("# fake skill\n")
+    (skill_pkg / "extra.txt").write_text("x")
+    _FakeMykg.__file__ = str(real_init / "__init__.py")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mykg",
+        _FakeMykg,
+    )
+    return real_init, skill_pkg
+
+
+def test_claude_skills_dir_uses_override(monkeypatch, tmp_path):
+    from mykg import cli
+
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "custom"))
+    out = cli._claude_skills_dir()
+    assert out == tmp_path / "custom" / "skills"
+
+
+def test_claude_skills_dir_default_when_exists(monkeypatch, tmp_path):
+    from mykg import cli
+
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    home_claude = tmp_path / "home" / ".claude" / "skills"
+    home_claude.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+
+    out = cli._claude_skills_dir()
+    assert out == home_claude
+
+
+def test_claude_skills_dir_default_when_missing(monkeypatch, tmp_path):
+    from mykg import cli
+
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    # Not Windows
+    monkeypatch.setattr(sys, "platform", "linux")
+    out = cli._claude_skills_dir()
+    assert out == tmp_path / "home" / ".claude" / "skills"
+
+
+def test_claude_skills_dir_windows_appdata_fallback(monkeypatch, tmp_path):
+    from mykg import cli
+
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    # ~/.claude/skills does NOT exist; APPDATA path DOES exist.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "nohome"))
+    appdata = tmp_path / "appdata"
+    (appdata / "Claude" / "skills").mkdir(parents=True)
+    monkeypatch.setenv("APPDATA", str(appdata))
+
+    out = cli._claude_skills_dir()
+    assert out == appdata / "Claude" / "skills"
+
+
+def test_claude_skills_dir_windows_no_appdata_env(monkeypatch, tmp_path):
+    """Windows but APPDATA env var is missing -> returns home claude path."""
+    from mykg import cli
+
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "nohome"))
+
+    out = cli._claude_skills_dir()
+    assert out == tmp_path / "nohome" / ".claude" / "skills"
+
+
+def test_manual_copy_hint_unix(monkeypatch):
+    from mykg import cli
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    hint = cli._manual_copy_hint(Path("/src"), Path("/dst"))
+    assert "cp -R" in hint
+    assert "/src" in hint
+    assert "/dst" in hint
+
+
+def test_manual_copy_hint_windows(monkeypatch):
+    from mykg import cli
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    hint = cli._manual_copy_hint(Path("C:/src"), Path("C:/dst"))
+    assert "xcopy" in hint
+
+
+def test_install_agent_skill_fresh_install(monkeypatch, tmp_path, capsys):
+    """First-time install copies and writes version stamp."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    cli._install_agent_skill()
+    captured = capsys.readouterr().out
+
+    target = skills_dir / "mykg"
+    assert target.is_dir()
+    assert (target / "SKILL.md").is_file()
+    stamp = target / cli._SKILL_VERSION_STAMP
+    assert stamp.is_file()
+    assert stamp.read_text() == "9.9.9"
+    assert "Installed:" in captured
+
+
+def test_install_agent_skill_idempotent(monkeypatch, tmp_path, capsys):
+    """Same version already installed -> 'Already installed' message."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    target = skills_dir / "mykg"
+    target.mkdir(parents=True)
+    (target / cli._SKILL_VERSION_STAMP).write_text("9.9.9")
+    (target / "SKILL.md").write_text("old")
+
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    assert "Already installed" in out
+
+
+def test_install_agent_skill_stale_version_warning(monkeypatch, tmp_path, capsys):
+    """Installed older version -> warning, no overwrite."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    target = skills_dir / "mykg"
+    target.mkdir(parents=True)
+    (target / cli._SKILL_VERSION_STAMP).write_text("0.0.1")
+    (target / "SKILL.md").write_text("old")
+
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    assert "Re-run with --reinstall-skill" in out
+    # The file is left untouched.
+    assert (target / "SKILL.md").read_text() == "old"
+
+
+def test_install_agent_skill_force_overwrites(monkeypatch, tmp_path, capsys):
+    """force=True overwrites even when versions match."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    target = skills_dir / "mykg"
+    target.mkdir(parents=True)
+    (target / cli._SKILL_VERSION_STAMP).write_text("9.9.9")
+    (target / "SKILL.md").write_text("old content")
+
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    cli._install_agent_skill(force=True)
+    out = capsys.readouterr().out
+    assert "Installed:" in out
+    # Old content has been replaced by the source SKILL.md content.
+    assert (target / "SKILL.md").read_text() == "# fake skill\n"
+
+
+def test_install_agent_skill_legacy_symlink_no_force(monkeypatch, tmp_path, capsys):
+    """Symlink at target without --force -> warns, returns."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    skills_dir.mkdir()
+    target = skills_dir / "mykg"
+    real_other = tmp_path / "other"
+    real_other.mkdir()
+    target.symlink_to(real_other)
+
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    assert "legacy symlink" in out
+    # Target is still a symlink (untouched).
+    assert target.is_symlink()
+
+
+def test_install_agent_skill_legacy_symlink_with_force(monkeypatch, tmp_path, capsys):
+    """Symlink at target with --force -> replaces with copy."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    skills_dir.mkdir()
+    target = skills_dir / "mykg"
+    real_other = tmp_path / "other"
+    real_other.mkdir()
+    target.symlink_to(real_other)
+
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    cli._install_agent_skill(force=True)
+    out = capsys.readouterr().out
+    assert "Installed:" in out
+    assert not target.is_symlink()
+    assert target.is_dir()
+
+
+def test_install_agent_skill_no_version_stamp_no_force(monkeypatch, tmp_path, capsys):
+    """Hand-edited copy (no stamp) without --force -> warns, returns."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    target = skills_dir / "mykg"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text("hand edited")
+
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    assert "no version stamp" in out
+    assert (target / "SKILL.md").read_text() == "hand edited"
+
+
+def test_install_agent_skill_mkdir_failure(monkeypatch, tmp_path, capsys):
+    """OSError on target_dir.mkdir -> prints fallback message and returns."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    # Patch Path.mkdir to raise for the target_dir.
+    real_mkdir = Path.mkdir
+
+    def fail_mkdir(self, *a, **kw):
+        if self == skills_dir:
+            raise OSError("denied")
+        return real_mkdir(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "mkdir", fail_mkdir)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    assert "Could not create" in out
+    assert "Copy manually" in out
+
+
+def test_install_agent_skill_copytree_failure(monkeypatch, tmp_path, capsys):
+    """OSError from shutil.copytree -> 'Failed to copy' message."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    def failing_copytree(*a, **kw):
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(shutil, "copytree", failing_copytree)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    assert "Failed to copy" in out
+
+
+def test_install_agent_skill_version_stamp_write_failure(monkeypatch, tmp_path, capsys):
+    """Stamp write fails but install proceeds; prints Warning."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    real_write_text = Path.write_text
+
+    def fail_write_for_stamp(self, *a, **kw):
+        if self.name == cli._SKILL_VERSION_STAMP:
+            raise OSError("read-only")
+        return real_write_text(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "write_text", fail_write_for_stamp)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    assert "could not write version stamp" in out
+    # Target exists even though stamp failed
+    assert (skills_dir / "mykg").is_dir()
+
+
+def test_install_agent_skill_missing_source(monkeypatch, tmp_path, capsys):
+    """Bundled source dir missing -> warning, no error."""
+    from mykg import cli
+
+    # Patch sys.modules['mykg'] with a fake whose data/skills/mykg does NOT exist
+    class _FakeMykg:
+        __file__ = str(tmp_path / "noexist" / "__init__.py")
+        __version__ = "9.9.9"
+
+    monkeypatch.setitem(sys.modules, "mykg", _FakeMykg)
+
+    skills_dir = tmp_path / "skills_root"
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "bundled skill not found" in out
+
+
+def test_install_agent_skill_replace_failure(monkeypatch, tmp_path, capsys):
+    """os.replace from tmp -> target failing surfaces error."""
+    import os
+
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    def fail_replace(*a, **kw):
+        raise OSError("rename failed")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    assert "Failed to install" in out
+
+
+def test_install_agent_skill_unreadable_stamp(monkeypatch, tmp_path, capsys):
+    """Existing stamp file but read_text raises -> falls through cleanly."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+
+    skills_dir = tmp_path / "skills_root"
+    target = skills_dir / "mykg"
+    target.mkdir(parents=True)
+    (target / cli._SKILL_VERSION_STAMP).write_text("x")
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    real_read = Path.read_text
+
+    def fail_read(self, *a, **kw):
+        if self.name == cli._SKILL_VERSION_STAMP:
+            raise OSError("denied")
+        return real_read(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+
+    cli._install_agent_skill()
+    out = capsys.readouterr().out
+    # Should hit the (unreadable) branch and likely warn (stale).
+    assert "(unreadable)" in out or "Re-run" in out
+
+
+def test_print_next_steps_reinstall_skill_non_agent_warns(capsys):
+    from mykg import cli
+
+    cli._print_next_steps("openrouter-free", reinstall_skill=True)
+    out = capsys.readouterr().out
+    assert "--reinstall-skill ignored" in out
+
+
+@pytest.mark.parametrize(
+    "profile,expected",
+    [
+        ("openrouter-free", "Next steps:"),
+        ("anthropic-claude", "Next steps:"),
+        ("ollama-local", "Ollama"),
+        ("claude-cli", "claude CLI"),
+    ],
+)
+def test_print_next_steps_each_profile(monkeypatch, capsys, profile, expected):
+    from mykg import cli
+
+    monkeypatch.setattr(cli, "_install_agent_skill", lambda *a, **kw: None)
+    cli._print_next_steps(profile)
+    out = capsys.readouterr().out
+    assert expected in out
+
+
+def test_print_next_steps_agent_profile_runs_install(monkeypatch, capsys):
+    from mykg import cli
+
+    called = {}
+    monkeypatch.setattr(
+        cli, "_install_agent_skill", lambda *, force=False: called.setdefault("force", force)
+    )
+
+    cli._print_next_steps("agent-claude-code", reinstall_skill=False)
+    out = capsys.readouterr().out
+    assert "/mykg" in out
+    assert called.get("force") is False
+
+
+def test_print_next_steps_agent_profile_force(monkeypatch, capsys):
+    from mykg import cli
+
+    called = {}
+    monkeypatch.setattr(
+        cli, "_install_agent_skill", lambda *, force=False: called.setdefault("force", force)
+    )
+
+    cli._print_next_steps("agent-claude-code", reinstall_skill=True)
+    assert called.get("force") is True
+
+
+def test_install_agent_skill_replaces_existing_tmp_file(monkeypatch, tmp_path, capsys):
+    """If tmp path exists as a *file*, it gets unlinked and replaced cleanly."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+    skills_dir = tmp_path / "skills_root"
+    skills_dir.mkdir()
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    # Create a stray file at the tmp path so the unlink branch executes.
+    stray_tmp = skills_dir / "mykg.tmp"
+    stray_tmp.write_text("stale")
+
+    cli._install_agent_skill(force=True)
+    out = capsys.readouterr().out
+    assert "Installed:" in out
+    assert (skills_dir / "mykg").is_dir()
+    assert not stray_tmp.exists()
+
+
+def test_install_agent_skill_replaces_existing_tmp_dir(monkeypatch, tmp_path, capsys):
+    """If tmp path exists as a *directory*, shutil.rmtree branch runs."""
+    from mykg import cli
+
+    real_init, skill_pkg = _patch_source(monkeypatch, tmp_path)
+    skills_dir = tmp_path / "skills_root"
+    skills_dir.mkdir()
+    monkeypatch.setattr(cli, "_claude_skills_dir", lambda: skills_dir)
+
+    stale = skills_dir / "mykg.tmp"
+    stale.mkdir()
+    (stale / "garbage").write_text("x")
+
+    cli._install_agent_skill(force=True)
+    out = capsys.readouterr().out
+    assert "Installed:" in out
+    assert (skills_dir / "mykg").is_dir()

--- a/tests/test_context_calculator.py
+++ b/tests/test_context_calculator.py
@@ -546,6 +546,191 @@ def test_main_manual_mode_errors_without_context(monkeypatch, capsys):
     assert exc_info.value.code != 0
 
 
+def test_write_candidate_config_leaves_other_profile_untouched(tmp_path):
+    """write_candidate_config must not patch keys outside the named profile (line 239)."""
+    cfg_text = """\
+profile: alpha
+profiles:
+  alpha:
+    llm:
+      context_window: 1000
+  beta:
+    llm:
+      context_window: 9999
+"""
+    cfg_path = tmp_path / "mykg_config.yaml"
+    cfg_path.write_text(cfg_text)
+
+    result = {
+        "context_window": 4242,
+        "max_output_tokens": 100,
+        "batch_token_target": 200,
+        "window_tokens": 300,
+        "overlap_tokens": 50,
+        "max_file_chars": 400,
+    }
+    out_path = write_candidate_config(cfg_path, "alpha", result)
+    out = out_path.read_text()
+
+    # The alpha profile's context_window should be patched, but beta's value
+    # (9999) must remain unchanged
+    assert "context_window: 4242" in out
+    assert "context_window: 9999" in out
+
+
+def test_print_report_prep_mode_concat(capsys):
+    """print_report shows the concat-specific message when prep_mode='concat' (line 324-325)."""
+    print_report(PRINT_RESULT, model="m", chunk_divisor=12, prep_mode="concat")
+    out = capsys.readouterr().out
+    assert "concat_batch_token_target" in out
+    assert "concat" in out
+
+
+def test_print_report_prep_mode_batch_chunks(capsys):
+    """print_report shows the batch_chunks message when prep_mode='batch_chunks' (line 326-327)."""
+    print_report(PRINT_RESULT, model="m", chunk_divisor=12, prep_mode="batch_chunks")
+    out = capsys.readouterr().out
+    assert "pass2.batch_token_target" in out
+    assert "batch_chunks" in out
+
+
+def test_print_report_prep_mode_per_file(capsys):
+    """print_report shows the per-file message for an unrecognized prep_mode (line 329)."""
+    print_report(PRINT_RESULT, model="m", chunk_divisor=12, prep_mode="per_file")
+    out = capsys.readouterr().out
+    assert "per-file chunking" in out
+
+
+def test_main_from_config_errors_when_context_missing(tmp_path, monkeypatch):
+    """parser.error fires (line 421-425) when llm.context_window is absent."""
+    cfg = """\
+profile: bad
+profiles:
+  bad:
+    llm: {}
+    pipeline:
+      chunking: {}
+"""
+    (tmp_path / "mykg_config.yaml").write_text(cfg)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["context_calculator.py", "--from-config"])
+
+    from mykg.utility.context_calculator import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code != 0
+
+
+def test_main_from_config_auto_discovers_input_files(tmp_path, monkeypatch, capsys):
+    """When --input-dir is omitted, main() finds ./input_files automatically (lines 436-440)."""
+    # Create ./input_files in cwd
+    input_dir = tmp_path / "input_files"
+    input_dir.mkdir()
+    (input_dir / "doc.md").write_text("hello world auto discover")
+
+    cfg = """\
+profile: p
+profiles:
+  p:
+    llm:
+      context_window: 32000
+      max_output_tokens: 8000
+    pipeline:
+      chunking:
+        window_tokens: 2000
+        overlap_tokens: 200
+        tiktoken_encoding: cl100k_base
+"""
+    (tmp_path / "mykg_config.yaml").write_text(cfg)
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(sys, "argv", ["context_calculator.py", "--from-config"])
+
+    mock_enc = MagicMock()
+    mock_enc.encode.side_effect = lambda text: [0] * len(text.split())
+    mock_tiktoken = MagicMock()
+    mock_tiktoken.get_encoding.return_value = mock_enc
+
+    with patch.dict(sys.modules, {"tiktoken": mock_tiktoken}):
+        from mykg.utility.context_calculator import main
+
+        main()
+
+    out = capsys.readouterr().out
+    assert "Token Budget Calculator" in out
+
+
+def test_main_from_config_errors_when_no_input_dir(tmp_path, monkeypatch):
+    """parser.error fires (line 441-444) when no input dir can be located."""
+    cfg = """\
+profile: p
+profiles:
+  p:
+    llm:
+      context_window: 32000
+      max_output_tokens: 8000
+    pipeline:
+      chunking:
+        tiktoken_encoding: cl100k_base
+"""
+    (tmp_path / "mykg_config.yaml").write_text(cfg)
+    monkeypatch.chdir(tmp_path)
+    # No input_files or _input_files directory exists
+    monkeypatch.setattr(sys, "argv", ["context_calculator.py", "--from-config"])
+
+    from mykg.utility.context_calculator import main
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code != 0
+
+
+def test_main_from_config_with_explicit_chunk_divisor(tmp_path, monkeypatch, capsys):
+    """When --chunk-divisor is supplied, the explicit-divisor branch (lines 453-465) runs."""
+    input_dir = tmp_path / "input_files"
+    input_dir.mkdir()
+    (input_dir / "doc.md").write_text("hello world")
+
+    cfg = """\
+profile: p
+profiles:
+  p:
+    llm:
+      context_window: 32000
+      max_output_tokens: 8000
+    pipeline:
+      chunking:
+        window_tokens: 2000
+        overlap_tokens: 200
+        tiktoken_encoding: cl100k_base
+      pass2:
+        prep_mode: concat
+"""
+    (tmp_path / "mykg_config.yaml").write_text(cfg)
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["context_calculator.py", "--from-config", "--chunk-divisor", "16"],
+    )
+
+    mock_enc = MagicMock()
+    mock_enc.encode.side_effect = lambda text: [0] * len(text.split())
+    mock_tiktoken = MagicMock()
+    mock_tiktoken.get_encoding.return_value = mock_enc
+
+    with patch.dict(sys.modules, {"tiktoken": mock_tiktoken}):
+        from mykg.utility.context_calculator import main
+
+        main()
+
+    out = capsys.readouterr().out
+    # explicit chunk_divisor=16 should be reflected in the YAML snippet
+    assert "32000" in out
+
+
 def test_main_from_config_mode_runs(tmp_path, monkeypatch, capsys):
     # Create a minimal corpus
     input_dir = tmp_path / "input_files"

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -295,3 +295,110 @@ def test_obsidian_return_value_includes_all_node_paths(tmp_path: Path) -> None:
     result = _run_obsidian(tmp_path)
     node_paths = [p for p in result if p != "obsidian_vault/index.md"]
     assert len(node_paths) == len(_OBS_NODES)
+
+
+# ---------------------------------------------------------------------------
+# Extra coverage: aliases / subClassOf / NX list flattening / obsidian fallback
+# ---------------------------------------------------------------------------
+
+
+def test_ttl_no_aliases_no_skos_prefix():
+    """When no node has aliases, the @prefix skos: line and altLabel triples are absent."""
+    ttl = export_ttl(SCHEMA, NODES, EDGE_METADATA)
+    assert "skos:altLabel" not in ttl
+    assert "@prefix skos:" not in ttl
+
+
+def test_ttl_with_aliases_emits_altLabel_and_skos_prefix():
+    """If at least one node has aliases, skos:altLabel triples + skos: prefix declaration appear."""
+    nodes_with_aliases = [
+        {
+            "id": "person-alice",
+            "type": "Person",
+            "confidence": 0.99,
+            "attributes": {"name": {"value": "Alice", "confidence": 0.99}},
+            "aliases": ["A. Smith", "Allie"],
+        },
+    ]
+    ttl = export_ttl(SCHEMA, nodes_with_aliases, {})
+    assert "@prefix skos:" in ttl
+    assert "skos:altLabel" in ttl
+    assert "A. Smith" in ttl
+    assert "Allie" in ttl
+
+
+def test_ttl_subclassof_branch():
+    """A concept whose parent is non-None emits an rdfs:subClassOf triple."""
+    schema = {
+        "concepts": [
+            {"type": "Person", "parent": None, "attributes": ["name"]},
+            {"type": "SoftwareEngineer", "parent": "Person", "attributes": []},
+        ],
+        "properties": [],
+    }
+    ttl = export_ttl(schema, [], {})
+    assert "ex:SoftwareEngineer rdfs:subClassOf ex:Person" in ttl
+
+
+def test_ttl_attribute_value_is_list_gets_joined():
+    """When an attribute's value is a list, export_ttl joins it with ', '."""
+    schema = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["nicknames"]}],
+        "properties": [],
+    }
+    nodes = [
+        {
+            "id": "person-alice",
+            "type": "Person",
+            "confidence": 0.9,
+            "attributes": {"nicknames": {"value": ["Al", "Ally"], "confidence": 0.9}},
+        }
+    ]
+    ttl = export_ttl(schema, nodes, {})
+    assert "Al, Ally" in ttl
+
+
+def test_nx_flatten_attributes_with_list_value():
+    """_nx_flatten_attributes joins list values with '|' for GML safety."""
+    from mykg.exporter import _nx_flatten_attributes
+
+    flat = _nx_flatten_attributes(
+        {"tags": {"value": ["python", "rust"], "confidence": 0.8}}
+    )
+    assert flat["attr_tags_value"] == "python|rust"
+    assert flat["attr_tags_confidence"] == 0.8
+
+
+def test_node_display_name_falls_back_to_id_when_no_name_attr():
+    """_node_display_name returns node['id'] when the 'name' attribute is absent."""
+    from mykg.exporter import _node_display_name
+
+    node = {"id": "person-noname", "attributes": {}}
+    assert _node_display_name(node) == "person-noname"
+
+
+def test_node_display_name_falls_back_when_name_value_falsy():
+    """If name attr exists but its value is empty, _node_display_name returns the id."""
+    from mykg.exporter import _node_display_name
+
+    node = {"id": "person-noname", "attributes": {"name": {"value": "", "confidence": 0.0}}}
+    assert _node_display_name(node) == "person-noname"
+
+
+def test_obsidian_entity_note_payload_not_dict_branch(tmp_path: Path) -> None:
+    """_obsidian_entity_note handles attribute payloads that are bare values, not dicts."""
+    from mykg.exporter import _obsidian_entity_note
+
+    node = {
+        "id": "person-bare",
+        "type": "Person",
+        "confidence": 0.8,
+        "attributes": {
+            "name": {"value": "Bare Person", "confidence": 1.0},
+            "raw_attr": "just-a-string",  # NOT a dict — exercises lines 737-738
+        },
+        "source_files": [],
+    }
+    content = _obsidian_entity_note(node, outgoing=[], incoming=[])
+    assert "just-a-string" in content
+    assert "raw_attr" in content

--- a/tests/test_extraction_edge_paths.py
+++ b/tests/test_extraction_edge_paths.py
@@ -126,3 +126,300 @@ def test_pass2_failed_chunk_recorded(tmp_path):
     entries = json.loads(failed_path.read_text())
     assert len(entries) > 0
     assert any(e["filename"] == "doc.md" for e in entries)
+
+
+# ---------------------------------------------------------------------------
+# Extended Unit 5 — pass2 edge paths
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_scalars_non_dict_node_attrs_replaced():
+    from mykg.pass2 import _normalize_scalars
+
+    extraction = {
+        "nodes": [
+            {"id": "p-1", "type": "Person", "attributes": "not-a-dict"},
+            {"id": "p-2", "type": "Person", "attributes": {"name": "Alice"}},
+            None,  # null item handled gracefully
+        ],
+        "edges": [
+            {"id": "e-1", "type": "x", "attributes": "string-not-dict"},
+            None,
+        ],
+    }
+    out = _normalize_scalars(extraction)
+    assert out["nodes"][0]["attributes"] == {}
+    # bare scalar coerced into wrapper
+    assert out["nodes"][1]["attributes"]["name"]["value"] == "Alice"
+    assert out["nodes"][1]["attributes"]["name"]["confidence"] > 0
+    assert out["edges"][0]["attributes"] == {}
+
+
+def test_backfill_extraction_handles_missing_attrs():
+    """_backfill_extraction adds null+0.0 for missing required attributes."""
+    from mykg.pass2 import _backfill_extraction
+
+    schema = {
+        "concepts": [{"type": "Person", "attributes": ["name", "email"]}],
+        "properties": [
+            {"name": "knows", "domain": "Person", "range": "Person", "attributes": ["since"]},
+        ],
+    }
+    flat = {"Person": ["name", "email"]}
+    extraction = {
+        "nodes": [
+            {"id": "p-1", "type": "Person", "attributes": {}},
+            None,
+        ],
+        "edges": [
+            {"type": "knows", "from": "p-1", "to": "p-1", "attributes": {}},
+            None,
+        ],
+    }
+    out = _backfill_extraction(extraction, schema, flat)
+    p1_attrs = out["nodes"][0]["attributes"]
+    assert p1_attrs["name"]["value"] is None
+    assert p1_attrs["email"]["confidence"] == 0.0
+    assert out["edges"][0]["attributes"]["since"]["value"] is None
+
+
+def test_build_schema_hint_block_with_matching_chunk():
+    """_build_schema_hint_block produces a non-empty hint when chunk_key matches."""
+    from mykg.pass2 import _build_schema_hint_block
+
+    hints = [
+        {
+            "orphan_id": "person-x",
+            "orphan_name": "Mr. X",
+            "orphan_type": "Person",
+            "new_properties": ["works_at"],
+            "shared_chunks": ["doc.md::1", "doc.md::3"],
+        }
+    ]
+    block = _build_schema_hint_block("doc.md::1", hints)
+    assert "SCHEMA ADDITION HINT" in block
+    assert "person-x" in block
+    assert "works_at" in block
+
+
+def test_build_schema_hint_block_no_match():
+    from mykg.pass2 import _build_schema_hint_block
+
+    hints = [
+        {
+            "orphan_id": "x",
+            "orphan_name": "X",
+            "orphan_type": "Person",
+            "new_properties": [],
+            "shared_chunks": ["doc.md::5"],
+        }
+    ]
+    assert _build_schema_hint_block("doc.md::99", hints) == ""
+
+
+def test_fmt_elapsed():
+    from mykg.pass2 import _fmt_elapsed
+
+    assert "h" in _fmt_elapsed(3661)
+    assert "m" in _fmt_elapsed(120)
+
+
+def test_validate_extraction_returns_early_on_structural_errors():
+    """Missing top-level keys / empty extraction should produce errors."""
+    from mykg.pass2 import validate_extraction
+
+    schema = {
+        "concepts": [{"type": "Person", "attributes": ["name"]}],
+        "properties": [],
+    }
+    flat = {"Person": ["name"]}
+    errors = validate_extraction({}, schema, flat)
+    assert any("Missing required top-level key" in e for e in errors)
+
+
+def test_dedup_within_file_keeps_higher_confidence():
+    from mykg.pass2 import _dedup_within_file
+
+    a = {
+        "id": "person-1",
+        "type": "Person",
+        "attributes": {
+            "name": {"value": "Alice", "confidence": 0.7},
+            "email": {"value": "a@x", "confidence": 0.9},
+        },
+    }
+    b = {
+        "id": "person-2",
+        "type": "Person",
+        "attributes": {
+            "name": {"value": "Alice", "confidence": 0.9},
+        },
+    }
+    out = _dedup_within_file([a, b])
+    assert len(out) == 1
+    # Higher-confidence name wins
+    assert out[0]["attributes"]["name"]["confidence"] == 0.9
+    # email comes from a
+    assert out[0]["attributes"]["email"]["value"] == "a@x"
+
+
+def test_run_pass2_stateful_chunks_carries_prior_nodes(monkeypatch):
+    """When stateful_chunks=True, prior nodes are passed to subsequent chunks."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_STATEFUL_CHUNKS", True)
+
+    calls = []
+
+    class Adapter(LLMAdapter):
+        def complete(self, system, user, context_label="", max_tokens=None, timeout=None):
+            calls.append(user)
+            return json.dumps(
+                {
+                    "nodes": [
+                        {
+                            "id": "person-alice",
+                            "type": "Person",
+                            "attributes": {"name": {"value": "Alice", "confidence": 0.9}},
+                        }
+                    ],
+                    "edges": [],
+                }
+            )
+
+        def endpoint_label(self) -> str:
+            return "mock"
+
+    files = {"doc.md": "Alice. " * 1500}  # multiple chunks
+    result, _idx, _failed = run_pass2(files, SCHEMA, FLAT_SCHEMA, Adapter(), max_workers=1)
+    assert "doc.md" in result
+    # Second call should include "NODES ALREADY EXTRACTED" block
+    if len(calls) > 1:
+        assert any("NODES ALREADY EXTRACTED" in c for c in calls[1:])
+
+
+def test_run_pass2_skip_files():
+    """skip_files removes those entries from processing."""
+
+    class Adapter(LLMAdapter):
+        def complete(self, system, user, context_label="", max_tokens=None, timeout=None):
+            return json.dumps({"nodes": [], "edges": []})
+
+        def endpoint_label(self) -> str:
+            return "mock"
+
+    files = {"doc1.md": "content", "doc2.md": "content"}
+    result, _idx, _failed = run_pass2(
+        files, SCHEMA, FLAT_SCHEMA, Adapter(), skip_files={"doc2.md"}, max_workers=1
+    )
+    assert "doc1.md" in result
+    assert "doc2.md" not in result
+
+
+def test_run_pass2_on_file_done_callback():
+    """on_file_done callback receives per-file results."""
+
+    class Adapter(LLMAdapter):
+        def complete(self, system, user, context_label="", max_tokens=None, timeout=None):
+            return json.dumps({"nodes": [], "edges": []})
+
+        def endpoint_label(self) -> str:
+            return "mock"
+
+    seen = []
+
+    def on_done(fname, result, idx):
+        seen.append((fname, result, idx))
+
+    run_pass2(
+        {"doc.md": "content"},
+        SCHEMA,
+        FLAT_SCHEMA,
+        Adapter(),
+        on_file_done=on_done,
+        max_workers=1,
+    )
+    assert seen
+    assert seen[0][0] == "doc.md"
+
+
+def test_run_pass2_surgical_reextract_chunks(monkeypatch):
+    """reextract_chunks confines processing to specific 1-based chunk indices."""
+
+    class Adapter(LLMAdapter):
+        def complete(self, system, user, context_label="", max_tokens=None, timeout=None):
+            return json.dumps(
+                {
+                    "nodes": [
+                        {
+                            "id": "p-new",
+                            "type": "Person",
+                            "attributes": {"name": {"value": "NewPerson", "confidence": 1.0}},
+                        }
+                    ],
+                    "edges": [],
+                }
+            )
+
+        def endpoint_label(self) -> str:
+            return "mock-surgical"
+
+    files = {"doc.md": "Alice. " * 1500}  # multiple chunks
+    prior_data = {
+        "doc.md": {
+            "nodes": [
+                {
+                    "id": "p-prior",
+                    "type": "Person",
+                    "attributes": {"name": {"value": "Prior", "confidence": 0.9}},
+                }
+            ],
+            "edges": [],
+        }
+    }
+    prior_idx = {"doc.md": {"1": ["person-prior"]}}
+
+    result, _idx, _failed = run_pass2(
+        files,
+        SCHEMA,
+        FLAT_SCHEMA,
+        Adapter(),
+        reextract_chunks={"doc.md": {2}},
+        prior_extractions=prior_data,
+        prior_chunk_index=prior_idx,
+        max_workers=1,
+    )
+    # The surgical pass should preserve prior node + add new one
+    node_ids = {n["id"] for n in result["doc.md"]["nodes"]}
+    assert "p-prior" in node_ids
+
+
+def test_partial_recover_with_unknown_node_type():
+    """Nodes with type not in schema concepts are dropped."""
+    from mykg.pass2 import _partial_recover
+
+    extraction = {
+        "nodes": [
+            {"id": "alien-1", "type": "Alien", "attributes": {}},
+            {"id": "p-1", "type": "Person", "attributes": {}},
+        ],
+        "edges": [],
+    }
+    result = _partial_recover(extraction, SCHEMA, prior_nodes=None)
+    node_ids = {n["id"] for n in result["nodes"]}
+    assert "alien-1" not in node_ids
+
+
+def test_extract_chunk_returns_none_on_blank_retry():
+    """_extract_chunk returns None when both initial and retry responses are blank."""
+    from mykg.pass2 import _extract_chunk
+
+    class BlankAdapter(LLMAdapter):
+        def complete(self, system, user, context_label="", max_tokens=None, timeout=None):
+            return ""
+
+        def endpoint_label(self) -> str:
+            return "mock-blank"
+
+    result = _extract_chunk("text", SCHEMA, FLAT_SCHEMA, BlankAdapter(), chunk_idx=1)
+    assert result is None

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -159,6 +159,82 @@ def test_fix_normalization_raises_on_bad_structure(tmp_path):
     assert result["mappings"]["Person"]["Alice"] == "Alice Smith"
 
 
+def test_fix_schema_deletes_stale_flattened_file(tmp_path):
+    """_fix_schema deletes flattened_schema.json when it exists (lines 68-70)."""
+    ctx = _make_ctx(tmp_path)
+    (ctx.intermediate_dir / "schema.json").write_text(
+        json.dumps({"concepts": [], "properties": []})
+    )
+    # Pre-create a stale flattened_schema.json — _fix_schema must delete it
+    flattened_path = ctx.intermediate_dir / "flattened_schema.json"
+    flattened_path.write_text("{}")
+    assert flattened_path.exists()
+
+    corrected = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
+    ctx.adapter.complete.return_value = json.dumps(corrected)
+
+    apply("schema_validate", "some rdfs error", ctx)
+
+    # File must have been removed because schema was corrected
+    assert not flattened_path.exists()
+
+
+def test_fix_orphan_connect_writes_corrected_connections(tmp_path):
+    """_fix_orphan_connect writes corrected JSON to orphan_connections.json (lines 135-158)."""
+    ctx = _make_ctx(tmp_path)
+
+    # Set up candidates + a stale connections file
+    candidates = {"groups": [{"filename": "f.md", "chunk_idx": 0, "orphan_ids": ["x"]}]}
+    (ctx.intermediate_dir / "orphan_candidates.json").write_text(json.dumps(candidates))
+    stale = {"edge-bad": {"type": "wrong", "from": "x", "to": "y"}}
+    connections_path = ctx.intermediate_dir / "orphan_connections.json"
+    connections_path.write_text(json.dumps(stale))
+
+    corrected = {
+        "edge-good": {
+            "type": "knows",
+            "from": "x",
+            "to": "y",
+            "confidence": 0.8,
+            "method": "orphan_inferred",
+        }
+    }
+    ctx.adapter.complete.return_value = json.dumps(corrected)
+
+    result = apply("orphan_connect", "edge type 'wrong' not in schema", ctx)
+    assert result is True
+
+    written = json.loads(connections_path.read_text())
+    assert "edge-good" in written
+    assert written["edge-good"]["type"] == "knows"
+
+
+def test_fix_orphan_connect_no_existing_candidates_or_connections(tmp_path):
+    """_fix_orphan_connect tolerates missing candidates/connections files (defaults '{}')."""
+    ctx = _make_ctx(tmp_path)
+    # Neither orphan_candidates.json nor orphan_connections.json exists
+
+    corrected = {"edge-1": {"type": "knows", "from": "a", "to": "b", "confidence": 0.5}}
+    ctx.adapter.complete.return_value = json.dumps(corrected)
+
+    apply("orphan_connect", "some error", ctx)
+
+    out = json.loads((ctx.intermediate_dir / "orphan_connections.json").read_text())
+    assert "edge-1" in out
+
+
+def test_fix_orphan_connect_raises_on_non_dict(tmp_path):
+    """_fix_orphan_connect raises ValueError when LLM returns non-dict JSON."""
+    ctx = _make_ctx(tmp_path)
+    ctx.adapter.complete.return_value = json.dumps(["not", "a", "dict"])
+
+    with pytest.raises(ValueError, match="invalid orphan_connections structure"):
+        apply("orphan_connect", "some error", ctx)
+
+
 def test_orchestrator_llm_correction_false_when_no_handler(tmp_path):
     """pipeline_state.json must not record llm_correction_applied=True when no handler ran."""
     import json as _json

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -1036,6 +1036,138 @@ def _load_openrouter_api_key() -> str | None:
     return key or None
 
 
+def test_openrouter_endpoint_label_includes_model_and_base_url():
+    """endpoint_label() returns a string with model and base URL (line 59)."""
+    with patch("openai.OpenAI"):
+        from mykg.llm.openrouter_adapter import OpenRouterAdapter
+
+        adapter = OpenRouterAdapter(
+            model="some/model",
+            max_tokens=100,
+            timeout=10,
+            api_key="test-key",
+        )
+        label = adapter.endpoint_label()
+    assert "some/model" in label
+    assert "openrouter.ai" in label
+
+
+def test_openrouter_wall_clock_timeout_raises_timeouterror(monkeypatch):
+    """When future.result raises concurrent.futures.TimeoutError, the adapter raises
+    TimeoutError and records the call with the timeout error annotation (lines 94-109)."""
+    import concurrent.futures as _cf
+
+    class _SlowFuture:
+        def result(self, timeout=None):
+            raise _cf.TimeoutError
+
+    class _FakeExec:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def submit(self, fn):
+            return _SlowFuture()
+
+    with (
+        patch("openai.OpenAI"),
+        patch("mykg.llm.openrouter_adapter.concurrent.futures.ThreadPoolExecutor", _FakeExec),
+        patch("mykg.llm.openrouter_adapter.record_llm_call") as mock_record,
+    ):
+        from mykg.llm.openrouter_adapter import OpenRouterAdapter
+
+        adapter = OpenRouterAdapter(
+            model="m",
+            max_tokens=10,
+            timeout=1,
+            api_key="test-key",
+            retry_429_max=0,  # don't retry through the rate-limit harness
+        )
+        with pytest.raises(TimeoutError, match="wall-clock timeout"):
+            adapter.complete("s", "u", context_label="ctx-tw")
+
+    # record_llm_call should have been invoked with the wall-clock error
+    found = any(
+        "wall-clock timeout" in str(c.kwargs.get("error", ""))
+        for c in mock_record.call_args_list
+    )
+    assert found, "record_llm_call should record the wall-clock timeout error"
+
+
+def test_openrouter_api_status_error_4xx_records_and_raises():
+    """APIStatusError with status<500 is recorded and re-raised (lines 129-141, 150)."""
+    import openai
+
+    api_err = openai.APIStatusError(
+        message="bad request",
+        response=MagicMock(status_code=400, headers={}),
+        body={"error": {"message": "bad request"}},
+    )
+
+    with (
+        patch("openai.OpenAI") as mock_cls,
+        patch("mykg.llm.openrouter_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = api_err
+
+        from mykg.llm.openrouter_adapter import OpenRouterAdapter
+
+        adapter = OpenRouterAdapter(
+            model="m",
+            max_tokens=10,
+            timeout=10,
+            api_key="test-key",
+            retry_429_max=0,
+        )
+        with pytest.raises(openai.APIStatusError):
+            adapter.complete("s", "u")
+
+    # A 4xx is recorded with status_code in the metadata
+    call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
+    assert any(k.get("status_code") == 400 for k in call_kwargs_list)
+
+
+def test_openrouter_api_status_error_5xx_converted_to_rate_limit(monkeypatch):
+    """APIStatusError with status>=500 is converted to RateLimitError (lines 144-149)."""
+    import openai
+
+    api_err = openai.APIStatusError(
+        message="upstream",
+        response=MagicMock(status_code=502, headers={}),
+        body={"error": {"message": "upstream"}},
+    )
+
+    with (
+        patch("openai.OpenAI") as mock_cls,
+        patch("mykg.llm.openrouter_adapter.record_llm_call"),
+        patch("time.sleep"),
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = api_err
+
+        from mykg.llm.openrouter_adapter import OpenRouterAdapter
+
+        adapter = OpenRouterAdapter(
+            model="m",
+            max_tokens=10,
+            timeout=10,
+            api_key="test-key",
+            retry_429_max=1,
+            retry_429_base_delay=0.0,
+        )
+        # The 5xx is converted to RateLimitError, which after retries surfaces
+        with pytest.raises(openai.RateLimitError):
+            adapter.complete("s", "u")
+
+
 @pytest.mark.live
 def test_openrouter_live_call_respects_timeout():
     """Live call: confirms the adapter actually connects and returns a non-empty response

--- a/tests/test_log_rotation.py
+++ b/tests/test_log_rotation.py
@@ -209,6 +209,164 @@ def test_adapter_passes_prompts_to_record(tmp_path):
     assert captured.get("user_prompt") == "USER PROMPT"
 
 
+def test_setup_with_no_log_file_adds_no_file_handler(tmp_path):
+    """setup(log_file=None) attaches only a stdout handler; _llm_handler and _prompt_dir reset."""
+    import logging
+
+    import mykg.logging as mykg_logging
+
+    mykg_logging.setup(log_file=None)
+    root = logging.getLogger()
+    file_handlers = [
+        h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]
+    assert file_handlers == []
+    assert mykg_logging._llm_handler is None
+    assert mykg_logging._llm_log_path is None
+    assert mykg_logging._prompt_dir is None
+
+
+def test_color_formatter_wraps_known_levels():
+    """_ColorFormatter wraps messages for known log levels with ANSI codes."""
+    from mykg.logging import LOG_FORMAT, _ColorFormatter
+
+    fmt = _ColorFormatter(LOG_FORMAT)
+    record = logging.makeLogRecord(
+        {"name": "x", "levelname": "INFO", "levelno": logging.INFO, "msg": "hello"}
+    )
+    out = fmt.format(record)
+    # ANSI reset is appended when a known color is matched
+    assert out.endswith("\033[0m")
+    assert "hello" in out
+
+
+def test_color_formatter_no_color_for_unknown_level():
+    """_ColorFormatter does not wrap when levelname is not in _LEVEL_COLORS."""
+    from mykg.logging import LOG_FORMAT, _ColorFormatter
+
+    fmt = _ColorFormatter(LOG_FORMAT)
+    record = logging.makeLogRecord(
+        {"name": "x", "levelname": "TRACE", "levelno": 5, "msg": "hello"}
+    )
+    out = fmt.format(record)
+    assert "\033[" not in out  # no ANSI escape sequence
+
+
+def test_setup_creates_prompt_dir_when_capture_prompts_enabled(tmp_path):
+    """setup() creates intermediate/llm_calls/ when LOG_CAPTURE_PROMPTS is True."""
+    from unittest.mock import patch
+
+    import mykg.logging as mykg_logging
+
+    log_file = tmp_path / "run.log"
+    with patch("mykg.config.LOG_CAPTURE_PROMPTS", True):
+        mykg_logging.setup(log_file=log_file)
+    assert mykg_logging._prompt_dir is not None
+    assert mykg_logging._prompt_dir.exists()
+    assert mykg_logging._prompt_dir.name == "llm_calls"
+
+
+def test_setup_no_prompt_dir_when_capture_prompts_disabled(tmp_path):
+    """setup() leaves _prompt_dir None when LOG_CAPTURE_PROMPTS is False."""
+    from unittest.mock import patch
+
+    import mykg.logging as mykg_logging
+
+    log_file = tmp_path / "run.log"
+    with patch("mykg.config.LOG_CAPTURE_PROMPTS", False):
+        mykg_logging.setup(log_file=log_file)
+    assert mykg_logging._prompt_dir is None
+
+
+def test_write_prompt_files_noop_when_dir_is_none(tmp_path):
+    """write_prompt_files is a no-op when _prompt_dir is None."""
+    import mykg.logging as mykg_logging
+
+    mykg_logging.setup(log_file=None)
+    assert mykg_logging._prompt_dir is None
+    # Must not raise nor write anything
+    mykg_logging.write_prompt_files(
+        n=1,
+        context_label="x",
+        system_prompt="s",
+        user_prompt="u",
+        response="r",
+    )
+
+
+def test_record_llm_call_invalid_token_type_returns_silently(tmp_path):
+    """record_llm_call returns silently when token counts can't be coerced to int."""
+    from unittest.mock import patch
+
+    import mykg.logging as mykg_logging
+
+    log_file = tmp_path / "run.log"
+    with patch("mykg.config.LOG_LLM_LOG", True):
+        mykg_logging.setup(log_file=log_file)
+    before_counter = mykg_logging._call_counter
+
+    # Pass a non-coercible value to trigger the (TypeError, ValueError) branch
+    mykg_logging.record_llm_call(
+        provider="p",
+        model="m",
+        context_label="ctx",
+        input_tokens="not-a-number",  # type: ignore[arg-type]
+        output_tokens=5,
+        duration_s=0.1,
+    )
+    # Counter must not have advanced
+    assert mykg_logging._call_counter == before_counter
+
+
+def test_record_llm_call_status_code_and_error_branches(tmp_path):
+    """record_llm_call adds status_code/error fields when provided."""
+    from unittest.mock import patch
+
+    import mykg.logging as mykg_logging
+
+    log_file = tmp_path / "run.log"
+    with patch("mykg.config.LOG_LLM_LOG", True):
+        mykg_logging.setup(log_file=log_file)
+
+    mykg_logging.record_llm_call(
+        provider="p",
+        model="m",
+        context_label="ctx-err",
+        input_tokens=0,
+        output_tokens=0,
+        duration_s=0.0,
+        status_code=429,
+        error="rate-limited",
+    )
+    # Flush handler so the entry hits disk
+    mykg_logging._llm_handler.flush()
+    contents = (tmp_path / "llm.log").read_text(encoding="utf-8")
+    assert '"status_code": 429' in contents
+    assert '"error": "rate-limited"' in contents
+
+
+def test_record_llm_call_noop_when_handler_is_none(tmp_path):
+    """record_llm_call short-circuits when LOG_LLM_LOG is False (no _llm_handler)."""
+    from unittest.mock import patch
+
+    import mykg.logging as mykg_logging
+
+    log_file = tmp_path / "run.log"
+    # With LOG_LLM_LOG False (the default), _llm_handler should be None
+    with patch("mykg.config.LOG_LLM_LOG", False):
+        mykg_logging.setup(log_file=log_file)
+    assert mykg_logging._llm_handler is None
+    # Should be a clean no-op
+    mykg_logging.record_llm_call(
+        provider="p",
+        model="m",
+        context_label="ctx",
+        input_tokens=1,
+        output_tokens=1,
+        duration_s=0.1,
+    )
+
+
 def test_call_counter_increments_per_call(tmp_path):
     """record_llm_call increments the global counter for each call."""
     from unittest.mock import patch

--- a/tests/test_merge_run.py
+++ b/tests/test_merge_run.py
@@ -440,6 +440,95 @@ def test_run_merge_non_blocking_step_continues_after_failure(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_run_merge_waits_at_human_review_when_review_enabled(tmp_path):
+    """When ctx.review=True and the approval flag is absent, the pipeline pauses at human_review."""
+    ctx = _make_ctx(tmp_path, review=True)
+
+    seen_steps: list[str] = []
+
+    def try_run_side_effect(step, ctx_arg):
+        seen_steps.append(step.name)
+        return None
+
+    # human_review step is the only one with requires_review_flag=True
+    with (
+        patch("mykg.merge_run._try_run", side_effect=try_run_side_effect),
+        patch("mykg.merge_run._is_done", return_value=False),
+        patch("mykg.merge_run._review_flag_exists", return_value=False),
+        patch("mykg.merge_run.log") as mock_log,
+    ):
+        run_merge(ctx)  # must return cleanly (no exception)
+
+    # Steps after human_review should NOT have been attempted
+    assert "human_review" not in seen_steps
+    # The merge run should have logged the WAITING message and returned
+    info_msgs = " ".join(str(c) for c in mock_log.info.call_args_list)
+    assert "WAITING" in info_msgs
+
+    # pipeline_state.json must have written human_review as waiting
+    state_path = ctx.intermediate_dir / "pipeline_state.json"
+    state = json.loads(state_path.read_text())
+    assert state["steps"]["human_review"]["status"] == "waiting"
+
+
+def test_run_merge_feedback_path_triggered_on_llm_step_failure(tmp_path):
+    """When an LLM step fails on retry, feedback.apply is called (lines 213-219)."""
+    ctx = _make_ctx(tmp_path)
+
+    # merge_schema is an is_llm_step=True step
+    llm_step_name = next(s.name for s in MERGE_STEPS if s.is_llm_step)
+
+    def try_run_side_effect(step, ctx_arg):
+        if step.name == llm_step_name:
+            return f"simulated {step.name} error"
+        return None
+
+    with (
+        patch("mykg.merge_run._try_run", side_effect=try_run_side_effect),
+        patch("mykg.merge_run._is_done", return_value=False),
+        patch("mykg.feedback.apply") as mock_feedback,
+        patch("mykg.merge_run.log"),
+    ):
+        mock_feedback.return_value = True
+        # Will raise PipelineHaltError because the step keeps failing and is blocking
+        try:
+            run_merge(ctx)
+        except PipelineHaltError:
+            pass
+
+    assert mock_feedback.called
+    # The first positional arg should be the step name
+    first_call_args = mock_feedback.call_args[0]
+    assert first_call_args[0] == llm_step_name
+
+
+def test_run_merge_feedback_handler_exception_logged_not_raised(tmp_path):
+    """If feedback.apply raises, the merge_run catches and logs but does not crash."""
+    ctx = _make_ctx(tmp_path)
+
+    llm_step_name = next(s.name for s in MERGE_STEPS if s.is_llm_step)
+
+    def try_run_side_effect(step, ctx_arg):
+        if step.name == llm_step_name:
+            return f"simulated {step.name} error"
+        return None
+
+    with (
+        patch("mykg.merge_run._try_run", side_effect=try_run_side_effect),
+        patch("mykg.merge_run._is_done", return_value=False),
+        patch("mykg.feedback.apply", side_effect=RuntimeError("feedback exploded")),
+        patch("mykg.merge_run.log") as mock_log,
+    ):
+        try:
+            run_merge(ctx)
+        except PipelineHaltError:
+            pass
+
+    # The "Feedback handler failed" warning should have been logged
+    warning_messages = " ".join(str(c) for c in mock_log.warning.call_args_list)
+    assert "Feedback handler failed" in warning_messages
+
+
 def test_run_merge_keyboard_interrupt_saved_to_state(tmp_path):
     """KeyboardInterrupt during a step saves the step as failed before re-raising."""
     ctx = _make_ctx(tmp_path)

--- a/tests/test_merge_step_units.py
+++ b/tests/test_merge_step_units.py
@@ -1,0 +1,217 @@
+"""Unit tests for the merge-pipeline step modules.
+
+Covers:
+- step_merge_raw.run_merge_raw  — cold re-entry path, namespacing skip-when-already-namespaced,
+  malformed chunk shard skip, JSON-decode error skip.
+- step_merge_schema.run_merge_schema  — RuntimeError when sessions are missing,
+  base_schema lock injection branch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mykg.merge_context import MergeContext
+from mykg.steps.step_merge_raw import run_merge_raw
+from mykg.steps.step_merge_schema import run_merge_schema
+
+
+def _make_session_on_disk(sessions_root: Path, name: str) -> Path:
+    """Create a minimal session directory laid out as load_session expects."""
+    root = sessions_root / name
+    (root / "intermediate").mkdir(parents=True, exist_ok=True)
+    (root / "output").mkdir(parents=True, exist_ok=True)
+    (root / "input").mkdir(parents=True, exist_ok=True)
+    schema = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
+    raw = {f"{name}/x.md": {"nodes": [], "edges": []}}
+    (root / "intermediate" / "schema.json").write_text(json.dumps(schema), encoding="utf-8")
+    (root / "intermediate" / "raw_extractions.json").write_text(json.dumps(raw), encoding="utf-8")
+    return root
+
+
+def _make_ctx(tmp_path: Path) -> MergeContext:
+    sessions_root = tmp_path / "sessions"
+    sessions_root.mkdir(parents=True, exist_ok=True)
+    _make_session_on_disk(sessions_root, "sess-a")
+    _make_session_on_disk(sessions_root, "sess-b")
+
+    intermediate = tmp_path / "intermediate"
+    intermediate.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "output").mkdir(parents=True, exist_ok=True)
+
+    return MergeContext(
+        session_a_name="sess-a",
+        session_b_name="sess-b",
+        sessions_root=sessions_root,
+        input_dir=tmp_path / "input",
+        output_dir=tmp_path / "output",
+        intermediate_dir=intermediate,
+        adapter=None,
+        review=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# step_merge_raw
+# ---------------------------------------------------------------------------
+
+
+def test_merge_raw_cold_reentry_loads_sessions(tmp_path):
+    """When ctx.session_a is None, run_merge_raw reloads both sessions from disk (lines 24-28)."""
+    ctx = _make_ctx(tmp_path)
+    assert ctx.session_a is None and ctx.session_b is None
+
+    run_merge_raw(ctx)
+    # Sessions must now be loaded
+    assert ctx.session_a is not None
+    assert ctx.session_b is not None
+    # Output files written
+    assert (ctx.intermediate_dir / "raw_extractions.json").exists()
+    assert (ctx.intermediate_dir / "raw_extractions.done").exists()
+    assert (ctx.intermediate_dir / "name_normalization.json").exists()
+    assert (ctx.intermediate_dir / "chunk_node_index.json").exists()
+
+
+def test_merge_raw_skips_already_namespaced_raw(tmp_path):
+    """When raw_extractions are already namespaced, the namespace step is skipped (lines 34, 36 skipped)."""
+    from mykg.merger import SessionData
+
+    ctx = _make_ctx(tmp_path)
+    # Manually populate session_a / session_b with already-namespaced keys
+    ctx.session_a = SessionData(
+        name="sess-a",
+        path=tmp_path / "sessions" / "sess-a",
+        schema={"concepts": [], "properties": []},
+        raw_extractions={"session_a/file.md": {"nodes": [], "edges": []}},
+        shards={},
+        manifest={},
+        prep_mode="per_file",
+    )
+    ctx.session_b = SessionData(
+        name="sess-b",
+        path=tmp_path / "sessions" / "sess-b",
+        schema={"concepts": [], "properties": []},
+        raw_extractions={"session_b/file.md": {"nodes": [], "edges": []}},
+        shards={},
+        manifest={},
+        prep_mode="per_file",
+    )
+
+    # If both inputs are already namespaced, the branches at lines 33-36 are skipped
+    run_merge_raw(ctx)
+
+    merged = json.loads((ctx.intermediate_dir / "raw_extractions.json").read_text())
+    assert "session_a/file.md" in merged
+    assert "session_b/file.md" in merged
+
+
+def test_merge_raw_skips_malformed_shard(tmp_path):
+    """run_merge_raw warns and skips shards that are not valid JSON or have wrong structure."""
+    ctx = _make_ctx(tmp_path)
+
+    shards_dir = ctx.intermediate_dir / "chunk_index_shards"
+    shards_dir.mkdir(parents=True, exist_ok=True)
+
+    # Shard 1 — valid JSON, good shape (will be included)
+    (shards_dir / "good.json").write_text(
+        json.dumps({"_fname": "session_a/x.md", "data": {"0": ["n1"]}}),
+        encoding="utf-8",
+    )
+    # Shard 2 — invalid JSON (triggers JSONDecodeError -> lines 59-63)
+    (shards_dir / "bad.json").write_text("{not valid json", encoding="utf-8")
+    # Shard 3 — valid JSON but missing _fname (triggers lines 67-68)
+    (shards_dir / "incomplete.json").write_text(
+        json.dumps({"data": {"0": ["n2"]}}), encoding="utf-8"
+    )
+    # Shard 4 — valid JSON but `data` is not a dict (triggers lines 67-68 as well)
+    (shards_dir / "wrong_type.json").write_text(
+        json.dumps({"_fname": "session_b/y.md", "data": "oops"}), encoding="utf-8"
+    )
+
+    run_merge_raw(ctx)
+
+    cni = json.loads((ctx.intermediate_dir / "chunk_node_index.json").read_text())
+    assert "session_a/x.md" in cni
+    # Bad / incomplete shards must NOT have made it in
+    assert "session_b/y.md" not in cni
+
+
+def test_merge_raw_does_not_overwrite_existing_norm_file(tmp_path):
+    """run_merge_raw must NOT overwrite an existing name_normalization.json (line 46 branch)."""
+    ctx = _make_ctx(tmp_path)
+    norm = ctx.intermediate_dir / "name_normalization.json"
+    norm.write_text(json.dumps({"mappings": {"Person": {"Alice": "Alice Smith"}}}), encoding="utf-8")
+
+    run_merge_raw(ctx)
+
+    after = json.loads(norm.read_text())
+    assert after["mappings"]["Person"]["Alice"] == "Alice Smith"
+
+
+# ---------------------------------------------------------------------------
+# step_merge_schema
+# ---------------------------------------------------------------------------
+
+
+def test_merge_schema_raises_when_sessions_missing(tmp_path):
+    """run_merge_schema must raise RuntimeError when session_a/session_b are not set (line 20)."""
+    ctx = _make_ctx(tmp_path)
+    assert ctx.session_a is None and ctx.session_b is None
+
+    with pytest.raises(RuntimeError, match="merge_setup"):
+        run_merge_schema(ctx)
+
+
+def test_merge_schema_uses_locked_classes_from_base_schema(tmp_path):
+    """When ctx.base_schema is set, locked_classes/locked_properties are extracted (lines 27-28)."""
+    from mykg.merger import SessionData
+
+    ctx = _make_ctx(tmp_path)
+    ctx.session_a = SessionData(
+        name="sess-a",
+        path=tmp_path / "sessions" / "sess-a",
+        schema={"concepts": [], "properties": []},
+        raw_extractions={},
+        shards={},
+        manifest={},
+        prep_mode="per_file",
+    )
+    ctx.session_b = SessionData(
+        name="sess-b",
+        path=tmp_path / "sessions" / "sess-b",
+        schema={"concepts": [], "properties": []},
+        raw_extractions={},
+        shards={},
+        manifest={},
+        prep_mode="per_file",
+    )
+    ctx.base_schema = {
+        "locked_classes": {"Person": {"attributes": ["name"]}},
+        "locked_properties": {"works_at": {"domain": "Person", "range": "Org"}},
+    }
+
+    captured = {}
+
+    def fake_merge(schema_a, schema_b, thesaurus, locked_classes, locked_properties):
+        captured["locked_classes"] = locked_classes
+        captured["locked_properties"] = locked_properties
+        return ({"concepts": [], "properties": []}, [])
+
+    def fake_harmonize(merged, _proposals, _adapter):
+        return merged
+
+    with (
+        patch("mykg.steps.step_merge_schema.merge_session_schemas", side_effect=fake_merge),
+        patch("mykg.steps.step_merge_schema.harmonize_merged_schema", side_effect=fake_harmonize),
+    ):
+        run_merge_schema(ctx)
+
+    assert "Person" in captured["locked_classes"]
+    assert "works_at" in captured["locked_properties"]

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -880,3 +880,245 @@ def test_build_targeted_top_k_variations(top_k):
     assert result is not None
     total_chunks = sum(len(v) for v in result.values())
     assert total_chunks <= top_k
+
+
+# ---------------------------------------------------------------------------
+# Extended Unit 7 — missing-line coverage
+# ---------------------------------------------------------------------------
+
+
+def test_copy_session_into_merged_copies_schema_history(tmp_path):
+    """copy_session_into_merged copies schema_history/ entries with alias prefix."""
+    from pathlib import Path
+
+    from mykg.merger import SessionData, copy_session_into_merged
+
+    src = tmp_path / "src_session"
+    src_inter = src / "intermediate"
+    hist_dir = src_inter / "schema_history"
+    hist_dir.mkdir(parents=True)
+    (hist_dir / "001_pass1.json").write_text("{}")
+    (hist_dir / "002_quality.json").write_text("{}")
+
+    merged_inter = tmp_path / "merged" / "intermediate"
+    merged_inter.mkdir(parents=True)
+
+    session = SessionData(
+        name="src",
+        path=src,
+        schema={},
+        raw_extractions={},
+        shards={},
+        manifest={},
+        prep_mode="per_file",
+    )
+    copy_session_into_merged(session, merged_inter, alias="session_a")
+    out = list((merged_inter / "schema_history").iterdir())
+    names = {p.name for p in out}
+    assert "session_a_001_pass1.json" in names
+    assert "session_a_002_quality.json" in names
+
+
+def test_build_merged_manifest_namespaces_keys():
+    """build_merged_manifest produces namespaced keys for both sessions."""
+    from pathlib import Path
+
+    from mykg.merger import SessionData, build_merged_manifest
+
+    s_a = SessionData(
+        name="a",
+        path=Path("."),
+        schema={},
+        raw_extractions={},
+        shards={},
+        manifest={"doc.md": {"sha256": "x"}, "other.md": {}},
+        prep_mode="per_file",
+    )
+    s_b = SessionData(
+        name="b",
+        path=Path("."),
+        schema={},
+        raw_extractions={},
+        shards={},
+        manifest={"doc.md": {"sha256": "y"}},
+        prep_mode="per_file",
+    )
+    merged = build_merged_manifest(s_a, s_b)
+    assert "session_a/doc.md" in merged
+    assert "session_a/other.md" in merged
+    assert "session_b/doc.md" in merged
+
+
+def test_reextract_for_merge_strategy_none():
+    """strategy='none' returns the input untouched."""
+    from pathlib import Path
+
+    raw = {"session_a/doc.md": {"nodes": [], "edges": []}}
+    result = reextract_for_merge(
+        session_alias="session_a",
+        session_path=Path("."),
+        raw_extractions_namespaced=raw,
+        merged_schema={"concepts": [], "properties": []},
+        flattened_schema={},
+        intermediate_dir=Path("."),
+        adapter=None,
+        config={},
+        strategy="none",
+    )
+    assert result is raw
+
+
+def test_reextract_for_merge_invalid_strategy():
+    """Unknown strategy raises ValueError."""
+    from pathlib import Path
+
+    with pytest.raises(ValueError, match="Unknown reextraction_strategy"):
+        reextract_for_merge(
+            session_alias="session_a",
+            session_path=Path("."),
+            raw_extractions_namespaced={},
+            merged_schema={},
+            flattened_schema={},
+            intermediate_dir=Path("."),
+            adapter=None,
+            config={},
+            strategy="bogus",
+        )
+
+
+def test_reextract_for_merge_surgical_no_delta(tmp_path):
+    """strategy='surgical' with no schema delta returns input unchanged."""
+    original_schema = {"concepts": [], "properties": [{"name": "knows"}]}
+    merged_schema = {"concepts": [], "properties": [{"name": "knows"}]}
+    raw = {"session_a/doc.md": {"nodes": [], "edges": []}}
+
+    result = reextract_for_merge(
+        session_alias="session_a",
+        session_path=tmp_path / "src",
+        raw_extractions_namespaced=raw,
+        merged_schema=merged_schema,
+        flattened_schema={},
+        intermediate_dir=tmp_path / "inter",
+        adapter=None,
+        config={},
+        strategy="surgical",
+        original_schema=original_schema,
+    )
+    assert result is raw
+
+
+def test_reextract_for_merge_full_no_input_dir(tmp_path):
+    """strategy='full' with missing input dir returns input unchanged + logs warning."""
+    raw = {"session_a/doc.md": {"nodes": [], "edges": []}}
+    result = reextract_for_merge(
+        session_alias="session_a",
+        session_path=tmp_path / "nonexistent",
+        raw_extractions_namespaced=raw,
+        merged_schema={},
+        flattened_schema={},
+        intermediate_dir=tmp_path / "inter",
+        adapter=None,
+        config={},
+        strategy="full",
+    )
+    assert result is raw
+
+
+def test_reextract_for_merge_surgical_no_input_dir(tmp_path):
+    """surgical strategy with delta but missing input dir returns input unchanged."""
+    raw = {"session_a/doc.md": {"nodes": [], "edges": []}}
+    result = reextract_for_merge(
+        session_alias="session_a",
+        session_path=tmp_path / "nonexistent",
+        raw_extractions_namespaced=raw,
+        merged_schema={
+            "concepts": [],
+            "properties": [{"name": "new_prop", "domain": "X", "range": "Y", "attributes": []}],
+        },
+        flattened_schema={},
+        intermediate_dir=tmp_path / "inter",
+        adapter=None,
+        config={},
+        strategy="surgical",
+        original_schema={"concepts": [], "properties": []},
+    )
+    assert result is raw
+
+
+def test_reextract_for_merge_full_no_files_resolved(tmp_path):
+    """strategy='full' with input dir present but no file contents -> input returned."""
+    sess = tmp_path / "src"
+    (sess / "input").mkdir(parents=True)
+    raw = {"session_a/doc.md": {"nodes": [], "edges": []}}
+
+    result = reextract_for_merge(
+        session_alias="session_a",
+        session_path=sess,
+        raw_extractions_namespaced=raw,
+        merged_schema={"concepts": [], "properties": []},
+        flattened_schema={},
+        intermediate_dir=tmp_path / "inter",
+        adapter=None,
+        config={},
+        strategy="full",
+    )
+    assert result is raw
+
+
+def test_reextract_for_merge_surgical_no_files_resolved(tmp_path):
+    """surgical strategy with delta + input dir but no file contents -> returns input."""
+    sess = tmp_path / "src"
+    (sess / "input").mkdir(parents=True)
+    raw = {"session_a/missing.md": {"nodes": [], "edges": []}}
+
+    result = reextract_for_merge(
+        session_alias="session_a",
+        session_path=sess,
+        raw_extractions_namespaced=raw,
+        merged_schema={
+            "concepts": [],
+            "properties": [{"name": "newp", "domain": "X", "range": "Y", "attributes": []}],
+        },
+        flattened_schema={},
+        intermediate_dir=tmp_path / "inter",
+        adapter=None,
+        config={},
+        strategy="surgical",
+        original_schema={"concepts": [], "properties": []},
+    )
+    assert result is raw
+
+
+def test_build_targeted_reextract_top_k_zero():
+    """top_k=0 disables targeted re-extraction -> returns empty dict."""
+    result = _build_targeted_reextract_chunks(
+        delta={"works_at"},
+        merged_schema={"concepts": [], "properties": []},
+        prior_extractions={},
+        prior_chunk_index={"f.md": {"1": ["x"]}},
+        top_k=0,
+    )
+    assert result == {}
+
+
+def test_copy_shard_dir_no_op_for_missing_dir(tmp_path):
+    """_copy_shard_dir is a no-op when src_dir doesn't exist."""
+    src = tmp_path / "nope"
+    dst = tmp_path / "dst"
+    _copy_shard_dir(src, dst, alias="session_a")
+    assert not dst.exists()
+
+
+def test_copy_shard_dir_with_oversized_filename(tmp_path):
+    """Long shard filenames are hashed instead of inflating."""
+    src = tmp_path / "src"
+    src.mkdir()
+    long_name = "a" * 200 + ".json"
+    shard = src / long_name
+    shard.write_text(json.dumps({"_fname": "x"}))
+
+    dst = tmp_path / "dst"
+    _copy_shard_dir(src, dst, alias="session_a")
+    out = list(dst.iterdir())
+    assert len(out) == 1
+    assert out[0].name.startswith("session_a_")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -455,3 +455,220 @@ def test_interrupt_marks_step_failed(tmp_path, exc_factory, exc_type):
     assert state_path.exists()
     state = json.loads(state_path.read_text())
     assert state["steps"]["interrupted"]["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Extended Unit 6 — retry / restart / re-entry coverage
+# ---------------------------------------------------------------------------
+
+
+def test_is_done_returns_false_when_no_outputs(tmp_path):
+    """Step with empty outputs list is never 'done' (line 96)."""
+    from mykg.orchestrator import _is_done
+
+    step = Step(name="x", fn=lambda c: None, outputs=[])
+    ctx = _make_ctx(tmp_path)
+    assert _is_done(step, ctx) is False
+
+
+def test_review_flag_check(tmp_path):
+    """_review_flag_exists checks for the approval flag."""
+    from mykg.orchestrator import _review_flag_exists
+
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True)
+    assert _review_flag_exists(ctx) is False
+    (ctx.intermediate_dir / "schema_approved.flag").write_text("ok")
+    assert _review_flag_exists(ctx) is True
+
+
+def test_human_review_waits_for_approval(tmp_path):
+    """Pipeline pauses at human_review when review=True and flag missing."""
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True)
+    ctx.review = True
+
+    executed = []
+
+    def fn(c):
+        executed.append("ran")
+        (c.intermediate_dir / "schema_approved.flag").write_text("approved")
+
+    def fn_b(c):
+        executed.append("b")
+        (c.intermediate_dir / "b.json").write_text("{}")
+
+    steps = [
+        Step(name="human_review", fn=fn, outputs=["schema_approved.flag"], requires_review_flag=True),
+        Step(name="b", fn=fn_b, outputs=["b.json"]),
+    ]
+    run(steps, ctx)
+    # No flag pre-existing -> pipeline returns early, fn never called
+    assert "b" not in executed
+
+
+def test_schema_restart_limit_reached(tmp_path, monkeypatch):
+    """schema_restart_count >= max -> step is marked failed, no further restart."""
+    import mykg.config as _cfg
+    from mykg.orchestrator import SchemaUpdatedError
+
+    monkeypatch.setattr(_cfg, "ORPHAN_SCHEMA_MAX_RESTARTS", 0)
+
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True)
+    ctx.output_dir.mkdir(parents=True)
+
+    fired = {"n": 0}
+
+    def orphan_connect_step(c):
+        fired["n"] += 1
+        raise SchemaUpdatedError(["new_prop"])
+
+    steps = [
+        Step(
+            name="orphan_connect",
+            fn=orphan_connect_step,
+            outputs=["orphan_connections.json"],
+            is_llm_step=True,
+            blocking=False,
+        ),
+    ]
+    run(steps, ctx)
+    # With max=0, the first call should be marked failed without restart
+    assert fired["n"] == 1
+
+
+def test_feedback_handler_failure_logged(tmp_path, monkeypatch):
+    """When feedback.apply raises, the orchestrator logs and continues."""
+    import mykg.feedback as feedback
+
+    monkeypatch.setattr(feedback, "apply", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("fb")))
+
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True)
+    ctx.output_dir.mkdir(parents=True)
+
+    fail_count = {"n": 0}
+
+    def bad_step(c):
+        fail_count["n"] += 1
+        raise ValueError(f"bad attempt {fail_count['n']}")
+
+    steps = [
+        Step(name="llm_step", fn=bad_step, outputs=["x.json"], is_llm_step=True, blocking=False),
+    ]
+    run(steps, ctx)
+    # 1st attempt + retry + post-feedback attempt = 3 calls
+    assert fail_count["n"] == 3
+
+
+def test_append_mode_requires_existing_schema(tmp_path):
+    """append=True without prior schema.json raises RuntimeError."""
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True)
+    ctx.append = True
+
+    with pytest.raises(RuntimeError, match="without --append"):
+        run([], ctx)
+
+
+def test_append_mode_invalidates_downstream(tmp_path):
+    """When append + new_files, pass2+downstream outputs are invalidated."""
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True)
+    ctx.output_dir.mkdir(parents=True)
+    ctx.append = True
+    # Required for append mode to pass the initial guard
+    (ctx.intermediate_dir / "schema.json").write_text("{}")
+
+    # Pre-populate downstream outputs that should be deleted
+    (ctx.intermediate_dir / "edge_metadata.json").write_text("{}")
+    (ctx.intermediate_dir / "name_normalization.json").write_text("{}")
+
+    def ingest_fn(c):
+        c.append_new_files = {"doc.md"}
+        (c.intermediate_dir / "file_manifest.json").write_text("{}")
+
+    def pass2_fn(c):
+        (c.intermediate_dir / "raw_extractions.json").write_text("{}")
+        (c.intermediate_dir / "chunk_node_index.json").write_text("{}")
+
+    def normalize_fn(c):
+        (c.intermediate_dir / "name_normalization.json").write_text("{}")
+
+    def assemble_fn(c):
+        (c.intermediate_dir / "edge_metadata.json").write_text("{}")
+
+    steps = [
+        Step(name="ingest", fn=ingest_fn, outputs=["file_manifest.json"]),
+        Step(
+            name="pass2",
+            fn=pass2_fn,
+            outputs=["raw_extractions.json", "chunk_node_index.json"],
+            is_llm_step=True,
+        ),
+        Step(name="normalize_names", fn=normalize_fn, outputs=["name_normalization.json"], is_llm_step=True),
+        Step(name="assemble", fn=assemble_fn, outputs=["edge_metadata.json"]),
+    ]
+    run(steps, ctx)
+
+    # All downstream outputs should be present at end of run (re-written by their steps)
+    assert (ctx.intermediate_dir / "raw_extractions.json").exists()
+
+
+def test_append_mode_no_new_files(tmp_path):
+    """append + ingest finds no new files -> downstream steps skipped."""
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True)
+    ctx.output_dir.mkdir(parents=True)
+    ctx.append = True
+    (ctx.intermediate_dir / "schema.json").write_text("{}")
+
+    executed = []
+
+    def ingest_fn(c):
+        c.append_new_files = set()  # explicitly empty
+        (c.intermediate_dir / "file_manifest.json").write_text("{}")
+        executed.append("ingest")
+
+    def downstream_fn(c):
+        executed.append("downstream")
+        (c.intermediate_dir / "out.json").write_text("{}")
+
+    steps = [
+        Step(name="ingest", fn=ingest_fn, outputs=["file_manifest.json"]),
+        Step(name="pass2", fn=downstream_fn, outputs=["out.json"]),
+    ]
+    run(steps, ctx)
+
+    assert "ingest" in executed
+    # downstream skipped because append_new_files is empty
+    assert "downstream" not in executed
+
+
+def test_append_mode_skips_pass1(tmp_path):
+    """append mode skips pass1, schema_validate, human_review."""
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True)
+    ctx.output_dir.mkdir(parents=True)
+    ctx.append = True
+    (ctx.intermediate_dir / "schema.json").write_text("{}")
+
+    executed = []
+
+    def fn_pass1(c):
+        executed.append("pass1")
+        (c.intermediate_dir / "schema.json").write_text("{}")
+
+    def fn_ingest(c):
+        executed.append("ingest")
+        c.append_new_files = set()
+        (c.intermediate_dir / "file_manifest.json").write_text("{}")
+
+    steps = [
+        Step(name="ingest", fn=fn_ingest, outputs=["file_manifest.json"]),
+        Step(name="pass1", fn=fn_pass1, outputs=["schema.json"], is_llm_step=True),
+    ]
+    run(steps, ctx)
+    assert "pass1" not in executed
+    assert "ingest" in executed

--- a/tests/test_orphan_connector.py
+++ b/tests/test_orphan_connector.py
@@ -1063,3 +1063,252 @@ def test_invalid_edge_type_dropped_partial_recovery():
     )
     assert len(confirmed) == 1
     assert confirmed[0]["type"] == "works_at"
+
+
+# ---------------------------------------------------------------------------
+# Extended Unit 9 — orphan_connector helper coverage
+# ---------------------------------------------------------------------------
+
+
+def test_get_node_attr_bare_string_value():
+    """_get_node_attr handles bare-string attribute values (line 100)."""
+    node = {"id": "p-1", "attributes": {"nickname": "Alex"}}
+    assert _get_node_attr(node, "nickname") == "Alex"
+
+
+def test_get_node_attr_falls_back_to_id():
+    """_get_node_attr returns id when attribute is missing or empty."""
+    node = {"id": "p-1", "attributes": {"name": {"value": "", "confidence": 0.0}}}
+    assert _get_node_attr(node, "name") == "p-1"
+
+
+def test_best_display_name_subject_fallback():
+    """_best_display_name uses subject when name is missing (line 114)."""
+    from mykg.orphan_connector import _best_display_name
+
+    node = {
+        "id": "doc-1",
+        "attributes": {"subject": {"value": "Report", "confidence": 1.0}},
+    }
+    assert _best_display_name(node) == "Report"
+
+
+def test_best_display_name_bare_string():
+    """_best_display_name handles bare string title attribute (line 114)."""
+    from mykg.orphan_connector import _best_display_name
+
+    node = {"id": "x", "attributes": {"title": "Memo"}}
+    assert _best_display_name(node) == "Memo"
+
+
+def test_best_display_name_falls_back_to_id():
+    from mykg.orphan_connector import _best_display_name
+
+    node = {"id": "thing-1", "attributes": {}}
+    assert _best_display_name(node) == "thing-1"
+
+
+def test_get_type_ancestors_walks_chain():
+    """_get_type_ancestors walks parent chain (lines 128-129)."""
+    from mykg.orphan_connector import _get_type_ancestors
+
+    concept_map = {
+        "Engineer": {"parent": "Person"},
+        "Person": {"parent": "Agent"},
+        "Agent": {"parent": None},
+    }
+    ancestors = _get_type_ancestors("Engineer", concept_map)
+    assert "Engineer" in ancestors
+    assert "Person" in ancestors
+    assert "Agent" in ancestors
+
+
+def test_get_type_ancestors_cycle_protection():
+    """_get_type_ancestors stops on cycle (line 127)."""
+    from mykg.orphan_connector import _get_type_ancestors
+
+    concept_map = {
+        "A": {"parent": "B"},
+        "B": {"parent": "A"},  # cycle
+    }
+    ancestors = _get_type_ancestors("A", concept_map)
+    assert "A" in ancestors
+    assert "B" in ancestors
+
+
+def test_is_schema_compatible_no_pairs_returns_true():
+    """_is_schema_compatible: empty valid_pairs -> True (line 138)."""
+    from mykg.orphan_connector import _is_schema_compatible
+
+    assert _is_schema_compatible("X", "Y", {}, set()) is True
+
+
+def test_confirm_one_json_parse_error():
+    """_confirm_one returns None on bad JSON (lines 590-597)."""
+    from mykg.orphan_connector import _confirm_one
+
+    adapter = MagicMock()
+    adapter.complete.return_value = "not valid json"
+
+    candidate = OrphanCandidate(
+        orphan_id="p-1",
+        orphan_type="Person",
+        orphan_name="Alice",
+        candidate_id="o-1",
+        candidate_type="Organization",
+        candidate_name="Acme",
+        shared_chunks=["doc.md::1"],
+        heuristic_score=0.5,
+        cooccurrence_count=1,
+    )
+    result = _confirm_one(candidate, SCHEMA, adapter, {"doc.md::1": "Alice at Acme"})
+    assert result is None
+
+
+def test_confirm_one_missing_type_returns_none():
+    """_confirm_one returns None when connected=true but no type (lines 604-609)."""
+    from mykg.orphan_connector import _confirm_one
+
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps({"connected": True})
+
+    candidate = OrphanCandidate(
+        orphan_id="p-1",
+        orphan_type="Person",
+        orphan_name="Alice",
+        candidate_id="o-1",
+        candidate_type="Organization",
+        candidate_name="Acme",
+        shared_chunks=["doc.md::1"],
+        heuristic_score=0.5,
+        cooccurrence_count=1,
+    )
+    result = _confirm_one(candidate, SCHEMA, adapter, {})
+    assert result is None
+
+
+def test_confirm_orphan_chunk_groups_handles_parse_error():
+    """confirm_orphan_chunk_groups handles JSON parse errors (lines 847-849)."""
+    nodes = [_node("p-1", "Person", "Alice"), _node("o-1", "Organization", "Acme")]
+    group = OrphanChunkGroup(
+        filename="doc.md",
+        chunk_idx=1,
+        chunk_key="doc.md::1",
+        orphan_ids=["p-1"],
+        connected_ids=["o-1"],
+        is_blank_response=False,
+    )
+    adapter = MagicMock()
+    adapter.complete.return_value = "not valid json {{{"
+    confirmed, rejections = confirm_orphan_chunk_groups(
+        [group], nodes, SCHEMA, adapter, chunk_texts={"doc.md::1": "text"}
+    )
+    assert confirmed == []
+    assert any(r["reason"] == "parse_error" for r in rejections)
+
+
+def test_confirm_orphan_chunk_groups_wrong_type():
+    """confirm_orphan_chunk_groups handles dict response (not list) (lines 855-860)."""
+    nodes = [_node("p-1", "Person", "Alice")]
+    group = OrphanChunkGroup(
+        filename="doc.md",
+        chunk_idx=1,
+        chunk_key="doc.md::1",
+        orphan_ids=["p-1"],
+        connected_ids=[],
+        is_blank_response=False,
+    )
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps({"foo": "bar"})  # Not a list
+    confirmed, rejections = confirm_orphan_chunk_groups(
+        [group], nodes, SCHEMA, adapter, chunk_texts={"doc.md::1": "x"}
+    )
+    assert confirmed == []
+    assert any(r["reason"] == "wrong_type" for r in rejections)
+
+
+def test_confirm_orphan_chunk_groups_drops_invalid_type():
+    """Edges with unknown type are dropped (line 877)."""
+    nodes = [_node("p-1", "Person", "Alice"), _node("o-1", "Organization", "Acme")]
+    group = OrphanChunkGroup(
+        filename="doc.md",
+        chunk_idx=1,
+        chunk_key="doc.md::1",
+        orphan_ids=["p-1"],
+        connected_ids=["o-1"],
+        is_blank_response=False,
+    )
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(
+        [
+            {"type": "totally_invalid", "from": "p-1", "to": "o-1", "confidence": 0.9},
+        ]
+    )
+    confirmed, _ = confirm_orphan_chunk_groups(
+        [group], nodes, SCHEMA, adapter, chunk_texts={"doc.md::1": "x"}
+    )
+    assert confirmed == []
+
+
+def test_confirm_orphan_chunk_groups_drops_dangling():
+    """Edges with from/to id not in node set are dropped (line 885)."""
+    nodes = [_node("p-1", "Person", "Alice"), _node("o-1", "Organization", "Acme")]
+    group = OrphanChunkGroup(
+        filename="doc.md",
+        chunk_idx=1,
+        chunk_key="doc.md::1",
+        orphan_ids=["p-1"],
+        connected_ids=["o-1"],
+        is_blank_response=False,
+    )
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(
+        [
+            {"type": "works_at", "from": "p-1", "to": "ghost", "confidence": 0.9},
+        ]
+    )
+    confirmed, _ = confirm_orphan_chunk_groups(
+        [group], nodes, SCHEMA, adapter, chunk_texts={"doc.md::1": "x"}
+    )
+    assert confirmed == []
+
+
+def test_propose_schema_additions_unparseable(monkeypatch):
+    """propose_schema_additions returns None on bad JSON (lines 1024-1026)."""
+    adapter = MagicMock()
+    adapter.complete.return_value = "not json"
+    gap = SchemaGapOrphan(
+        orphan_id="p-1",
+        orphan_type="Person",
+        orphan_name="Alice",
+        cooccurring_types=["Organization"],
+        shared_chunks=["doc.md::1"],
+    )
+    result = propose_schema_additions([gap], SCHEMA, adapter, {"doc.md::1": "x"})
+    assert result is None
+
+
+def test_propose_schema_additions_empty_after_filter():
+    """All proposed properties have undeclared domain/range -> {new_properties: []}."""
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(
+        {
+            "new_properties": [
+                {
+                    "name": "p1",
+                    "domain": "UndeclaredType",
+                    "range": "AnotherUndeclared",
+                    "attributes": [],
+                }
+            ]
+        }
+    )
+    gap = SchemaGapOrphan(
+        orphan_id="p-1",
+        orphan_type="Person",
+        orphan_name="Alice",
+        cooccurring_types=["Org"],
+        shared_chunks=["doc.md::1"],
+    )
+    result = propose_schema_additions([gap], SCHEMA, adapter, {"doc.md::1": "x"})
+    assert result == {"new_properties": []}

--- a/tests/test_orphan_steps.py
+++ b/tests/test_orphan_steps.py
@@ -237,3 +237,141 @@ def test_orphan_connect_empty_candidates(tmp_path):
     assert connections_path.exists()
     connections = json.loads(connections_path.read_text())
     assert connections == {}
+
+
+# ---------------------------------------------------------------------------
+# Extended Unit 11 — step_orphan_connect coverage
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_connect_schema_gap_with_max_restarts_zero(tmp_path, monkeypatch):
+    """When ORPHAN_SCHEMA_MAX_RESTARTS=0, schema-gap orphan triggers no LLM call."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "ORPHAN_SCHEMA_MAX_RESTARTS", 0)
+
+    ctx = _make_ctx(tmp_path)
+    candidates = {
+        "groups": [
+            {
+                "chunk_key": "doc.md::1",
+                "filename": "doc.md",
+                "chunk_idx": 1,
+                "is_blank_response": False,
+                "orphan_ids": ["person-bob"],
+                "connected_ids": [],
+            }
+        ],
+        "schema_gap_orphans": [],
+    }
+    (ctx.intermediate_dir / "orphan_candidates.json").write_text(json.dumps(candidates))
+    (ctx.intermediate_dir / "nodes.json").write_text(json.dumps(NODES))
+    (ctx.intermediate_dir / "schema.json").write_text(json.dumps(SCHEMA))
+    (ctx.intermediate_dir / "edge_metadata.json").write_text(json.dumps({}))
+
+    with patch("mykg.orphan_connector.llm_complete_with_retry") as mock_llm:
+        # Only one call expected: orphan confirmation. Schema proposal skipped.
+        mock_llm.return_value = json.dumps([])  # no edges confirmed
+        run_orphan_connect(ctx)
+
+    # schema_gap_proposals.json must exist with empty new_properties
+    proposals_path = ctx.intermediate_dir / "schema_gap_proposals.json"
+    assert proposals_path.exists()
+    proposals = json.loads(proposals_path.read_text())
+    assert proposals == {"new_properties": []}
+
+
+def test_orphan_connect_schema_gap_raises_schema_updated(tmp_path, monkeypatch):
+    """Valid schema additions from LLM -> SchemaUpdatedError."""
+    import mykg.config as cfg
+
+    from mykg.orchestrator import SchemaUpdatedError
+
+    monkeypatch.setattr(cfg, "ORPHAN_SCHEMA_MAX_RESTARTS", 1)
+
+    ctx = _make_ctx(tmp_path)
+    candidates = {
+        "groups": [
+            {
+                "chunk_key": "doc.md::1",
+                "filename": "doc.md",
+                "chunk_idx": 1,
+                "is_blank_response": False,
+                "orphan_ids": ["person-bob"],
+                "connected_ids": [],
+            }
+        ],
+        "schema_gap_orphans": [],
+    }
+    (ctx.intermediate_dir / "orphan_candidates.json").write_text(json.dumps(candidates))
+    (ctx.intermediate_dir / "nodes.json").write_text(json.dumps(NODES))
+    (ctx.intermediate_dir / "schema.json").write_text(json.dumps(SCHEMA))
+    (ctx.intermediate_dir / "edge_metadata.json").write_text(json.dumps({}))
+
+    with patch("mykg.orphan_connector.llm_complete_with_retry") as mock_llm:
+        mock_llm.side_effect = [
+            json.dumps([]),  # no edges from chunk recovery
+            json.dumps(
+                {
+                    "new_properties": [
+                        {
+                            "name": "new_relates_to",
+                            "domain": "Person",
+                            "range": "Person",
+                            "attributes": [],
+                        }
+                    ]
+                }
+            ),
+        ]
+        import pytest as _pytest
+
+        with _pytest.raises(SchemaUpdatedError) as exc_info:
+            run_orphan_connect(ctx)
+
+        assert "new_relates_to" in exc_info.value.new_property_names
+
+
+def test_orphan_connect_incremental_preserves_prior(tmp_path):
+    """Incremental sweep should retain prior orphan_connections.json edges."""
+    ctx = _make_ctx(tmp_path)
+    ctx.orphan_incremental = True
+    candidates = {
+        "groups": [
+            {
+                "chunk_key": "doc.md::1",
+                "filename": "doc.md",
+                "chunk_idx": 1,
+                "is_blank_response": False,
+                "orphan_ids": ["person-bob"],
+                "connected_ids": ["person-alice"],
+            }
+        ],
+        "schema_gap_orphans": [],
+    }
+    (ctx.intermediate_dir / "orphan_candidates.json").write_text(json.dumps(candidates))
+    (ctx.intermediate_dir / "nodes.json").write_text(json.dumps(NODES))
+    (ctx.intermediate_dir / "schema.json").write_text(json.dumps(SCHEMA))
+    (ctx.intermediate_dir / "edge_metadata.json").write_text(json.dumps({}))
+
+    # Pre-existing connection for person-bob
+    prior = {
+        "edge-prior": {
+            "type": "works_at",
+            "from": "person-bob",
+            "to": "org-acme",
+            "confidence": 0.7,
+        }
+    }
+    (ctx.intermediate_dir / "orphan_connections.json").write_text(json.dumps(prior))
+
+    with patch("mykg.orphan_connector.llm_complete_with_retry") as mock_llm:
+        # No new edges; schema gap returns nothing
+        mock_llm.return_value = json.dumps([])
+        run_orphan_connect(ctx)
+
+    connections = json.loads((ctx.intermediate_dir / "orphan_connections.json").read_text())
+    assert "edge-prior" in connections
+    orphan_log = json.loads((ctx.intermediate_dir / "orphan_log.json").read_text())
+    # retained event present
+    assert any(e["event"] == "orphan_edge_retained" for e in orphan_log)

--- a/tests/test_preprocess_step.py
+++ b/tests/test_preprocess_step.py
@@ -91,3 +91,124 @@ def test_preprocess_step_in_steps_registry() -> None:
 
     assert STEPS[0].name == "preprocess"
     assert STEPS[1].name == "ingest"
+
+
+# ---------------------------------------------------------------------------
+# Extended Unit 10 — HTML conversion + skipped-file paths
+# ---------------------------------------------------------------------------
+
+
+def test_preprocess_converts_html_file(tmp_path: Path) -> None:
+    """HTML files routed through _convert_html_files (in-process markdownify)."""
+    ctx = _make_ctx(tmp_path)
+    (ctx.input_dir / "page.html").write_text(
+        "<html><body><h1>Hello</h1><p>World</p></body></html>"
+    )
+
+    with (
+        patch("mykg.config.PREPROCESS_ENABLED", True),
+        patch("mykg.steps.step_preprocess.subprocess.run") as fake_run,
+    ):
+        run_preprocess(ctx)
+
+    # MinerU subprocess should NOT have been called for HTML-only input.
+    fake_run.assert_not_called()
+    subdir_name = __import__("mykg.config", fromlist=["PREPROCESS_SUBDIR"]).PREPROCESS_SUBDIR
+    sub = ctx.input_dir / subdir_name if subdir_name else ctx.input_dir
+    converted = sub / "page.md"
+    assert converted.exists()
+    assert "Hello" in converted.read_text()
+
+
+def test_preprocess_skipped_files_in_manifest(tmp_path: Path) -> None:
+    """Files whose suffix isn't in the allowlist are skipped + recorded."""
+    import json as _json
+
+    ctx = _make_ctx(tmp_path)
+    (ctx.input_dir / "ignored.svg").write_text("<svg/>")
+    (ctx.input_dir / "ignored.css").write_text("body{}")
+
+    with (
+        patch("mykg.config.PREPROCESS_ENABLED", True),
+        patch("mykg.steps.step_preprocess.subprocess.run") as fake_run,
+    ):
+        run_preprocess(ctx)
+
+    fake_run.assert_not_called()
+    manifest = _json.loads((ctx.intermediate_dir / "preprocess_manifest.json").read_text())
+    skipped = manifest["skipped_files"]
+    paths = {r["path"] for r in skipped}
+    assert "ignored.svg" in paths
+    assert "ignored.css" in paths
+
+
+def test_preprocess_html_conversion_failure(tmp_path: Path, monkeypatch) -> None:
+    """When markdownify raises, the failure is recorded but doesn't halt pipeline."""
+    import json as _json
+
+    ctx = _make_ctx(tmp_path)
+    (ctx.input_dir / "broken.html").write_text("<html>bad</html>")
+
+    def fail_markdownify(html, **kwargs):
+        raise ValueError("markdownify exploded")
+
+    monkeypatch.setattr("markdownify.markdownify", fail_markdownify)
+
+    with patch("mykg.config.PREPROCESS_ENABLED", True):
+        run_preprocess(ctx)
+
+    manifest = _json.loads((ctx.intermediate_dir / "preprocess_manifest.json").read_text())
+    records = manifest.get("html_records", [])
+    assert any(r["path"] == "broken.html" and not r["ok"] for r in records)
+
+
+def test_preprocess_mineru_timeout(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path)
+    (ctx.input_dir / "doc.pdf").write_bytes(b"%PDF fake")
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, timeout=10)
+
+    with (
+        patch("mykg.config.PREPROCESS_ENABLED", True),
+        patch("mykg.steps.step_preprocess.subprocess.run", side_effect=fake_run),
+    ):
+        with pytest.raises(RuntimeError, match="timed out"):
+            run_preprocess(ctx)
+
+
+def test_preprocess_default_subdir_layout(tmp_path: Path) -> None:
+    """With default subdir, output lands under input/<subdir>/ ."""
+    import mykg.config as cfg
+
+    ctx = _make_ctx(tmp_path)
+    (ctx.input_dir / "page.html").write_text("<html><body>hi</body></html>")
+
+    with patch("mykg.config.PREPROCESS_ENABLED", True):
+        run_preprocess(ctx)
+
+    sub = ctx.input_dir / cfg.PREPROCESS_SUBDIR
+    assert (sub / "page.md").exists()
+
+
+def test_preprocess_html_and_pdf_combined(tmp_path: Path) -> None:
+    """When both HTML and PDF files are present, both pathways run."""
+    ctx = _make_ctx(tmp_path)
+    (ctx.input_dir / "page.html").write_text("<html><body>hi</body></html>")
+    (ctx.input_dir / "doc.pdf").write_bytes(b"%PDF fake")
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with (
+        patch("mykg.config.PREPROCESS_ENABLED", True),
+        patch("mykg.steps.step_preprocess.subprocess.run", side_effect=fake_run),
+    ):
+        run_preprocess(ctx)
+
+    # Manifest should record both branches
+    import json as _json
+
+    manifest = _json.loads((ctx.intermediate_dir / "preprocess_manifest.json").read_text())
+    assert manifest["html_files"] == 1
+    assert manifest["mineru_files"] == 1

--- a/tests/test_schema_history.py
+++ b/tests/test_schema_history.py
@@ -1,0 +1,106 @@
+"""Tests for src/mykg/schema_history.py — schema delta audit log."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mykg.schema_history import (
+    TRIGGER_PASS1_MERGE,
+    TRIGGER_SCHEMA_GAP,
+    write_schema,
+)
+
+
+def test_write_schema_initial_creates_schema_json_and_delta(tmp_path: Path) -> None:
+    """write_schema writes schema.json and a delta file when no prior schema exists."""
+    schema = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
+    write_schema(schema, tmp_path, TRIGGER_PASS1_MERGE)
+
+    schema_path = tmp_path / "schema.json"
+    assert schema_path.exists()
+    assert json.loads(schema_path.read_text())["concepts"][0]["type"] == "Person"
+
+    history_dir = tmp_path / "schema_history"
+    deltas = sorted(history_dir.glob("*.json"))
+    assert len(deltas) == 1
+    delta = json.loads(deltas[0].read_text())
+    assert delta["seq"] == 1
+    assert delta["trigger"] == TRIGGER_PASS1_MERGE
+    assert "Person" in delta["concepts_added"]
+    assert delta["concepts_total"] == 1
+
+
+def test_write_schema_no_diff_still_writes_delta(tmp_path: Path) -> None:
+    """A no-op write (same schema as before) still produces an empty delta file."""
+    schema = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
+    write_schema(schema, tmp_path, TRIGGER_PASS1_MERGE)
+    # Second call with identical schema — no real diff
+    write_schema(schema, tmp_path, TRIGGER_PASS1_MERGE)
+
+    deltas = sorted((tmp_path / "schema_history").glob("*.json"))
+    assert len(deltas) == 2
+    second = json.loads(deltas[1].read_text())
+    assert second["concepts_added"] == []
+    assert second["concepts_removed"] == []
+    assert second["properties_added"] == []
+    assert second["properties_removed"] == []
+    assert second["concepts_total"] == 1
+    assert second["properties_total"] == 0
+
+
+def test_write_schema_handles_corrupt_previous_schema(tmp_path: Path) -> None:
+    """If the existing schema.json is invalid JSON, write_schema still proceeds (lines 67-68)."""
+    # Pre-create a corrupt schema.json
+    (tmp_path / "schema.json").write_text("not valid json {{{")
+
+    schema = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
+    write_schema(schema, tmp_path, TRIGGER_PASS1_MERGE)
+
+    # New schema is written and a delta file is created
+    after = json.loads((tmp_path / "schema.json").read_text())
+    assert after["concepts"][0]["type"] == "Person"
+    deltas = sorted((tmp_path / "schema_history").glob("*.json"))
+    assert len(deltas) == 1
+
+
+def test_write_schema_extra_merged_into_delta(tmp_path: Path) -> None:
+    """When `extra` is supplied, its keys are merged into the delta file (line 102-103)."""
+    schema = {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [
+            {"name": "knows", "domain": "Person", "range": "Person", "attributes": []}
+        ],
+    }
+    write_schema(
+        schema,
+        tmp_path,
+        TRIGGER_SCHEMA_GAP,
+        extra={"orphans_resolved": ["person-x"], "note": "schema gap loop"},
+    )
+
+    deltas = sorted((tmp_path / "schema_history").glob("*.json"))
+    assert len(deltas) == 1
+    delta = json.loads(deltas[0].read_text())
+    assert delta["orphans_resolved"] == ["person-x"]
+    assert delta["note"] == "schema gap loop"
+
+
+def test_write_schema_sequence_increments(tmp_path: Path) -> None:
+    """The sequence number monotonically increments across writes."""
+    base = {"concepts": [], "properties": []}
+    write_schema(base, tmp_path, TRIGGER_PASS1_MERGE)
+    write_schema(base, tmp_path, TRIGGER_PASS1_MERGE)
+    write_schema(base, tmp_path, TRIGGER_PASS1_MERGE)
+    deltas = sorted((tmp_path / "schema_history").glob("*.json"))
+    seqs = [json.loads(d.read_text())["seq"] for d in deltas]
+    assert seqs == [1, 2, 3]

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -55,3 +55,43 @@ def test_result_has_error_fields():
     err = result.errors[0]
     assert "type" in err
     assert "message" in err
+
+
+UNDEFINED_DOMAIN_TTL = """\
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://mykg.local/schema/> .
+
+ex:Organization rdf:type rdfs:Class .
+
+ex:works_at rdf:type rdf:Property ;
+    rdfs:domain ex:Person ;
+    rdfs:range  ex:Organization .
+"""
+
+UNDEFINED_PARENT_TTL = """\
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://mykg.local/schema/> .
+
+ex:Person rdf:type rdfs:Class .
+
+ex:SoftwareEngineer rdf:type rdfs:Class ;
+    rdfs:subClassOf ex:Worker .
+"""
+
+
+def test_undefined_domain_detected():
+    """domain that refers to an undeclared class generates an undefined_domain error (line 32-38)."""
+    result = validate_schema_ttl(UNDEFINED_DOMAIN_TTL)
+    assert result.valid is False
+    assert any(e["type"] == "undefined_domain" for e in result.errors)
+    assert any("Person" in e["message"] for e in result.errors)
+
+
+def test_undefined_parent_detected():
+    """subClassOf parent that is not declared generates an undefined_parent error (lines 50-59)."""
+    result = validate_schema_ttl(UNDEFINED_PARENT_TTL)
+    assert result.valid is False
+    assert any(e["type"] == "undefined_parent" for e in result.errors)
+    assert any("Worker" in e["message"] for e in result.errors)

--- a/tests/test_step_pass2.py
+++ b/tests/test_step_pass2.py
@@ -1,0 +1,240 @@
+"""Tests for mykg.steps.step_pass2 orchestration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mykg.llm.adapter import LLMAdapter
+from mykg.orchestrator import PipelineContext
+from mykg.steps.step_pass2 import _load_manifest, run_pass2_step, run_schema_flatten
+
+
+class MockAdapter(LLMAdapter):
+    def __init__(self, response: str = '{"nodes": [], "edges": []}'):
+        self._response = response
+
+    def complete(self, system, user, context_label="", max_tokens=None, timeout=None):
+        return self._response
+
+    def endpoint_label(self) -> str:
+        return "mock"
+
+
+def _make_ctx(tmp_path: Path) -> PipelineContext:
+    out = tmp_path / "output"
+    inter = tmp_path / "intermediate"
+    inp = tmp_path / "input"
+    for p in (out, inter, inp):
+        p.mkdir(parents=True)
+    return PipelineContext(
+        input_dir=inp,
+        output_dir=out,
+        intermediate_dir=inter,
+        adapter=MockAdapter(),
+        base_schema=None,
+        thesaurus=None,
+        review=False,
+    )
+
+
+SCHEMA = {
+    "concepts": [
+        {"type": "Person", "parent": None, "attributes": ["name"]},
+        {"type": "Organization", "parent": None, "attributes": ["name"]},
+    ],
+    "properties": [
+        {"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []}
+    ],
+}
+
+
+def _write_schema(ctx: PipelineContext) -> None:
+    (ctx.intermediate_dir / "schema.json").write_text(json.dumps(SCHEMA))
+
+
+def test_run_schema_flatten_writes_flattened(tmp_path):
+    ctx = _make_ctx(tmp_path)
+    _write_schema(ctx)
+    run_schema_flatten(ctx)
+    flat_path = ctx.intermediate_dir / "flattened_schema.json"
+    assert flat_path.exists()
+    flat = json.loads(flat_path.read_text())
+    assert "Person" in flat
+    assert "Organization" in flat
+
+
+def test_load_manifest_from_ctx(tmp_path):
+    ctx = _make_ctx(tmp_path)
+    ctx.file_contents = {"doc.md": "content"}
+    out = _load_manifest(ctx)
+    assert out == {"doc.md": "content"}
+
+
+def test_load_manifest_from_file(tmp_path):
+    ctx = _make_ctx(tmp_path)
+    manifest = {"doc.md": "content"}
+    (ctx.intermediate_dir / "file_manifest.json").write_text(json.dumps(manifest))
+    out = _load_manifest(ctx)
+    assert out == manifest
+
+
+def test_load_manifest_missing(tmp_path):
+    ctx = _make_ctx(tmp_path)
+    with pytest.raises(RuntimeError, match="file_manifest.json not found"):
+        _load_manifest(ctx)
+
+
+def test_run_pass2_step_fresh_extraction(tmp_path):
+    ctx = _make_ctx(tmp_path)
+    _write_schema(ctx)
+    (ctx.intermediate_dir / "flattened_schema.json").write_text(
+        json.dumps({"Person": ["name"], "Organization": ["name"]})
+    )
+    (ctx.intermediate_dir / "file_manifest.json").write_text(
+        json.dumps({"doc.md": "Alice works at Acme."})
+    )
+
+    run_pass2_step(ctx)
+
+    raw = json.loads((ctx.intermediate_dir / "raw_extractions.json").read_text())
+    assert "doc.md" in raw
+
+
+def test_run_pass2_step_skips_shards_already_present(tmp_path):
+    """With existing shards, pass2 skips those files."""
+    ctx = _make_ctx(tmp_path)
+    _write_schema(ctx)
+    (ctx.intermediate_dir / "flattened_schema.json").write_text(
+        json.dumps({"Person": ["name"], "Organization": ["name"]})
+    )
+    (ctx.intermediate_dir / "file_manifest.json").write_text(
+        json.dumps({"doc.md": "x", "other.md": "y"})
+    )
+
+    shard_dir = ctx.intermediate_dir / "raw_extractions_shards"
+    chunk_shard_dir = ctx.intermediate_dir / "chunk_index_shards"
+    shard_dir.mkdir()
+    chunk_shard_dir.mkdir()
+
+    # Pre-existing shard for doc.md
+    (shard_dir / "doc.md.json").write_text(
+        json.dumps({"_fname": "doc.md", "data": {"nodes": [{"id": "p-1", "type": "Person"}], "edges": []}})
+    )
+    (chunk_shard_dir / "doc.md.json").write_text(
+        json.dumps({"_fname": "doc.md", "data": {"1": ["p-1"]}})
+    )
+
+    run_pass2_step(ctx)
+    raw = json.loads((ctx.intermediate_dir / "raw_extractions.json").read_text())
+    assert "doc.md" in raw
+    assert "other.md" in raw  # newly extracted
+
+
+def test_run_pass2_step_surgical_reextract(tmp_path):
+    """When schema_hints + existing_raw both present, surgical re-extract runs."""
+    ctx = _make_ctx(tmp_path)
+    _write_schema(ctx)
+    (ctx.intermediate_dir / "flattened_schema.json").write_text(
+        json.dumps({"Person": ["name"], "Organization": ["name"]})
+    )
+
+    # Required: file_manifest.json + existing shards
+    (ctx.intermediate_dir / "file_manifest.json").write_text(
+        json.dumps({"doc.md": "Alice works at Acme."})
+    )
+    shard_dir = ctx.intermediate_dir / "raw_extractions_shards"
+    chunk_shard_dir = ctx.intermediate_dir / "chunk_index_shards"
+    shard_dir.mkdir()
+    chunk_shard_dir.mkdir()
+    (shard_dir / "doc.md.json").write_text(
+        json.dumps({"_fname": "doc.md", "data": {"nodes": [], "edges": []}})
+    )
+    (chunk_shard_dir / "doc.md.json").write_text(json.dumps({"_fname": "doc.md", "data": {}}))
+
+    ctx.schema_hints = [
+        {
+            "orphan_id": "person-x",
+            "orphan_name": "X",
+            "orphan_type": "Person",
+            "new_properties": ["works_at"],
+            "shared_chunks": ["doc.md::1"],
+        }
+    ]
+
+    run_pass2_step(ctx)
+    raw = json.loads((ctx.intermediate_dir / "raw_extractions.json").read_text())
+    assert "doc.md" in raw
+
+
+def test_run_pass2_step_no_files_to_extract(tmp_path):
+    """When all files are skipped via shards, the step is a no-op write."""
+    ctx = _make_ctx(tmp_path)
+    _write_schema(ctx)
+    (ctx.intermediate_dir / "flattened_schema.json").write_text(
+        json.dumps({"Person": ["name"], "Organization": ["name"]})
+    )
+    (ctx.intermediate_dir / "file_manifest.json").write_text(json.dumps({"doc.md": "x"}))
+
+    shard_dir = ctx.intermediate_dir / "raw_extractions_shards"
+    chunk_shard_dir = ctx.intermediate_dir / "chunk_index_shards"
+    shard_dir.mkdir()
+    chunk_shard_dir.mkdir()
+    (shard_dir / "doc.md.json").write_text(
+        json.dumps({"_fname": "doc.md", "data": {"nodes": [], "edges": []}})
+    )
+    (chunk_shard_dir / "doc.md.json").write_text(json.dumps({"_fname": "doc.md", "data": {}}))
+
+    run_pass2_step(ctx)
+    raw = json.loads((ctx.intermediate_dir / "raw_extractions.json").read_text())
+    assert "doc.md" in raw
+
+
+def test_run_pass2_step_batch_chunks_mode(tmp_path, monkeypatch):
+    """When PASS2_PREP_MODE == 'batch_chunks', uses run_pass2_batched."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_PREP_MODE", "batch_chunks")
+
+    ctx = _make_ctx(tmp_path)
+    _write_schema(ctx)
+    (ctx.intermediate_dir / "flattened_schema.json").write_text(
+        json.dumps({"Person": ["name"], "Organization": ["name"]})
+    )
+    (ctx.intermediate_dir / "file_manifest.json").write_text(
+        json.dumps({"doc.md": "Alice works at Acme."})
+    )
+
+    run_pass2_step(ctx)
+    batch_map_path = ctx.intermediate_dir / "pass2_batch_map.json"
+    assert batch_map_path.exists()
+
+
+def test_load_manifest_with_dict_entry(tmp_path):
+    """Manifest entries may be dicts (with content key) or bare strings."""
+    ctx = _make_ctx(tmp_path)
+    manifest = {"doc.md": {"content": "x", "sha256": "y"}}
+    (ctx.intermediate_dir / "file_manifest.json").write_text(json.dumps(manifest))
+    out = _load_manifest(ctx)
+    assert out == manifest
+
+
+def test_run_pass2_step_concat_mode_creates_batches(tmp_path, monkeypatch):
+    """When PREP_MODE == 'concat', pass2_concat_map.json is written."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_PREP_MODE", "concat")
+
+    ctx = _make_ctx(tmp_path)
+    _write_schema(ctx)
+    (ctx.intermediate_dir / "flattened_schema.json").write_text(
+        json.dumps({"Person": ["name"], "Organization": ["name"]})
+    )
+    (ctx.intermediate_dir / "file_manifest.json").write_text(
+        json.dumps({"doc.md": "Alice. " * 50, "doc2.md": "Bob. " * 50})
+    )
+
+    run_pass2_step(ctx)
+    assert (ctx.intermediate_dir / "pass2_concat_map.json").exists()

--- a/tests/test_ttl_validator.py
+++ b/tests/test_ttl_validator.py
@@ -1,4 +1,4 @@
-from mykg.ttl_validator import validate_knowledge_graph_ttl
+from mykg.ttl_validator import sanitize_abox_ttl, validate_knowledge_graph_ttl
 
 VALID_TTL = """\
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -53,3 +53,109 @@ def test_result_always_has_tbox_and_abox():
     assert "abox_checks" in result
     assert "errors" in result["tbox_checks"]
     assert "errors" in result["abox_checks"]
+
+
+def test_sanitize_abox_ttl_drops_undeclared_predicate_lines():
+    """sanitize_abox_ttl drops object-property triples whose predicate is not declared (line 36)."""
+    ttl = (
+        "@prefix ex: <http://mykg.local/schema/> .\n"
+        "@prefix data: <http://mykg.local/data/> .\n"
+        "data:alice ex:works_at data:acme .\n"
+        "data:alice ex:unknown_pred data:bob .\n"
+    )
+    schema = {"properties": [{"name": "works_at", "domain": "Person", "range": "Org"}]}
+    cleaned = sanitize_abox_ttl(ttl, schema)
+    assert "ex:works_at" in cleaned
+    assert "ex:unknown_pred" not in cleaned
+
+
+def test_validate_returns_syntax_error_on_bad_ttl():
+    """Invalid Turtle returns a syntax_error tbox entry (lines 48-53)."""
+    result = validate_knowledge_graph_ttl("this is %% not valid ttl")
+    assert result["valid"] is False
+    assert any(e["type"] == "syntax_error" for e in result["tbox_checks"]["errors"])
+
+
+UNDEFINED_DOMAIN_AND_RANGE_TBOX = """\
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://mykg.local/schema/> .
+
+ex:Organization rdf:type rdfs:Class .
+
+ex:works_at rdf:type rdf:Property ;
+    rdfs:domain ex:NotAClass ;
+    rdfs:range  ex:AnotherNotAClass .
+"""
+
+
+def test_validate_tbox_undefined_domain_and_range_errors():
+    """Validator returns undefined_domain + undefined_range when class refs are undeclared (lines 63-70)."""
+    result = validate_knowledge_graph_ttl(UNDEFINED_DOMAIN_AND_RANGE_TBOX)
+    assert result["valid"] is False
+    tbox = result["tbox_checks"]["errors"]
+    assert any(e["type"] == "undefined_domain" for e in tbox)
+    assert any(e["type"] == "undefined_range" for e in tbox)
+
+
+UNDEFINED_PARENT_TBOX = """\
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://mykg.local/schema/> .
+
+ex:Person rdf:type rdfs:Class .
+
+ex:Engineer rdf:type rdfs:Class ;
+    rdfs:subClassOf ex:UnknownParent .
+"""
+
+
+def test_validate_tbox_undefined_parent_error():
+    """subClassOf parent that is not declared produces undefined_parent error (lines 71-75)."""
+    result = validate_knowledge_graph_ttl(UNDEFINED_PARENT_TBOX)
+    assert result["valid"] is False
+    tbox = result["tbox_checks"]["errors"]
+    assert any(e["type"] == "undefined_parent" for e in tbox)
+
+
+UNDECLARED_PREDICATE_ABOX = """\
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://mykg.local/schema/> .
+@prefix data: <http://mykg.local/data/> .
+
+ex:Person rdf:type rdfs:Class .
+
+data:alice rdf:type ex:Person .
+data:alice ex:nope_predicate "value" .
+"""
+
+
+def test_validate_abox_undeclared_predicate_error():
+    """ABox triples with an undeclared predicate are flagged (lines 98-104)."""
+    result = validate_knowledge_graph_ttl(UNDECLARED_PREDICATE_ABOX)
+    assert result["valid"] is False
+    abox = result["abox_checks"]["errors"]
+    assert any(e["type"] == "undeclared_predicate" for e in abox)
+
+
+SKOS_EXEMPT_ABOX = """\
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://mykg.local/schema/> .
+@prefix data: <http://mykg.local/data/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:Person rdf:type rdfs:Class .
+
+data:alice rdf:type ex:Person .
+data:alice skos:altLabel "Allie" .
+"""
+
+
+def test_validate_abox_skos_predicate_is_exempt():
+    """SKOS namespace predicates skip the undeclared_predicate check (lines 96-97)."""
+    result = validate_knowledge_graph_ttl(SKOS_EXEMPT_ABOX)
+    # SKOS predicate should NOT generate an undeclared_predicate error
+    abox = result["abox_checks"]["errors"]
+    assert not any(e["type"] == "undeclared_predicate" for e in abox)

--- a/tests/test_walkthrough_sections.py
+++ b/tests/test_walkthrough_sections.py
@@ -6,10 +6,20 @@ import json
 from pathlib import Path
 
 from mykg.walkthrough import (
+    _load_json,
+    _parse_log_lines,
+    _section_extraction_summary,
     _section_final_graph,
+    _section_health_status,
     _section_llm_stats,
+    _section_merge_provenance,
+    _section_node_edge_trace,
     _section_orphan_pass,
+    _section_run_overview,
     _section_schema_evolution,
+    _section_warnings,
+    _seconds_to_hms,
+    _ts_to_seconds,
     generate_walkthrough,
 )
 
@@ -262,3 +272,628 @@ def test_generate_walkthrough_minimal(tmp_path):
     assert isinstance(result, str)
     assert result
     assert "##" in result
+
+
+# ---------------------------------------------------------------------------
+# Helper coverage
+# ---------------------------------------------------------------------------
+
+
+def test_seconds_to_hms_negative():
+    """Negative durations are clamped to 0."""
+    assert _seconds_to_hms(-5) == "0s"
+
+
+def test_seconds_to_hms_with_hours():
+    assert _seconds_to_hms(3661) == "1h 01m 01s"
+
+
+def test_seconds_to_hms_with_minutes_only():
+    assert _seconds_to_hms(125) == "2m 05s"
+
+
+def test_seconds_to_hms_seconds_only():
+    assert _seconds_to_hms(7) == "7s"
+
+
+def test_load_json_malformed_returns_none(tmp_path):
+    p = tmp_path / "broken.json"
+    p.write_text("not valid json {{{")
+    assert _load_json(p) is None
+
+
+def test_load_json_absent_returns_none(tmp_path):
+    p = tmp_path / "missing.json"
+    assert _load_json(p) is None
+
+
+# ---------------------------------------------------------------------------
+# _section_run_overview — missing fields branches (lines 110, 116, 121, 123)
+# ---------------------------------------------------------------------------
+
+
+def test_run_overview_no_log_lines(tmp_path):
+    """Empty lines list -> 'unknown' duration."""
+    session = tmp_path / "session"
+    session.mkdir()
+    result = _section_run_overview(session, [], {}, {})
+    assert "unknown" in result
+
+
+def test_run_overview_unknown_provider(tmp_path):
+    """No LLM endpoint line in log -> provider stays 'unknown'."""
+    session = tmp_path / "session"
+    session.mkdir()
+    lines = [
+        {"ts": "09:00:00", "level": "INFO", "logger": "mykg.orchestrator", "message": "x"},
+        {"ts": "09:30:00", "level": "INFO", "logger": "mykg.orchestrator", "message": "done"},
+    ]
+    result = _section_run_overview(session, lines, {}, {})
+    assert "| LLM provider | unknown |" in result
+
+
+def test_run_overview_duration_wraps_midnight(tmp_path):
+    """End < start -> +86400 wrap branch."""
+    session = tmp_path / "session"
+    session.mkdir()
+    lines = [
+        {"ts": "23:59:00", "level": "INFO", "logger": "mykg.orchestrator", "message": "x"},
+        {"ts": "00:01:00", "level": "INFO", "logger": "mykg.orchestrator", "message": "y"},
+    ]
+    result = _section_run_overview(session, lines, {}, {})
+    # Should be reasonable duration not negative
+    assert "| Total duration |" in result
+
+
+def test_run_overview_warning_count_only(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    lines = [
+        {"ts": "09:00:00", "level": "INFO", "logger": "x", "message": "x"},
+        {"ts": "09:30:00", "level": "WARNING", "logger": "x", "message": "warn"},
+    ]
+    result = _section_run_overview(session, lines, {}, {})
+    assert "healthy with warnings" in result
+
+
+def test_run_overview_health_with_errors(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    lines = [
+        {"ts": "09:00:00", "level": "ERROR", "logger": "x", "message": "boom"},
+    ]
+    result = _section_run_overview(session, lines, {}, {})
+    assert "unhealthy" in result
+
+
+def test_run_overview_schema_gap_count(tmp_path):
+    """schema_history dir with schema_gap files counts gap restarts."""
+    session = tmp_path / "session"
+    schema_hist = session / "intermediate" / "schema_history"
+    schema_hist.mkdir(parents=True)
+    (schema_hist / "001_pass1_merge.json").write_text("{}")
+    (schema_hist / "002_schema_gap.json").write_text("{}")
+    (schema_hist / "003_schema_gap_correct.json").write_text("{}")
+
+    result = _section_run_overview(session, [], {}, {})
+    assert "Schema-gap restarts | 2 |" in result
+
+
+# ---------------------------------------------------------------------------
+# _section_extraction_summary — branches at 171–175, 386–387, 391–392, 395–406, 434–443
+# ---------------------------------------------------------------------------
+
+
+def test_extraction_summary_with_retries_and_partial_recovery(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    (session / "intermediate").mkdir()
+
+    lines = [
+        {
+            "ts": "09:00:00",
+            "level": "INFO",
+            "logger": "mykg.pass2",
+            "message": "doc.md — total: 10 node(s), 5 edge(s)",
+        },
+        {
+            "ts": "09:00:01",
+            "level": "WARNING",
+            "logger": "mykg.pass2",
+            "message": "doc.md — chunk 1 — validation errors found",
+        },
+        {
+            "ts": "09:00:02",
+            "level": "WARNING",
+            "logger": "mykg.pass2",
+            "message": "doc.md — chunk 2 — JSON parse error: foo — retrying",
+        },
+        {
+            "ts": "09:00:03",
+            "level": "WARNING",
+            "logger": "mykg.pass2",
+            "message": "doc.md — chunk 2 — retry JSON parse error",
+        },
+        {
+            "ts": "09:00:04",
+            "level": "WARNING",
+            "logger": "mykg.pass2",
+            "message": "skipping chunk 7",
+        },
+        {
+            "ts": "09:00:05",
+            "level": "WARNING",
+            "logger": "mykg.pass2",
+            "message": "partial recovery — dropped 3 invalid edge(s) and dropped 2 unanchored node(s)",
+        },
+        {
+            "ts": "09:00:06",
+            "level": "INFO",
+            "logger": "mykg.pass2",
+            "message": "doc.md chunk 1/3 dispatched",
+        },
+        {
+            "ts": "09:00:07",
+            "level": "WARNING",
+            "logger": "mykg.assembler",
+            "message": "dropping edge — unknown id",
+        },
+    ]
+
+    result = _section_extraction_summary(session, lines, {"doc.md": "x"})
+    # Retry stats present
+    assert "JSON parse error → retry" in result
+    assert "Partial recoveries" in result
+    assert "Per-file extraction" in result
+    assert "doc.md" in result
+    # Dangling edges line present
+    assert "Dangling edges dropped:" in result
+
+
+def test_extraction_summary_includes_dedup_and_normalization(tmp_path):
+    session = tmp_path / "session"
+    inter = session / "intermediate"
+    inter.mkdir(parents=True)
+
+    (inter / "name_normalization.json").write_text(
+        json.dumps(
+            {
+                "mappings": {"Person": {"al": "Alice"}},
+                "metadata": {"aliases_mapped": 1},
+            }
+        )
+    )
+    (inter / "merge_log.json").write_text(
+        json.dumps(
+            [
+                {"event": "node_merge", "id": "person-alice"},
+                {"event": "node_merge", "id": "person-bob"},
+                {"event": "edge_merge", "id": "edge-1"},
+            ]
+        )
+    )
+
+    lines = []
+    result = _section_extraction_summary(session, lines, {})
+    assert "Name normalization" in result
+    assert "Deduplication" in result
+    assert "1 edge merge" in result
+
+
+# ---------------------------------------------------------------------------
+# _section_orphan_pass — empty paths (386-387, 391-392, 395-406)
+# ---------------------------------------------------------------------------
+
+
+def test_section_orphan_pass_no_files(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    result = _section_orphan_pass(session, [], [], {})
+    assert "## 7. Orphan Pass Summary" in result
+    assert "not found" in result
+
+
+def test_section_orphan_pass_promoted_to_schema_gap(tmp_path):
+    """Logs that mention 'promoted to schema-gap orphan' surface in the section."""
+    session = tmp_path / "session"
+    inter = session / "intermediate"
+    inter.mkdir(parents=True)
+    (inter / "orphan_candidates.json").write_text(json.dumps({"groups": [], "schema_gap_orphans": []}))
+
+    lines = [
+        {
+            "ts": "09:00:00",
+            "level": "INFO",
+            "logger": "x",
+            "message": "orphan-1 promoted to schema-gap orphan",
+        }
+    ]
+    result = _section_orphan_pass(session, lines, [], {})
+    assert "Promoted to schema-gap orphan" in result
+
+
+def test_section_orphan_pass_many_orphans_truncate(tmp_path):
+    """If >20 orphans remain in graph, render the '...and N more' line.
+
+    The orphan tail rendering branch only fires when ``edge_data`` is non-empty,
+    so we provide a single dummy edge that doesn't connect any of the orphans.
+    """
+    session = tmp_path / "session"
+    (session / "intermediate").mkdir(parents=True)
+
+    nodes = [{"id": f"p-{i}", "type": "Person"} for i in range(25)]
+    edges = {"dummy": {"type": "x", "from": "other-1", "to": "other-2"}}
+    result = _section_orphan_pass(session, [], nodes, edges)
+    assert "…and 5 more" in result
+
+
+# ---------------------------------------------------------------------------
+# _section_final_graph — empty branches and networkx output
+# ---------------------------------------------------------------------------
+
+
+def test_section_final_graph_empty(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    result = _section_final_graph(session, [], {})
+    assert "**Total nodes:** 0" in result
+    assert "**Total edges:** 0" in result
+
+
+def test_section_final_graph_with_networkx_output(tmp_path):
+    session = tmp_path / "session"
+    out_dir = session / "output"
+    nx_dir = out_dir / "networkx_output"
+    nx_dir.mkdir(parents=True)
+    (nx_dir / "graph.gml").write_text("graph []")
+    (nx_dir / "graph.graphml").write_text("<graphml/>")
+    (out_dir / "nodes.jsonl").write_text("")
+
+    result = _section_final_graph(session, [], {})
+    assert "networkx_output/" in result
+    assert "graph.gml" in result
+
+
+# ---------------------------------------------------------------------------
+# _section_warnings — title rendering branches (line 1104)
+# ---------------------------------------------------------------------------
+
+
+def test_section_warnings_no_warnings():
+    result = _section_warnings([])
+    assert "No warnings or errors recorded" in result
+
+
+def test_section_warnings_categorization():
+    lines = [
+        {
+            "ts": "09:00:00",
+            "level": "WARNING",
+            "logger": "pass2",
+            "message": "chunk 1 — validation errors",
+        },
+        {
+            "ts": "09:00:01",
+            "level": "WARNING",
+            "logger": "assembler",
+            "message": "dropping edge edge-1 dangling",
+        },
+        {
+            "ts": "09:00:02",
+            "level": "WARNING",
+            "logger": "schema_validate",
+            "message": "schema property foo missing range",
+        },
+        {
+            "ts": "09:00:03",
+            "level": "WARNING",
+            "logger": "x",
+            "message": "something else",
+        },
+    ]
+    result = _section_warnings(lines)
+    assert "Chunk Errors & Retries" in result
+    assert "Dangling Edges Dropped" in result
+    assert "Schema Issues" in result
+    assert "Other Warnings" in result
+
+
+# ---------------------------------------------------------------------------
+# _section_health_status — credit + abox advisory branches (1054, 1059, 1065)
+# ---------------------------------------------------------------------------
+
+
+def test_section_health_status_failed_steps(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    state = {"steps": {"pass2": {"status": "failed"}}}
+    result = _section_health_status(session, [], state)
+    assert "step(s) failed" in result
+
+
+def test_section_health_status_credit_error(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    lines = [
+        {"ts": "09:00:00", "level": "ERROR", "logger": "x", "message": "402 insufficient credit"},
+    ]
+    result = _section_health_status(session, lines, {})
+    assert "402" in result
+    assert "credit error" in result
+
+
+def test_section_health_status_other_errors(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    lines = [
+        {"ts": "09:00:00", "level": "ERROR", "logger": "x", "message": "some random failure"},
+    ]
+    result = _section_health_status(session, lines, {})
+    assert "other error" in result.lower()
+
+
+def test_section_health_status_abox_advisory(tmp_path):
+    session = tmp_path / "session"
+    out = session / "output"
+    out.mkdir(parents=True)
+    (out / "knowledge_graph_validation.json").write_text(
+        json.dumps(
+            {
+                "valid": False,
+                "tbox_checks": {"errors": []},
+                "abox_checks": {"errors": ["err1", "err2"]},
+            }
+        )
+    )
+    result = _section_health_status(session, [], {})
+    assert "ABox advisory" in result
+
+
+def test_section_health_status_clean(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    result = _section_health_status(session, [], {})
+    assert "✓ Clean" in result
+
+
+# ---------------------------------------------------------------------------
+# Merge sections
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_merge_session(tmp_path, with_net_new=False, with_cross_edge=False):
+    """Set up a fake merge session structure under tmp_path."""
+    sessions_root = tmp_path / "sessions"
+    session = sessions_root / "merged"
+    session_a = sessions_root / "sess-a"
+    session_b = sessions_root / "sess-b"
+    for s in (session, session_a, session_b):
+        (s / "intermediate").mkdir(parents=True)
+        (s / "output").mkdir(parents=True)
+
+    # Source-map (key invariant: meta has session_a + session_b)
+    source_map = {
+        "_meta": {
+            "session_a": {"name": "sess-a"},
+            "session_b": {"name": "sess-b"},
+        },
+        "sess-a/doc.md": {"role": "input_a", "sha256": "deadbeef"},
+        "sess-b/doc.md": {"role": "input_b", "sha256": "cafebabe"},
+    }
+    _write(session / "intermediate" / "source_map.json", source_map)
+
+    # Source-session artifacts
+    for s, ids in [(session_a, ["a-1", "a-2"]), (session_b, ["b-1"])]:
+        nodes = [{"id": nid, "type": "X", "attributes": {"name": {"value": nid}}} for nid in ids]
+        _write(s / "intermediate" / "nodes.json", nodes)
+        _write(s / "intermediate" / "edge_metadata.json", {})
+        _write(s / "intermediate" / "schema.json", {"concepts": [], "properties": []})
+        _write(s / "intermediate" / "raw_extractions.json", {f"{s.name}/doc.md": {"nodes": [], "edges": []}})
+
+    # Merged artifacts
+    merged_nodes = [
+        {"id": "a-1", "type": "X", "attributes": {"name": {"value": "n1"}}},
+        {"id": "b-1", "type": "X", "attributes": {"name": {"value": "n3"}}},
+    ]
+    if with_net_new:
+        merged_nodes.append({"id": "net-new-1", "type": "Y", "attributes": {"name": {"value": "n4"}}})
+
+    merged_edges = {}
+    if with_cross_edge:
+        merged_edges["edge-x"] = {
+            "type": "works_at",
+            "from": "a-1",
+            "to": "b-1",
+            "method": "orphan_inferred",
+        }
+
+    _write(session / "intermediate" / "nodes.json", merged_nodes)
+    _write(session / "intermediate" / "edge_metadata.json", merged_edges)
+    _write(
+        session / "intermediate" / "schema.json",
+        {"concepts": [], "properties": [{"name": "works_at"}]},
+    )
+    _write(
+        session / "intermediate" / "merge_manifest.json",
+        {
+            "session_a": "sess-a",
+            "session_b": "sess-b",
+            "merged_at": "2026-05-20T10:00:00+00:00",
+            "reextraction_strategy": "surgical",
+            "schema_delta_session_a": [],
+            "schema_delta_session_b": ["works_at"],
+            "schema_synonym_log": [{"kept": "works_at", "removed": "employed_at"}],
+        },
+    )
+    _write(
+        session / "intermediate" / "raw_extractions.json",
+        {
+            "sess-a/doc.md": {"nodes": [], "edges": []},
+            "sess-b/doc.md": {"nodes": [], "edges": []},
+        },
+    )
+    return session
+
+
+def test_section_node_edge_trace_no_source_map(tmp_path):
+    """No source_map.json -> returns None."""
+    session = tmp_path / "session"
+    session.mkdir()
+    assert _section_node_edge_trace(session) is None
+
+
+def test_section_node_edge_trace_meta_missing(tmp_path):
+    """source_map present but _meta lacks session_a/session_b -> None."""
+    session = tmp_path / "session"
+    inter = session / "intermediate"
+    inter.mkdir(parents=True)
+    (inter / "source_map.json").write_text(json.dumps({"_meta": {}}))
+    assert _section_node_edge_trace(session) is None
+
+
+def test_section_node_edge_trace_with_data(tmp_path):
+    session = _make_minimal_merge_session(tmp_path, with_cross_edge=True)
+    result = _section_node_edge_trace(session)
+    assert result is not None
+    assert "Node & Edge Count Trace" in result
+
+
+def test_section_merge_provenance_no_source_map(tmp_path):
+    session = tmp_path / "session"
+    session.mkdir()
+    assert _section_merge_provenance(session) is None
+
+
+def test_section_merge_provenance_meta_missing(tmp_path):
+    session = tmp_path / "session"
+    inter = session / "intermediate"
+    inter.mkdir(parents=True)
+    (inter / "source_map.json").write_text(json.dumps({"_meta": {}}))
+    assert _section_merge_provenance(session) is None
+
+
+def test_section_merge_provenance_with_data(tmp_path):
+    session = _make_minimal_merge_session(tmp_path, with_net_new=True, with_cross_edge=True)
+    result = _section_merge_provenance(session)
+    assert result is not None
+    assert "## 2. Merge Provenance" in result
+    assert "Net-new" in result
+    assert "Cross-session" in result
+    # Synonym log rendering
+    assert "works_at" in result
+
+
+def test_section_merge_provenance_no_cross_edges(tmp_path):
+    """Renders the 'No cross-session edges' fallback message."""
+    session = _make_minimal_merge_session(tmp_path)
+    result = _section_merge_provenance(session)
+    assert result is not None
+    assert "No cross-session edges" in result
+
+
+def test_section_merge_provenance_many_net_new(tmp_path):
+    """Net-new >20 -> truncation row."""
+    session = _make_minimal_merge_session(tmp_path)
+    # Add many net-new nodes
+    nodes = _load_json(session / "intermediate" / "nodes.json")
+    for i in range(25):
+        nodes.append(
+            {"id": f"net-{i}", "type": "Z", "attributes": {"name": {"value": f"n{i}"}}}
+        )
+    _write(session / "intermediate" / "nodes.json", nodes)
+
+    result = _section_merge_provenance(session)
+    assert "…and " in result and "more" in result
+
+
+def test_section_merge_provenance_many_cross_edges(tmp_path):
+    """Many cross-session edges -> truncation row."""
+    session = _make_minimal_merge_session(tmp_path)
+    # Build 25 cross-session edges
+    edges = {}
+    for i in range(25):
+        edges[f"edge-{i}"] = {
+            "type": "works_at",
+            "from": "a-1",
+            "to": "b-1",
+            "method": "orphan_inferred",
+        }
+    _write(session / "intermediate" / "edge_metadata.json", edges)
+    result = _section_merge_provenance(session)
+    assert "…and " in result
+
+
+def test_section_merge_provenance_many_new_prop_edges(tmp_path):
+    session = _make_minimal_merge_session(tmp_path)
+    edges = {}
+    # All use "works_at" which is in delta_session_b
+    for i in range(25):
+        # Use a node id present in a (so they're not cross-session)
+        edges[f"edge-{i}"] = {
+            "type": "works_at",
+            "from": "a-1",
+            "to": "a-1",
+            "method": "llm_extraction",
+        }
+    _write(session / "intermediate" / "edge_metadata.json", edges)
+    result = _section_merge_provenance(session)
+    assert "Edges using new merged property types" in result
+
+
+def test_section_merge_provenance_synonym_log_with_string_entry(tmp_path):
+    session = _make_minimal_merge_session(tmp_path)
+    # Patch manifest with a string-form entry to trigger the "else" branch
+    _write(
+        session / "intermediate" / "merge_manifest.json",
+        {
+            "session_a": "sess-a",
+            "session_b": "sess-b",
+            "reextraction_strategy": "surgical",
+            "schema_delta_session_a": ["foo"],
+            "schema_delta_session_b": [],
+            "schema_synonym_log": ["raw entry 1"],
+        },
+    )
+    result = _section_merge_provenance(session)
+    assert "raw entry 1" in result
+    # Schema delta A rendering branch
+    assert "Session A" in result
+
+
+def test_section_merge_provenance_long_synonym_log(tmp_path):
+    session = _make_minimal_merge_session(tmp_path)
+    log_entries = [{"kept": f"k{i}", "removed": f"r{i}"} for i in range(15)]
+    _write(
+        session / "intermediate" / "merge_manifest.json",
+        {
+            "session_a": "sess-a",
+            "session_b": "sess-b",
+            "reextraction_strategy": "surgical",
+            "schema_delta_session_a": [],
+            "schema_delta_session_b": [],
+            "schema_synonym_log": log_entries,
+        },
+    )
+    result = _section_merge_provenance(session)
+    assert "and 5 more" in result
+
+
+def test_parse_log_lines_handles_bad_lines(tmp_path):
+    log = tmp_path / "run.log"
+    log.write_text(
+        "10:00:00 [INFO] mykg.orchestrator — RUN  ingest\n"
+        "garbage line that does not match\n"
+        "10:00:02 [DONE] mykg.orchestrator — done\n"
+    )
+    out = _parse_log_lines(log)
+    # Two well-formed lines, garbage skipped
+    assert len(out) == 2
+
+
+def test_parse_log_lines_missing_file(tmp_path):
+    out = _parse_log_lines(tmp_path / "nope.log")
+    assert out == []
+
+
+def test_ts_to_seconds():
+    assert _ts_to_seconds("01:02:03") == 3723


### PR DESCRIPTION
## Summary

Adds unit-test coverage for the lowest-covered modules in mykg, raising total coverage from **87% (798 missing) to 94% (349 missing)**.

- 188 new tests (713 → 901 passing)
- All mocked / data-driven — no `@pytest.mark.live` tests added
- Single commit on `coverage/batch-increase` (3625 lines across 12 test files)

## Modules covered

| Module | Before | After |
|---|---|---|
| cli.py | 58% | ~95% (init, skill installer, extract-graph, merge-graphs, parse-docs, delete-from-step) |
| walkthrough.py | 86% | 97% (orphan / merge / empty-data section branches) |
| pass2.py | 91% | ~99% (partial_recover, blank-response, surgical re-extract) |
| step_pass2.py | 73% | 98% |
| step_preprocess.py | 67% | 98% |
| orchestrator.py | 85% | ~95% (retry + schema-restart loop) |
| merger.py | 88% | ~96% (confidence-1.0 concat, alias union) |
| orphan_connector.py | 93% | ~98% |
| step_orphan_connect.py | 77% | ~93% |
| assembler.py | 86% | ~97% |

## Deferred to follow-up batch (~95 missing lines)

- exporter.py (14 missing)
- logging.py (10)
- feedback.py (13)
- merge_run.py + step_merge_raw + step_merge_schema (28)
- utility/context_calculator.py (20)
- small modules: schema_validator, schema_history, ttl_validator, openrouter_adapter (~27)

## Test plan

- [x] Full non-live suite passes: `uv run pytest -m "not live"` → 901 passed, 5 deselected
- [x] Per-module Miss decreased for every targeted module
- [x] No live-API tests added

## Summary by Sourcery

Expand automated test coverage across CLI commands, extraction pipeline steps, orphan handling, merging, walkthrough reporting, and assembler/orchestrator behaviors to improve reliability and capture edge cases without changing runtime logic.

Tests:
- Add extensive CLI tests for init, skill installation, parsing docs, walkthrough, merge-graphs, delete-from-step, and error/validation flows.
- Increase coverage of pass2 extraction logic, including normalization, validation, deduplication, stateful chunks, surgical re-extraction, and blank-response handling.
- Add tests for walkthrough report helpers and sections, including run overview, extraction/orphan summaries, final graph rendering, warnings, and health status.
- Expand orphan connector and step_orphan_connect tests to cover helper utilities, LLM error paths, schema-gap proposals, incremental runs, and edge filtering logic.
- Extend merger tests for session copying, manifest building, merge re-extraction strategies, and shard handling utilities.
- Add orchestrator tests for retry/restart behaviors, schema restart limits, append mode semantics, human review, and feedback failure handling.
- Enhance assembler tests to cover confidence-1.0 concatenation, alias unioning, and robust handling of non-dict attributes.
- Expand preprocess and step_pass2 tests to validate HTML/PDF preprocessing flows, skipped-file manifesting, mineru timeouts, schema flattening, manifest loading, sharded runs, and prep modes.