### PR TITLE
Propagate base-schema lock into Pass 1 cleanup prompts

### DIFF
--- a/src/mykg/schema_merge.py
+++ b/src/mykg/schema_merge.py
@@ -151,20 +151,30 @@ def _normalize_schema(schema: dict) -> dict:
     return schema
 
 
-def harmonize_schema(schema: dict, proposals: list[dict], adapter: LLMAdapter) -> dict:
+def harmonize_schema(
+    schema: dict, proposals: list[dict], adapter: LLMAdapter, locked_block: str = ""
+) -> dict:
     """LLM pass that collapses semantic near-duplicates the algorithmic merge missed.
 
     Sees both the merged schema and all raw batch proposals so it can detect concepts
     that were kept separate only because their names differed slightly across batches.
     Returns the improved schema, or the original if the response is unparseable.
+
+    ``locked_block`` is the base-schema lock notice (D27). When non-empty it is appended
+    to the system prompt so this unlocked pass is told which names it must not rename,
+    remove, or duplicate — the same mechanism Pass 1 extraction uses. Empty by default,
+    so behaviour is unchanged when no base schema is in play.
     """
     proposals_block = json.dumps(proposals, indent=2)
     merged_block = json.dumps(schema, indent=2)
     user = "MERGED SCHEMA:\n" + merged_block + "\n\nRAW PROPOSALS:\n" + proposals_block
+    system = _HARMONIZE_SYSTEM_PROMPT
+    if locked_block:
+        system = system + "\n\n" + locked_block
     try:
         raw = llm_complete_with_retry(
             adapter,
-            _HARMONIZE_SYSTEM_PROMPT,
+            system,
             user,
             context_label="schema_harmonize",
         )
@@ -198,17 +208,25 @@ def _reject_empty_schema(improved: dict, original: dict, label: str) -> dict | N
     return None
 
 
-def review_schema_quality(schema: dict, adapter: LLMAdapter) -> dict:
+def review_schema_quality(schema: dict, adapter: LLMAdapter, locked_block: str = "") -> dict:
     """Call the LLM to review the merged schema for quality issues.
 
     Returns the improved schema dict, or the original if the LLM response
     cannot be parsed or has the wrong structure.
+
+    ``locked_block`` is the base-schema lock notice (D27). When non-empty it is appended
+    to the system prompt so this unlocked pass — whose instructions explicitly tell the
+    LLM to remove "singleton" concepts and rename "generic" properties — is told which
+    names it must not touch. Empty by default; behaviour unchanged without a base schema.
     """
     user = json.dumps(schema, indent=2)
+    system = _QUALITY_SYSTEM_PROMPT
+    if locked_block:
+        system = system + "\n\n" + locked_block
     try:
         raw = llm_complete_with_retry(
             adapter,
-            _QUALITY_SYSTEM_PROMPT,
+            system,
             user,
             context_label="schema_quality_review",
         )

--- a/src/mykg/steps/step_pass1.py
+++ b/src/mykg/steps/step_pass1.py
@@ -84,7 +84,7 @@ def run_pass1_step(ctx: PipelineContext) -> None:
     write_schema(schema, ctx.intermediate_dir, TRIGGER_PASS1_MERGE)
 
     log.info("Step 3 — harmonizing schema (semantic near-duplicate collapse) …")
-    schema = harmonize_schema(schema, proposals, ctx.adapter)
+    schema = harmonize_schema(schema, proposals, ctx.adapter, locked_block=locked_block)
     n_concepts_h = len(schema.get("concepts", []))
     n_props_h = len(schema.get("properties", []))
     log.info(
@@ -95,7 +95,7 @@ def run_pass1_step(ctx: PipelineContext) -> None:
     write_schema(schema, ctx.intermediate_dir, TRIGGER_SCHEMA_HARMONIZE)
 
     log.info("Step 3 — reviewing schema quality …")
-    schema = review_schema_quality(schema, ctx.adapter)
+    schema = review_schema_quality(schema, ctx.adapter, locked_block=locked_block)
     n_concepts_q = len(schema.get("concepts", []))
     n_props_q = len(schema.get("properties", []))
     log.info(

--- a/tests/test_pass1.py
+++ b/tests/test_pass1.py
@@ -359,6 +359,46 @@ def test_run_pass1_step_applies_quality_review(tmp_path):
     assert "schema_quality" in triggers
 
 
+def test_run_pass1_step_propagates_locked_block_to_cleanup_prompts(tmp_path):
+    """End-to-end wiring: with a base schema, run_pass1_step must inject the locked
+    block into BOTH cleanup-pass system prompts (harmonize + quality review), not just
+    the Pass 1 extraction prompt. Guards against someone dropping the locked_block
+    argument from either call site — which the per-function unit tests cannot catch.
+    """
+    response = json.dumps(
+        {
+            "concepts": [{"type": "Vehicle", "parent": None, "attributes": ["name"]}],
+            "properties": [],
+        }
+    )
+    # SequenceAdapter records every (system, user) call: pass1 batch(es), then
+    # harmonize, then quality review. With one batch that is 3 calls.
+    adapter = SequenceAdapter([response, response, response])
+    ctx = _make_step_ctx(tmp_path, adapter)
+    ctx.base_schema = {
+        "locked_classes": {
+            "Vehicle": {"type": "Vehicle", "parent": None, "attributes": ["name"]}
+        },
+        "locked_properties": {
+            "owns": {"name": "owns", "domain": "Person", "range": "Vehicle", "attributes": []}
+        },
+    }
+    run_pass1_step(ctx)
+
+    # The locked block lists the locked class/property names; assert both reach the
+    # harmonize and quality system prompts. Identify each pass by its base prompt.
+    from mykg.schema_merge import _HARMONIZE_SYSTEM_PROMPT, _QUALITY_SYSTEM_PROMPT
+
+    harmonize_systems = [s for s, _ in adapter.calls if s.startswith(_HARMONIZE_SYSTEM_PROMPT)]
+    quality_systems = [s for s, _ in adapter.calls if s.startswith(_QUALITY_SYSTEM_PROMPT)]
+    assert harmonize_systems, "harmonize_schema was never called"
+    assert quality_systems, "review_schema_quality was never called"
+    for system in harmonize_systems + quality_systems:
+        assert "Vehicle" in system, "locked class name missing from cleanup prompt"
+        assert "owns" in system, "locked property name missing from cleanup prompt"
+        assert "DO NOT RENAME, REMOVE, OR DUPLICATE" in system
+
+
 # ---------------------------------------------------------------------------
 # List-type guard tests
 # ---------------------------------------------------------------------------

--- a/tests/test_schema_merge.py
+++ b/tests/test_schema_merge.py
@@ -234,8 +234,9 @@ def test_harmonize_injects_locked_block():
     adapter.complete.return_value = json.dumps(_REDUCED_SCHEMA)
     harmonize_schema(_SMALL_SCHEMA, _RAW_PROPOSALS, adapter, locked_block=_LOCKED_BLOCK)
     system_prompt = adapter.complete.call_args[0][0]
-    assert _LOCKED_BLOCK in system_prompt
-    assert system_prompt.startswith(_HARMONIZE_SYSTEM_PROMPT)
+    # Exact match pins the placement and spacing of the block, not just its presence,
+    # so a prompt-format regression that weakens the lock signal is caught.
+    assert system_prompt == _HARMONIZE_SYSTEM_PROMPT + "\n\n" + _LOCKED_BLOCK
 
 
 def test_harmonize_no_locked_block_unchanged():
@@ -251,8 +252,8 @@ def test_review_quality_injects_locked_block():
     adapter.complete.return_value = json.dumps(_SMALL_SCHEMA)
     review_schema_quality(_SMALL_SCHEMA, adapter, locked_block=_LOCKED_BLOCK)
     system_prompt = adapter.complete.call_args[0][0]
-    assert _LOCKED_BLOCK in system_prompt
-    assert system_prompt.startswith(_QUALITY_SYSTEM_PROMPT)
+    # Exact match (mirrors the harmonize test) guards placement + spacing of the block.
+    assert system_prompt == _QUALITY_SYSTEM_PROMPT + "\n\n" + _LOCKED_BLOCK
 
 
 def test_review_quality_no_locked_block_unchanged():

--- a/tests/test_schema_merge.py
+++ b/tests/test_schema_merge.py
@@ -2,6 +2,8 @@ import json
 from unittest.mock import MagicMock
 
 from mykg.schema_merge import (
+    _HARMONIZE_SYSTEM_PROMPT,
+    _QUALITY_SYSTEM_PROMPT,
     _normalize_schema,
     harmonize_schema,
     harmonize_schema_for_merge,
@@ -216,6 +218,49 @@ def test_harmonize_falls_back_on_wrong_structure():
     adapter.complete.return_value = json.dumps({"concepts": []})
     result = harmonize_schema(_SMALL_SCHEMA, _RAW_PROPOSALS, adapter)
     assert result is _SMALL_SCHEMA
+
+
+# base-schema lock injection (D27) — the locked block must reach the cleanup-pass
+# system prompt so this unlocked pass is told which names it must not rename/remove.
+
+_LOCKED_BLOCK = (
+    "EXISTING SCHEMA (DO NOT RENAME, REMOVE, OR DUPLICATE THESE):\n"
+    "Classes: OrderHeader\nProperties: writes\n"
+)
+
+
+def test_harmonize_injects_locked_block():
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(_REDUCED_SCHEMA)
+    harmonize_schema(_SMALL_SCHEMA, _RAW_PROPOSALS, adapter, locked_block=_LOCKED_BLOCK)
+    system_prompt = adapter.complete.call_args[0][0]
+    assert _LOCKED_BLOCK in system_prompt
+    assert system_prompt.startswith(_HARMONIZE_SYSTEM_PROMPT)
+
+
+def test_harmonize_no_locked_block_unchanged():
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(_REDUCED_SCHEMA)
+    harmonize_schema(_SMALL_SCHEMA, _RAW_PROPOSALS, adapter)
+    system_prompt = adapter.complete.call_args[0][0]
+    assert system_prompt == _HARMONIZE_SYSTEM_PROMPT
+
+
+def test_review_quality_injects_locked_block():
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(_SMALL_SCHEMA)
+    review_schema_quality(_SMALL_SCHEMA, adapter, locked_block=_LOCKED_BLOCK)
+    system_prompt = adapter.complete.call_args[0][0]
+    assert _LOCKED_BLOCK in system_prompt
+    assert system_prompt.startswith(_QUALITY_SYSTEM_PROMPT)
+
+
+def test_review_quality_no_locked_block_unchanged():
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(_SMALL_SCHEMA)
+    review_schema_quality(_SMALL_SCHEMA, adapter)
+    system_prompt = adapter.complete.call_args[0][0]
+    assert system_prompt == _QUALITY_SYSTEM_PROMPT
 
 
 def test_harmonize_calls_llm_once():


### PR DESCRIPTION
## Problem

The `--base-schema` lock (D27) lets a user supply a locked RDFS TBox the LLM may **enrich** but must not **rename, remove, or re-parent**. It's enforced hard in the *algorithmic* merge — `merge_proposals` seeds the working set with locked entries and only ever unions attributes onto them (`schema_merge.py`).

But Pass 1 then runs **two more LLM passes** — `harmonize_schema` and `review_schema_quality` (`steps/step_pass1.py`) — and **neither received the locked sets**. They hand the entire merged schema to the LLM and trust the result. Their prompts actively instruct the LLM to do exactly what the lock forbids:

- `quality_system.txt` rule 3: remove "singleton / named-entity" concepts → a locked table like `OrderHeader` reads as a named entity and gets deleted.
- rule 4: rename "overly generic properties" → `references` / `writes` are prime rename targets.
- rule 5: collapse a subclass with no own attributes into its parent.
- `harmonize_system.txt` C: lift "misclassified instances" → same deletion risk.

So a locked schema can survive the merge intact and then be mangled by the cleanup passes.

## Fix

Both cleanup functions gain an optional `locked_block: str = ""` appended to their system prompt — the **same advisory mechanism Pass 1 extraction already uses** (`pass1.py`). `step_pass1` passes the `locked_block` it already builds. Default `""` ⇒ **zero behavior change** when no base schema is present; every existing positional call site stays valid.

## Honest limitation

This is **advisory** (prompt-level) — the same strength as the existing Pass 1 lock prompt. It stops the common case but is **not** an absolute guarantee against a model that ignores the instruction. A deterministic post-pass re-assert would be the unbreakable floor; intentionally **out of scope** here.

## Scope

Extract pipeline only. The merge-graphs cleanup twins (`*_for_merge`) are untouched — merge has no `--base-schema` wiring today, so a locked block there would always be empty.

## Tests

4 new tests in `test_schema_merge.py`: block-injected (asserts it reaches the system prompt, prepended to the bare constant) and block-absent (asserts the prompt is unchanged), for each function. Targeted suite (`test_schema_merge.py` + `test_pass1.py`): **70 passed**. Full suite: 1109 passed; the 1 failure (`test_live_pipeline.py::test_claude_cli_adapter_smoke`) is a pre-existing flaky live-CLI smoke test unrelated to this change — it passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Propagate the base-schema lock notice into the Pass 1 LLM cleanup prompts so that harmonization and quality review respect locked schema elements, and extend tests to cover prompt injection behavior.

Bug Fixes:
- Ensure the base-schema lock advisory block is appended to the harmonize and quality review LLM system prompts so locked concepts and properties are not renamed or removed during cleanup passes.

Enhancements:
- Add optional locked_block parameters to harmonize_schema and review_schema_quality while keeping existing behavior unchanged when no base schema is provided.

Tests:
- Add tests verifying that the locked_block text is injected into harmonize and quality review system prompts when provided, and that prompts remain unchanged when it is absent.