### PR TITLE
fix: atomic writes for edge_metadata.json (crash-safety, to-do #23)

### DIFF
--- a/src/mykg/steps/step_assemble.py
+++ b/src/mykg/steps/step_assemble.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import json
 
-from mykg import config as _cfg
 from mykg.assembler import assign_stable_ids, deduplicate_edges, deduplicate_nodes
 from mykg.logging import get
 from mykg.name_normalizer import build_alias_index
 from mykg.orchestrator import PipelineContext
+from mykg.utility.atomic_io import atomic_write_json
 
 log = get("mykg.steps.assemble")
 
@@ -49,10 +49,8 @@ def run_assemble(ctx: PipelineContext) -> None:
         len(ctx.nodes),
         len(ctx.edge_metadata),
     )
-    (ctx.intermediate_dir / "edge_metadata.json").write_text(
-        json.dumps(ctx.edge_metadata, indent=_cfg.JSON_INDENT)
-    )
-    (ctx.intermediate_dir / "nodes.json").write_text(json.dumps(ctx.nodes, indent=_cfg.JSON_INDENT))
+    atomic_write_json(ctx.intermediate_dir / "edge_metadata.json", ctx.edge_metadata)
+    atomic_write_json(ctx.intermediate_dir / "nodes.json", ctx.nodes)
 
     # Preserve synonym_collapse events written by pass1 (D21), then append
     # dedup events from this assembly run. On Re-entry C (--from-step assemble),
@@ -66,5 +64,5 @@ def run_assemble(ctx: PipelineContext) -> None:
         except (json.JSONDecodeError, ValueError):
             synonym_events = []
     merge_log = synonym_events + node_log + edge_log
-    merge_log_path.write_text(json.dumps(merge_log, indent=_cfg.JSON_INDENT))
+    atomic_write_json(merge_log_path, merge_log)
     log.info("Steps 7–9 — merge_log.json written (%d entries)", len(merge_log))

--- a/src/mykg/steps/step_orphan_connect.py
+++ b/src/mykg/steps/step_orphan_connect.py
@@ -13,6 +13,7 @@ from mykg.orphan_connector import (
     confirm_orphan_chunk_groups,
     propose_schema_additions,
 )
+from mykg.utility.atomic_io import atomic_write_json
 
 log = get("mykg.steps.orphan_connect")
 
@@ -27,12 +28,8 @@ def _edge_id(edge: dict) -> str:
 def run_orphan_connect(ctx: PipelineContext) -> None:
     if not _cfg.ORPHAN_PASS_ENABLED:
         log.info("Step orphan_connect — skipped (orphan_pass.enabled: false)")
-        (ctx.intermediate_dir / "orphan_connections.json").write_text(
-            json.dumps({}, indent=_cfg.JSON_INDENT)
-        )
-        (ctx.intermediate_dir / "orphan_log.json").write_text(
-            json.dumps([], indent=_cfg.JSON_INDENT)
-        )
+        atomic_write_json(ctx.intermediate_dir / "orphan_connections.json", {})
+        atomic_write_json(ctx.intermediate_dir / "orphan_log.json", [])
         return
 
     raw_payload = json.loads((ctx.intermediate_dir / "orphan_candidates.json").read_text())
@@ -89,7 +86,7 @@ def run_orphan_connect(ctx: PipelineContext) -> None:
         error_gate=ctx.error_gate,
     )
 
-    (ctx.intermediate_dir / "nodes.json").write_text(json.dumps(nodes, indent=_cfg.JSON_INDENT))
+    atomic_write_json(ctx.intermediate_dir / "nodes.json", nodes)
     ctx.nodes = nodes
 
     # Seed from prior run; new confirmations are overlaid (dedup by ID).
@@ -152,15 +149,11 @@ def run_orphan_connect(ctx: PipelineContext) -> None:
             continue
         edge_metadata[eid] = edge
 
-    edge_metadata_path.write_text(json.dumps(edge_metadata, indent=_cfg.JSON_INDENT))
+    atomic_write_json(edge_metadata_path, edge_metadata)
     ctx.edge_metadata = edge_metadata
 
-    (ctx.intermediate_dir / "orphan_log.json").write_text(
-        json.dumps(orphan_log, indent=_cfg.JSON_INDENT)
-    )
-    (ctx.intermediate_dir / "orphan_connections.json").write_text(
-        json.dumps(orphan_connections, indent=_cfg.JSON_INDENT)
-    )
+    atomic_write_json(ctx.intermediate_dir / "orphan_log.json", orphan_log)
+    atomic_write_json(ctx.intermediate_dir / "orphan_connections.json", orphan_connections)
 
     log.info(
         "Step orphan_connect — %d edge(s) added to edge_metadata.json (%d skipped as duplicates)",
@@ -190,8 +183,9 @@ def run_orphan_connect(ctx: PipelineContext) -> None:
                 "schema_max_restarts=0; skipping schema proposal LLM call.",
                 len(schema_gap_orphans),
             )
-            (ctx.intermediate_dir / "schema_gap_proposals.json").write_text(
-                json.dumps({"new_properties": []}, indent=_cfg.JSON_INDENT)
+            atomic_write_json(
+                ctx.intermediate_dir / "schema_gap_proposals.json",
+                {"new_properties": []},
             )
             return
         log.info(
@@ -200,8 +194,9 @@ def run_orphan_connect(ctx: PipelineContext) -> None:
             len(schema_gap_orphans),
         )
         proposal = propose_schema_additions(schema_gap_orphans, schema, ctx.adapter, chunk_texts)
-        (ctx.intermediate_dir / "schema_gap_proposals.json").write_text(
-            json.dumps(proposal or {"new_properties": []}, indent=_cfg.JSON_INDENT)
+        atomic_write_json(
+            ctx.intermediate_dir / "schema_gap_proposals.json",
+            proposal or {"new_properties": []},
         )
 
         if proposal and proposal.get("new_properties"):

--- a/src/mykg/steps/step_preprocess.py
+++ b/src/mykg/steps/step_preprocess.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -13,6 +12,7 @@ from pathlib import Path
 from mykg import config as _cfg
 from mykg.logging import get
 from mykg.orchestrator import PipelineContext
+from mykg.utility.atomic_io import atomic_write_json
 
 log = get("mykg.steps.preprocess")
 
@@ -31,10 +31,8 @@ def _write_sentinel(intermediate_dir: Path, manifest: dict) -> None:
 
 
 def _atomic_write_json(path: Path, data: dict) -> None:
-    """Write JSON atomically: write to .tmp, then os.replace onto the target."""
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(data, indent=_cfg.JSON_INDENT))
-    os.replace(tmp, path)
+    """Write JSON atomically. Thin alias kept for in-module call sites."""
+    atomic_write_json(path, data)
 
 
 def _sha256_path(p: Path) -> str:

--- a/src/mykg/utility/atomic_io.py
+++ b/src/mykg/utility/atomic_io.py
@@ -6,10 +6,13 @@ pipeline outputs are single sources of truth — most notably
 ``intermediate/edge_metadata.json`` (D8) — so a truncated write corrupts state
 that later re-entry points read back blindly.
 
-``atomic_write_json`` writes to a sibling ``.tmp`` file and then ``os.replace``s
-it over the target. ``os.replace`` is atomic on POSIX and Windows, so a reader
-(or a crash) ever sees either the old complete file or the new complete file,
-never a partial one.
+``atomic_write_json`` writes to a sibling ``.tmp`` file, ``fsync``s it so the
+bytes are durably on disk, and then ``os.replace``s it over the target.
+``os.replace`` is atomic on POSIX and Windows, so a reader (or a crash) ever
+sees either the old complete file or the new complete file, never a partial one.
+The ``fsync`` extends the guarantee to survive sudden power loss, not just a
+mid-write process kill. On any failure the temp file is removed so a failed
+write never leaves stray ``.tmp`` files behind.
 """
 
 from __future__ import annotations
@@ -25,9 +28,19 @@ from mykg import config as _cfg
 def atomic_write_json(path: Path, data: Any) -> None:
     """Serialize ``data`` to JSON and write it to ``path`` atomically.
 
-    Writes to ``<path>.tmp`` first, then ``os.replace`` onto ``path``. Uses the
-    configured ``JSON_INDENT`` so output matches every other intermediate file.
+    Writes to ``<path>.tmp``, ``fsync``s it to disk, then ``os.replace`` onto
+    ``path``. Uses the configured ``JSON_INDENT`` so output matches every other
+    intermediate file. If anything fails, the temp file is cleaned up so no
+    stray ``.tmp`` is left behind.
     """
     tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(data, indent=_cfg.JSON_INDENT))
-    os.replace(tmp, path)
+    payload = json.dumps(data, indent=_cfg.JSON_INDENT)
+    try:
+        with tmp.open("w") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise

--- a/src/mykg/utility/atomic_io.py
+++ b/src/mykg/utility/atomic_io.py
@@ -1,0 +1,33 @@
+"""Atomic file writes shared across pipeline steps.
+
+A bare ``path.write_text(...)`` is not crash-safe: if the process is killed
+(SIGKILL/OOM) partway through, the target file is left truncated. Several
+pipeline outputs are single sources of truth — most notably
+``intermediate/edge_metadata.json`` (D8) — so a truncated write corrupts state
+that later re-entry points read back blindly.
+
+``atomic_write_json`` writes to a sibling ``.tmp`` file and then ``os.replace``s
+it over the target. ``os.replace`` is atomic on POSIX and Windows, so a reader
+(or a crash) ever sees either the old complete file or the new complete file,
+never a partial one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from mykg import config as _cfg
+
+
+def atomic_write_json(path: Path, data: Any) -> None:
+    """Serialize ``data`` to JSON and write it to ``path`` atomically.
+
+    Writes to ``<path>.tmp`` first, then ``os.replace`` onto ``path``. Uses the
+    configured ``JSON_INDENT`` so output matches every other intermediate file.
+    """
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=_cfg.JSON_INDENT))
+    os.replace(tmp, path)

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -61,3 +61,27 @@ def test_crash_mid_replace_preserves_old_file(tmp_path: Path, monkeypatch) -> No
 
     # Old content survives — no partial/truncated write reached the target.
     assert json.loads(target.read_text()) == {"intact": True}
+    # The temp file from the failed write is cleaned up, not left behind.
+    assert not (tmp_path / "edge_metadata.json.tmp").exists()
+
+
+def test_fsync_called_before_replace(tmp_path: Path, monkeypatch) -> None:
+    """Bytes are fsync'd to disk before the rename, guarding against power loss."""
+    calls: list[str] = []
+    real_fsync = os.fsync
+    real_replace = os.replace
+
+    def traced_fsync(fd):
+        calls.append("fsync")
+        return real_fsync(fd)
+
+    def traced_replace(src, dst):
+        calls.append("replace")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "fsync", traced_fsync)
+    monkeypatch.setattr(os, "replace", traced_replace)
+
+    atomic_write_json(tmp_path / "nodes.json", {"ok": True})
+
+    assert calls == ["fsync", "replace"], "fsync must happen before the atomic rename"

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from mykg.utility.atomic_io import atomic_write_json
+
+
+def test_writes_correct_content(tmp_path: Path) -> None:
+    target = tmp_path / "edge_metadata.json"
+    data = {"edge-1": {"type": "works_at", "from": "a", "to": "b"}}
+
+    atomic_write_json(target, data)
+
+    assert json.loads(target.read_text()) == data
+
+
+def test_overwrites_existing_file(tmp_path: Path) -> None:
+    target = tmp_path / "nodes.json"
+    target.write_text(json.dumps({"old": True}))
+
+    atomic_write_json(target, {"new": True})
+
+    assert json.loads(target.read_text()) == {"new": True}
+
+
+def test_serializes_lists(tmp_path: Path) -> None:
+    target = tmp_path / "orphan_log.json"
+    data = [{"event": "orphan_edge_added"}, {"event": "orphan_edge_rejected"}]
+
+    atomic_write_json(target, data)
+
+    assert json.loads(target.read_text()) == data
+
+
+def test_leaves_no_tmp_file_on_success(tmp_path: Path) -> None:
+    target = tmp_path / "schema_gap_proposals.json"
+
+    atomic_write_json(target, {"new_properties": []})
+
+    assert not (tmp_path / "schema_gap_proposals.json.tmp").exists()
+    assert list(tmp_path.iterdir()) == [target]
+
+
+def test_crash_mid_replace_preserves_old_file(tmp_path: Path, monkeypatch) -> None:
+    """If os.replace fails (crash window), the original target must remain intact —
+    never a truncated file. This is the core guarantee item 23 asks for."""
+    target = tmp_path / "edge_metadata.json"
+    target.write_text(json.dumps({"intact": True}))
+
+    def boom(src, dst):
+        raise OSError("simulated crash during replace")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+    with pytest.raises(OSError):
+        atomic_write_json(target, {"new": "data"})
+
+    # Old content survives — no partial/truncated write reached the target.
+    assert json.loads(target.read_text()) == {"intact": True}


### PR DESCRIPTION
## What & why

A bare `path.write_text()` is **not crash-safe**: a process killed mid-write (SIGKILL/OOM) leaves the target file truncated. `intermediate/edge_metadata.json` is the single source of truth for all edge metadata (D8), so a truncated write corrupts state that later re-entry points read back blindly — `validate_graph` would then read a partial file with no warning.

This addresses the **atomic-write half of `architecture.md` to-do #23** (the truncation-on-crash risk).

## Change

- Adds `src/mykg/utility/atomic_io.py::atomic_write_json` — writes to a sibling `.tmp`, then `os.replace` onto the target (atomic on POSIX and Windows). Uses the configured `JSON_INDENT` so output is byte-identical to before.
- Routes **both** `edge_metadata.json` writers through it:
  - `step_assemble.py:52`
  - `step_orphan_connect.py:155` (the read-modify-write named in #23)
- Routes the adjacent intermediate-JSON writes in the same two steps through it for consistency: `nodes.json`, `merge_log.json`, `orphan_log.json`, `orphan_connections.json`, `schema_gap_proposals.json`.
- The existing private `_atomic_write_json` in `step_preprocess.py` now delegates to the shared helper (de-duplicated); its in-module call site is unchanged.
- Removes now-dead imports (`os` in step_preprocess, `_cfg` in step_assemble).

No new dependencies. Behavior of the write path is identical except for atomicity.

## Out of scope

The **concurrent-same-session last-write-wins** half of #23 (two processes writing one session's `edge_metadata.json` in parallel) is a separate, design-gated concern — it requires cross-process locking, a new dependency used nowhere else, and a decision about whether concurrent same-session runs are even supported (per D32 each run is normally an isolated session). Tracked separately.

## Testing

- New `tests/test_atomic_io.py` (5 tests, 100% coverage of the helper) including a **crash-window regression**: if `os.replace` raises mid-write, the original target file is left intact (never truncated).
- E2E: ran the real `run_orphan_connect` step against a temp session dir — sidecars written atomically, valid JSON, no `.tmp` residue.
- `113 passed` across `test_atomic_io / test_assembler / test_orphan_connector / test_orphan_steps / test_preprocess_step`.
- `ruff check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce shared atomic JSON write helper and route critical intermediate outputs through it to ensure crash-safe file writes.

New Features:
- Add shared atomic_write_json utility for atomic JSON file output across pipeline steps.

Enhancements:
- Refactor assemble, orphan_connect, and preprocess steps to use the shared atomic_write_json helper for intermediate JSON artifacts, including edge_metadata.json, nodes.json, logs, and schema proposals.

Tests:
- Add dedicated atomic_io test suite covering correctness, overwrite behavior, list serialization, absence of tmp residue, and crash-window integrity guarantees.