### PR TITLE
feat: --append-with-grow-schema locked-incremental schema growth (D52)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -325,11 +325,11 @@ After each LLM call, the pipeline validates the response: edges whose type is no
 
 **Per-file shards.** When a file finishes, its results are written immediately to a per-file shard on disk. On restart, files with existing shards are skipped. Only unfinished files are re-extracted.
 
-### Incremental Schema Growth (`--append --grow-schema`)
+### Incremental Schema Growth (`--append-with-grow-schema`)
 
-Plain `--append` re-runs only on new or modified files against the existing, frozen schema — Pass 1 is skipped, so the schema can never grow. `--grow-schema` (which requires `--append`) lifts that restriction at bounded cost.
+Plain `--append` re-runs only on new or modified files against the existing, frozen schema — Pass 1 is skipped, so the schema can never grow. `--append-with-grow-schema` lifts that restriction at bounded cost (it implies `--append`).
 
-When `--grow-schema` is set, the session's existing `intermediate/schema.ttl` is auto-loaded as a **locked base schema** (the same lock mechanism used by `--base-schema`): the LLM may ADD new concepts and properties but cannot rename, remove, or restructure the existing ones. Passing `--base-schema` alongside `--grow-schema` is an error — the base is auto-derived from the session.
+When `--append-with-grow-schema` is set, the session's existing `intermediate/schema.ttl` is auto-loaded as a **locked base schema** (the same lock mechanism used by `--base-schema`): the LLM may ADD new concepts and properties but cannot rename, remove, or restructure the existing ones. Passing `--base-schema` alongside `--append-with-grow-schema` is an error — the base is auto-derived from the session.
 
 The flow has three parts:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -325,6 +325,22 @@ After each LLM call, the pipeline validates the response: edges whose type is no
 
 **Per-file shards.** When a file finishes, its results are written immediately to a per-file shard on disk. On restart, files with existing shards are skipped. Only unfinished files are re-extracted.
 
+### Incremental Schema Growth (`--append --grow-schema`)
+
+Plain `--append` re-runs only on new or modified files against the existing, frozen schema — Pass 1 is skipped, so the schema can never grow. `--grow-schema` (which requires `--append`) lifts that restriction at bounded cost.
+
+When `--grow-schema` is set, the session's existing `intermediate/schema.ttl` is auto-loaded as a **locked base schema** (the same lock mechanism used by `--base-schema`): the LLM may ADD new concepts and properties but cannot rename, remove, or restructure the existing ones. Passing `--base-schema` alongside `--grow-schema` is an error — the base is auto-derived from the session.
+
+The flow has three parts:
+
+1. **Changed-files-only locked Pass 1.** Pass 1 is re-run, but only over the new/modified files, with the existing vocabulary injected as a locked block. The merge step unions any genuinely new concepts/properties into the locked schema.
+
+2. **Changed-file extraction.** Pass 2 extracts the new/modified files against the now-grown schema, exactly as plain `--append` does.
+
+3. **Schema-delta surgical back-fill.** When — and only when — the locked Pass 1 actually grew the schema, the already-extracted OLD files are stale: they were extracted before the new types existed. The back-fill selector decides which OLD chunks are worth re-extracting, using only `chunk_node_index.json` (no source text is re-read). A new property `D → R` targets old chunks that already contain a node of type `D` or `R`; a new concept targets old chunks containing nodes of its parent or sibling type (a root concept with no parent/siblings yields no targets). Candidates are ranked by co-occurrence count and capped per type by `pipeline.append.grow_schema_backfill_top_k_chunks_per_type` (default 10; `0` disables back-fill). Only those chunks are re-extracted surgically; all other shards are reused.
+
+This keeps the graph consistent — instances of a newly-added type appear in BOTH the new and the old documents — while staying sub-linear in corpus size (Invariant 16). The selector is a heuristic: false negatives are backstopped by the orphan pass and future runs, and a false positive costs only one no-op LLM call, bounded by the top-K cap. All exported formats are kept in sync by the same export-time validation as a fresh run (Invariant 14).
+
 ### Assembly and Deduplication
 
 Once all files are extracted, the assembler combines everything into a single consistent graph.

--- a/mykg_config.yaml
+++ b/mykg_config.yaml
@@ -178,6 +178,8 @@ profiles:
         surgical_top_k_chunks_per_property: 5  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   anthropic-claude:
@@ -341,6 +343,8 @@ profiles:
         surgical_top_k_chunks_per_property: 5  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   claude-cli:
@@ -501,6 +505,8 @@ profiles:
         surgical_top_k_chunks_per_property: 5  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   openai:
@@ -670,6 +676,8 @@ profiles:
         surgical_top_k_chunks_per_property: 0  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   ollama-local:
@@ -833,6 +841,8 @@ profiles:
         surgical_top_k_chunks_per_property: 0  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   agent-claude-code:
@@ -986,3 +996,5 @@ profiles:
         surgical_top_k_chunks_per_property: 0
         human_review: false
         orphan_pass_max_restarts: 0
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (D52)

--- a/scripts/live_test_grow_schema.py
+++ b/scripts/live_test_grow_schema.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+"""Live end-to-end test of mykg `--append --grow-schema` against OpenRouter.
+
+Runs two real pipeline stages and emits a reusable, idempotent report:
+
+  STAGE 1  initial `extract-graph <input_dir>` (auto-creates a session)
+  STAGE 2  copy <new_file> into <input_dir>, then
+           `extract-graph <input_dir> --append --grow-schema --session <s1>`
+
+It reports the stage-2 schema delta, back-fill evidence (whether the OLD
+file's shard was rewritten), and node/edge changes.
+
+Key behaviours / safety:
+  * There is NO `--profile` flag on extract-graph. The active profile is the
+    top-level `profile:` key in mykg_config.yaml. This script rewrites that
+    one line to the chosen profile (exactly like `mykg init`), and ALWAYS
+    restores the original value via try/finally + atexit.
+  * Must be run from the repo root so `.env.mykg` (OPENROUTER_API_KEY) is
+    picked up by the CLI's load_dotenv(".env.mykg").
+  * An EMPTY schema delta is a VALID success: grow mode correctly collapses
+    to a plain append when nothing new is induced.
+  * Exits non-zero only on real failure (CLI non-zero exit, missing outputs,
+    0 or >1 new sessions in stage 1).
+
+Usage:
+    uv run python scripts/live_test_grow_schema.py
+    uv run python scripts/live_test_grow_schema.py --profile openrouter-free \
+        --input-dir _input_files --new-file tech_stack.md --config mykg_config.yaml
+"""
+from __future__ import annotations
+
+import argparse
+import atexit
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Repo root = parent of this script's directory (scripts/ lives at the root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# --------------------------------------------------------------------------- #
+# Small helpers
+# --------------------------------------------------------------------------- #
+def _log(msg: str) -> None:
+    print(f"[live-test] {msg}", flush=True)
+
+
+def _sha256_path(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _wc_l(path: Path) -> int:
+    """Count non-empty lines in a JSONL file (0 if missing)."""
+    if not path.exists():
+        return 0
+    n = 0
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip():
+                n += 1
+    return n
+
+
+def _load_schema(schema_path: Path) -> dict:
+    if not schema_path.exists():
+        return {"concepts": [], "properties": []}
+    with schema_path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _concept_names(schema: dict) -> set[str]:
+    return {c.get("type", "") for c in schema.get("concepts", []) if c.get("type")}
+
+
+def _property_names(schema: dict) -> set[str]:
+    return {p.get("name", "") for p in schema.get("properties", []) if p.get("name")}
+
+
+def _session_names(sessions_root: Path) -> set[str]:
+    if not sessions_root.exists():
+        return set()
+    return {p.name for p in sessions_root.iterdir() if p.is_dir()}
+
+
+def _run_cli(args: list[str]) -> int:
+    """Run `uv run mykg ...` from the repo root, streaming output live."""
+    cmd = ["uv", "run", "mykg", *args]
+    _log("$ " + " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=str(REPO_ROOT))
+    return proc.returncode
+
+
+def _tail_run_log(session_root: Path, n: int = 60) -> str:
+    log_path = session_root / "run.log"
+    if not log_path.exists():
+        return f"(no run.log at {log_path})"
+    lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(lines[-n:])
+
+
+# --------------------------------------------------------------------------- #
+# Profile rewrite (restored via try/finally AND atexit)
+# --------------------------------------------------------------------------- #
+class ProfileGuard:
+    """Rewrite the top-level `profile:` line; guarantee restoration."""
+
+    def __init__(self, config_path: Path, new_profile: str) -> None:
+        self.config_path = config_path
+        self.new_profile = new_profile
+        self.original_text = config_path.read_text(encoding="utf-8")
+        m = re.search(r"^profile:[ \t]*(\S+)", self.original_text, flags=re.M)
+        if not m:
+            raise RuntimeError(f"No top-level `profile:` line found in {config_path}")
+        self.original_profile = m.group(1)
+        self._restored = False
+
+    def apply(self) -> None:
+        new_text = re.sub(
+            r"^profile:.*$",
+            f"profile: {self.new_profile}",
+            self.original_text,
+            count=1,
+            flags=re.M,
+        )
+        self.config_path.write_text(new_text, encoding="utf-8")
+        _log(f"profile: {self.original_profile} -> {self.new_profile} (in {self.config_path.name})")
+
+    def restore(self) -> None:
+        if self._restored:
+            return
+        # Restore the ORIGINAL full text so no incidental edits leak.
+        self.config_path.write_text(self.original_text, encoding="utf-8")
+        self._restored = True
+        _log(f"profile restored to: {self.original_profile}")
+
+
+# --------------------------------------------------------------------------- #
+# Resolve the configured model slug for the chosen profile (best-effort).
+# --------------------------------------------------------------------------- #
+def _resolve_model(config_path: Path, profile: str) -> str:
+    """Parse the `model:` under the given profile block. Best-effort, no YAML dep."""
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except OSError:
+        return "(unknown)"
+    lines = text.splitlines()
+    in_profile = False
+    profile_indent = None
+    for line in lines:
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        if re.match(rf"^{re.escape(profile)}:\s*$", stripped):
+            in_profile = True
+            profile_indent = indent
+            continue
+        if in_profile:
+            # A line at the same indent as the profile key (and not blank/comment)
+            # ends the profile block.
+            if stripped and not stripped.startswith("#") and indent <= (profile_indent or 0):
+                break
+            m = re.match(r"model:\s*(\S+)", stripped)
+            if m:
+                return m.group(1)
+    return "(unknown)"
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Live e2e test of mykg --append --grow-schema against OpenRouter."
+    )
+    parser.add_argument("--profile", default="openrouter-free",
+                        help="LLM profile to activate (default: openrouter-free)")
+    parser.add_argument("--input-dir", default="_input_files",
+                        help="Input dir for extraction (default: _input_files)")
+    parser.add_argument("--new-file", default="tech_stack.md",
+                        help="File at repo root to add in stage 2 (default: tech_stack.md)")
+    parser.add_argument("--config", default="mykg_config.yaml",
+                        help="Config file holding the `profile:` key (default: mykg_config.yaml)")
+    args = parser.parse_args()
+
+    config_path = (REPO_ROOT / args.config).resolve()
+    input_dir = (REPO_ROOT / args.input_dir).resolve()
+    new_file_src = (REPO_ROOT / args.new_file).resolve()
+    sessions_root = REPO_ROOT / "mykg_sessions"
+    report_path = REPO_ROOT / "scripts" / "live_test_report.md"
+
+    # Pre-flight checks.
+    for p, label in [(config_path, "config"), (input_dir, "input dir"),
+                     (new_file_src, "new file")]:
+        if not p.exists():
+            _log(f"FATAL: {label} not found: {p}")
+            return 2
+
+    model = _resolve_model(config_path, args.profile)
+    _log(f"profile={args.profile}  model={model}")
+
+    # ----- Profile rewrite with guaranteed restore -----
+    guard = ProfileGuard(config_path, args.profile)
+    atexit.register(guard.restore)
+    guard.apply()
+
+    report: dict = {"errors": []}
+
+    try:
+        # ================= STAGE 1 =================
+        _log("STAGE 1: initial extract-graph")
+        before = _session_names(sessions_root)
+        stage1_cmd = [args.input_dir, "--obsidian-vault"]
+        rc1 = _run_cli(["extract-graph", *stage1_cmd])
+        after = _session_names(sessions_root)
+        new_sessions = sorted(after - before)
+
+        if rc1 != 0:
+            _log(f"STAGE 1 CLI exited {rc1}")
+            # Try to surface the run.log of the new session, if any.
+            for s in new_sessions:
+                _log(f"--- tail run.log of {s} ---")
+                print(_tail_run_log(sessions_root / s))
+            report["errors"].append(f"stage1 CLI exit {rc1}")
+            _write_report(report_path, report)
+            return 1
+
+        if len(new_sessions) != 1:
+            _log(f"STAGE 1 expected exactly 1 new session, got {len(new_sessions)}: {new_sessions}")
+            report["errors"].append(f"stage1 produced {len(new_sessions)} new sessions")
+            _write_report(report_path, report)
+            return 1
+
+        s1 = new_sessions[0]
+        s1_root = sessions_root / s1
+        _log(f"STAGE 1 session: {s1}")
+
+        s1_schema_path = s1_root / "intermediate" / "schema.json"
+        s1_nodes = s1_root / "output" / "nodes.jsonl"
+        s1_edges = s1_root / "output" / "edges.jsonl"
+
+        if not s1_nodes.exists() or _wc_l(s1_nodes) == 0:
+            _log("STAGE 1 nodes.jsonl missing or empty")
+            print(_tail_run_log(s1_root))
+            report["errors"].append("stage1 nodes.jsonl missing/empty")
+            _write_report(report_path, report)
+            return 1
+        if not s1_edges.exists() or _wc_l(s1_edges) == 0:
+            _log("STAGE 1 edges.jsonl missing or empty")
+            print(_tail_run_log(s1_root))
+            report["errors"].append("stage1 edges.jsonl missing/empty")
+            _write_report(report_path, report)
+            return 1
+
+        s1_schema = _load_schema(s1_schema_path)
+        s1_concepts = _concept_names(s1_schema)
+        s1_props = _property_names(s1_schema)
+        s1_node_count = _wc_l(s1_nodes)
+        s1_edge_count = _wc_l(s1_edges)
+
+        report.update({
+            "profile": args.profile,
+            "model": model,
+            "stage1_cmd": "mykg extract-graph " + " ".join(stage1_cmd),
+            "stage2_cmd": (
+                f"mykg extract-graph {args.input_dir} --append --grow-schema "
+                f"--session {s1} --obsidian-vault"
+            ),
+            "stage1_session": s1,
+            "stage1_concepts": len(s1_concepts),
+            "stage1_properties": len(s1_props),
+            "stage1_nodes": s1_node_count,
+            "stage1_edges": s1_edge_count,
+        })
+        _log(f"STAGE 1: concepts={len(s1_concepts)} properties={len(s1_props)} "
+             f"nodes={s1_node_count} edges={s1_edge_count}")
+
+        # ----- Locate OLD file's shard; snapshot mtime+sha BEFORE stage 2 -----
+        # NOTE: under `concat`/`batch_chunks` prep modes the OLD file is folded
+        # into a single virtual batch shard (e.g. concat_batch_0000.md.json), so
+        # an "Active_Projects" shard may not exist by name. We therefore also
+        # track raw_extractions.json (always rewritten when Pass 2 re-runs) and
+        # the orchestrator's "invalidated pass2 ... for N changed file(s)" log
+        # line as prep-mode-independent back-fill evidence.
+        intermediate = s1_root / "intermediate"
+        shard_dir = intermediate / "raw_extractions_shards"
+        old_shard = _find_old_shard(shard_dir, "Active_Projects")
+        old_shard_sha_before = _sha256_path(old_shard) if old_shard else None
+        old_shard_mtime_before = old_shard.stat().st_mtime if old_shard else None
+        report["old_shard_path"] = str(old_shard.relative_to(REPO_ROOT)) if old_shard else None
+
+        raw_extractions = intermediate / "raw_extractions.json"
+        raw_sha_before = _sha256_path(raw_extractions)
+        raw_mtime_before = raw_extractions.stat().st_mtime if raw_extractions.exists() else None
+
+        # Snapshot schema_history files BEFORE stage 2 (to identify new deltas).
+        history_dir = s1_root / "intermediate" / "schema_history"
+        history_before = (
+            {p.name for p in history_dir.iterdir()} if history_dir.exists() else set()
+        )
+
+        # ================= STAGE 2 =================
+        _log("STAGE 2: copy new file + append --grow-schema")
+        new_file_dst = input_dir / new_file_src.name
+        if new_file_dst.exists() and _sha256_path(new_file_dst) == _sha256_path(new_file_src):
+            _log(f"new file already present and identical: {new_file_dst.name}")
+            report["new_file_state"] = "already present (identical)"
+        else:
+            shutil.copy2(new_file_src, new_file_dst)
+            _log(f"copied {new_file_src.name} -> {new_file_dst}")
+            report["new_file_state"] = "copied"
+
+        stage2_args = [
+            args.input_dir, "--append", "--grow-schema",
+            "--session", s1, "--obsidian-vault",
+        ]
+        rc2 = _run_cli(["extract-graph", *stage2_args])
+        if rc2 != 0:
+            _log(f"STAGE 2 CLI exited {rc2}")
+            print(_tail_run_log(s1_root))
+            report["errors"].append(f"stage2 CLI exit {rc2}")
+            _write_report(report_path, report)
+            return 1
+
+        # ----- Stage-2 schema delta -----
+        s2_schema = _load_schema(s1_schema_path)  # same path, rewritten in place
+        s2_concepts = _concept_names(s2_schema)
+        s2_props = _property_names(s2_schema)
+
+        concepts_added = sorted(s2_concepts - s1_concepts)
+        concepts_removed = sorted(s1_concepts - s2_concepts)
+        props_added = sorted(s2_props - s1_props)
+        props_removed = sorted(s1_props - s2_props)
+
+        empty_delta = not (concepts_added or concepts_removed or props_added or props_removed)
+        report.update({
+            "delta_concepts_added": concepts_added,
+            "delta_concepts_removed": concepts_removed,
+            "delta_properties_added": props_added,
+            "delta_properties_removed": props_removed,
+            "delta_empty": empty_delta,
+        })
+
+        # ----- schema_history new files (stage-2 deltas) -----
+        history_after = (
+            {p.name for p in history_dir.iterdir()} if history_dir.exists() else set()
+        )
+        new_history = sorted(history_after - history_before)
+        report["schema_history_new_files"] = new_history
+        history_summaries = []
+        for name in new_history:
+            try:
+                hp = history_dir / name
+                hd = json.loads(hp.read_text(encoding="utf-8"))
+                history_summaries.append({
+                    "file": name,
+                    "trigger": hd.get("trigger"),
+                    "concepts_added": hd.get("concepts_added"),
+                    "concepts_removed": hd.get("concepts_removed"),
+                    "properties_added": hd.get("properties_added"),
+                    "properties_removed": hd.get("properties_removed"),
+                })
+            except Exception as exc:  # noqa: BLE001 - report parse issues, don't crash
+                history_summaries.append({"file": name, "parse_error": str(exc)})
+        report["schema_history_summaries"] = history_summaries
+
+        # ----- Back-fill evidence -----
+        # (a) Per-file shard rewrite — only meaningful in `per_file` prep mode.
+        old_shard_sha_after = _sha256_path(old_shard) if old_shard else None
+        old_shard_mtime_after = old_shard.stat().st_mtime if old_shard else None
+        shard_rewritten = (
+            old_shard is not None
+            and (old_shard_sha_before != old_shard_sha_after
+                 or old_shard_mtime_before != old_shard_mtime_after)
+        )
+        report["old_shard_rewritten"] = bool(shard_rewritten)
+        report["old_shard_sha_changed"] = (
+            old_shard is not None and old_shard_sha_before != old_shard_sha_after
+        )
+
+        # (b) raw_extractions.json rewrite — prep-mode-independent proof that
+        #     Pass 2 re-ran (and therefore re-extracted the OLD file's content).
+        raw_sha_after = _sha256_path(raw_extractions)
+        raw_mtime_after = raw_extractions.stat().st_mtime if raw_extractions.exists() else None
+        raw_rewritten = (
+            raw_mtime_before != raw_mtime_after or raw_sha_before != raw_sha_after
+        )
+        report["raw_extractions_rewritten"] = bool(raw_rewritten)
+        report["raw_extractions_sha_changed"] = (raw_sha_before != raw_sha_after)
+
+        # (c) Orchestrator log line: how many files were invalidated/re-extracted.
+        invalidated = _scan_invalidated_files(s1_root)
+        report["pass2_invalidated_files"] = invalidated
+        old_file_reextracted = any("Active_Projects" in f for f in invalidated)
+        report["old_file_reextracted"] = old_file_reextracted
+
+        # Does any node of a newly-added concept type list the OLD file in source_files?
+        backfill_nodes = []
+        if props_added or concepts_added:
+            backfill_nodes = _backfill_node_evidence(
+                s1_nodes, set(concepts_added), "Active_Projects"
+            )
+        report["backfill_node_evidence"] = backfill_nodes
+
+        if empty_delta:
+            report["backfill_summary"] = (
+                "no back-fill — empty schema delta, collapsed to plain append (valid)"
+            )
+        else:
+            report["backfill_summary"] = (
+                f"OLD file re-extracted under grown schema: {old_file_reextracted} "
+                f"(pass2 invalidated {len(invalidated)} file(s): {invalidated}); "
+                f"raw_extractions.json rewritten: {raw_rewritten}; "
+                f"per-file shard rewritten: {shard_rewritten} "
+                f"(shard absent/stale under concat/batch prep modes — "
+                f"raw_extractions.json + invalidation log are the authoritative signals); "
+                f"new-concept nodes citing OLD file: {len(backfill_nodes)}"
+            )
+
+        # ----- Stage-2 final counts + net change -----
+        s2_node_count = _wc_l(s1_nodes)
+        s2_edge_count = _wc_l(s1_edges)
+        report.update({
+            "stage2_nodes": s2_node_count,
+            "stage2_edges": s2_edge_count,
+            "net_nodes": s2_node_count - s1_node_count,
+            "net_edges": s2_edge_count - s1_edge_count,
+        })
+
+        # ----- failed chunks / 429 notes -----
+        failed_chunks_path = s1_root / "intermediate" / "failed_chunks.json"
+        failed = []
+        if failed_chunks_path.exists():
+            try:
+                failed = json.loads(failed_chunks_path.read_text(encoding="utf-8"))
+            except Exception as exc:  # noqa: BLE001
+                failed = [{"parse_error": str(exc)}]
+        report["failed_chunks"] = failed
+        report["rate_limit_notes"] = _scan_429(s1_root)
+
+        _write_report(report_path, report)
+        _log("DONE. Report written to scripts/live_test_report.md")
+        _log(f"  schema delta empty? {empty_delta}")
+        _log(f"  concepts +{concepts_added} -{concepts_removed}")
+        _log(f"  properties +{props_added} -{props_removed}")
+        _log(f"  nodes {s1_node_count}->{s2_node_count}  edges {s1_edge_count}->{s2_edge_count}")
+        return 0
+
+    finally:
+        guard.restore()
+
+
+def _find_old_shard(shard_dir: Path, needle: str) -> Path | None:
+    """Find the shard for the OLD file by glob, then by _fname content."""
+    if not shard_dir.exists():
+        return None
+    # 1) filename glob
+    for p in sorted(shard_dir.glob("*.json")):
+        if needle.lower() in p.name.lower():
+            return p
+    # 2) content _fname match
+    for p in sorted(shard_dir.glob("*.json")):
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            continue
+        fname = str(data.get("_fname", ""))
+        if needle.lower() in fname.lower():
+            return p
+    return None
+
+
+def _backfill_node_evidence(nodes_jsonl: Path, new_concepts: set[str], old_needle: str):
+    """Return nodes of new concept types whose source_files include the OLD file."""
+    out = []
+    if not nodes_jsonl.exists() or not new_concepts:
+        return out
+    with nodes_jsonl.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                node = json.loads(line)
+            except Exception:  # noqa: BLE001
+                continue
+            if node.get("type") not in new_concepts:
+                continue
+            src = node.get("source_files", []) or []
+            if any(old_needle.lower() in str(s).lower() for s in src):
+                out.append({
+                    "id": node.get("id"),
+                    "type": node.get("type"),
+                    "source_files": src,
+                })
+    return out
+
+
+def _scan_invalidated_files(session_root: Path) -> list[str]:
+    """Parse the orchestrator's append-invalidation log line.
+
+    Matches e.g.::
+
+        append: invalidated pass2 and downstream outputs for 2 changed
+        file(s): ['Active_Projects_Q2_Q3_2026.md', 'tech_stack.md']
+
+    Returns the list of changed filenames from the LAST such line (stage 2).
+    """
+    log_path = session_root / "run.log"
+    if not log_path.exists():
+        return []
+    files: list[str] = []
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if "invalidated pass2" not in line:
+            continue
+        # The line also contains a leading "[INFO]" tag, so anchor on the
+        # bracketed file list that follows "file(s):" and extract quoted names.
+        m = re.search(r"file\(s\):\s*\[([^\]]*)\]", line)
+        if m:
+            files = re.findall(r"'([^']+)'", m.group(1))
+    return files
+
+
+def _scan_429(session_root: Path) -> list[str]:
+    """Grep run.log + llm.log for 429 / rate-limit / 402 signals."""
+    notes = []
+    for name in ("run.log", "llm.log"):
+        lp = session_root / name
+        if not lp.exists():
+            continue
+        for line in lp.read_text(encoding="utf-8", errors="replace").splitlines():
+            low = line.lower()
+            if "429" in low or "rate limit" in low or "rate-limit" in low or " 402" in low:
+                notes.append(f"{name}: {line.strip()[:200]}")
+    return notes[:30]
+
+
+def _write_report(path: Path, r: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+
+    def fmt_list(xs):
+        return ", ".join(xs) if xs else "(none)"
+
+    lines = [
+        "# mykg `--append --grow-schema` live test report",
+        "",
+        f"_Generated: {now}_",
+        "",
+        f"- **Profile:** `{r.get('profile', '?')}`",
+        f"- **Model:** `{r.get('model', '?')}`",
+        "",
+        "## Commands run",
+        "",
+        "```",
+        r.get("stage1_cmd", "(not run)"),
+        r.get("stage2_cmd", "(not run)"),
+        "```",
+        "",
+        "## Stage 1 — initial extract",
+        "",
+        f"- Session: `{r.get('stage1_session', '(none)')}`",
+        f"- Concepts: {r.get('stage1_concepts', '-')}",
+        f"- Properties: {r.get('stage1_properties', '-')}",
+        f"- Nodes: {r.get('stage1_nodes', '-')}",
+        f"- Edges: {r.get('stage1_edges', '-')}",
+        "",
+        "## Stage 2 — append --grow-schema",
+        "",
+        f"- New file: {r.get('new_file_state', '-')}",
+        f"- **Schema delta empty?** {r.get('delta_empty', '-')}",
+        f"- Concepts added: {fmt_list(r.get('delta_concepts_added', []))}",
+        f"- Concepts removed: {fmt_list(r.get('delta_concepts_removed', []))}",
+        f"- Properties added: {fmt_list(r.get('delta_properties_added', []))}",
+        f"- Properties removed: {fmt_list(r.get('delta_properties_removed', []))}",
+        "",
+        "### schema_history (stage-2 deltas)",
+        "",
+        f"- New history files: {fmt_list(r.get('schema_history_new_files', []))}",
+    ]
+    for h in r.get("schema_history_summaries", []):
+        lines.append(
+            f"  - `{h.get('file')}` trigger=`{h.get('trigger')}` "
+            f"+concepts={h.get('concepts_added')} -concepts={h.get('concepts_removed')} "
+            f"+props={h.get('properties_added')} -props={h.get('properties_removed')}"
+        )
+    lines += [
+        "",
+        "### Back-fill evidence",
+        "",
+        f"- Pass 2 invalidated/re-extracted files (stage 2): "
+        f"{fmt_list(r.get('pass2_invalidated_files', []))}",
+        f"- **OLD file re-extracted under grown schema:** {r.get('old_file_reextracted', '-')}",
+        f"- raw_extractions.json rewritten: {r.get('raw_extractions_rewritten', '-')} "
+        f"(sha changed: {r.get('raw_extractions_sha_changed', '-')})",
+        f"- Old file shard: `{r.get('old_shard_path', '(not found — concat/batch prep mode)')}`",
+        f"- Per-file shard rewritten: {r.get('old_shard_rewritten', '-')} "
+        f"(sha changed: {r.get('old_shard_sha_changed', '-')}) "
+        f"— only meaningful in per_file prep mode",
+        f"- New-concept nodes citing OLD file: "
+        f"{len(r.get('backfill_node_evidence', []))}",
+    ]
+    for n in r.get("backfill_node_evidence", [])[:20]:
+        lines.append(f"  - `{n.get('id')}` ({n.get('type')}) <- {n.get('source_files')}")
+    net_nodes = r.get("net_nodes")
+    net_edges = r.get("net_edges")
+    nodes_line = f"- Stage-2 nodes: {r.get('stage2_nodes', '-')}"
+    if isinstance(net_nodes, int):
+        nodes_line += f" (net {net_nodes:+d})"
+    edges_line = f"- Stage-2 edges: {r.get('stage2_edges', '-')}"
+    if isinstance(net_edges, int):
+        edges_line += f" (net {net_edges:+d})"
+    lines += [
+        f"- Summary: {r.get('backfill_summary', '-')}",
+        "",
+        "## Node / edge change",
+        "",
+        nodes_line,
+        edges_line,
+        "",
+        "## Diagnostics",
+        "",
+        f"- failed_chunks entries: {len(r.get('failed_chunks', []) or [])}",
+        f"- rate-limit / 429 / 402 notes: {len(r.get('rate_limit_notes', []) or [])}",
+    ]
+    for note in (r.get("rate_limit_notes", []) or [])[:20]:
+        lines.append(f"  - {note}")
+    if r.get("errors"):
+        lines += ["", "## Errors", ""]
+        for e in r["errors"]:
+            lines.append(f"- {e}")
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/live_test_grow_schema.py
+++ b/scripts/live_test_grow_schema.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Live end-to-end test of mykg `--append --grow-schema` against OpenRouter.
+"""Live end-to-end test of mykg `--append-with-grow-schema` against OpenRouter.
 
 Runs two real pipeline stages and emits a reusable, idempotent report:
 
   STAGE 1  initial `extract-graph <input_dir>` (auto-creates a session)
   STAGE 2  copy <new_file> into <input_dir>, then
-           `extract-graph <input_dir> --append --grow-schema --session <s1>`
+           `extract-graph <input_dir> --append-with-grow-schema --session <s1>`
 
 It reports the stage-2 schema delta, back-fill evidence (whether the OLD
 file's shard was rewritten), and node/edge changes.
@@ -181,7 +181,7 @@ def _resolve_model(config_path: Path, profile: str) -> str:
 # --------------------------------------------------------------------------- #
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Live e2e test of mykg --append --grow-schema against OpenRouter."
+        description="Live e2e test of mykg --append-with-grow-schema against OpenRouter."
     )
     parser.add_argument("--profile", default="openrouter-free",
                         help="LLM profile to activate (default: openrouter-free)")
@@ -273,7 +273,7 @@ def main() -> int:
             "model": model,
             "stage1_cmd": "mykg extract-graph " + " ".join(stage1_cmd),
             "stage2_cmd": (
-                f"mykg extract-graph {args.input_dir} --append --grow-schema "
+                f"mykg extract-graph {args.input_dir} --append-with-grow-schema "
                 f"--session {s1} --obsidian-vault"
             ),
             "stage1_session": s1,
@@ -310,7 +310,7 @@ def main() -> int:
         )
 
         # ================= STAGE 2 =================
-        _log("STAGE 2: copy new file + append --grow-schema")
+        _log("STAGE 2: copy new file + append-with-grow-schema")
         new_file_dst = input_dir / new_file_src.name
         if new_file_dst.exists() and _sha256_path(new_file_dst) == _sha256_path(new_file_src):
             _log(f"new file already present and identical: {new_file_dst.name}")
@@ -321,7 +321,7 @@ def main() -> int:
             report["new_file_state"] = "copied"
 
         stage2_args = [
-            args.input_dir, "--append", "--grow-schema",
+            args.input_dir, "--append-with-grow-schema",
             "--session", s1, "--obsidian-vault",
         ]
         rc2 = _run_cli(["extract-graph", *stage2_args])
@@ -553,7 +553,7 @@ def _write_report(path: Path, r: dict) -> None:
         return ", ".join(xs) if xs else "(none)"
 
     lines = [
-        "# mykg `--append --grow-schema` live test report",
+        "# mykg `--append-with-grow-schema` live test report",
         "",
         f"_Generated: {now}_",
         "",
@@ -575,7 +575,7 @@ def _write_report(path: Path, r: dict) -> None:
         f"- Nodes: {r.get('stage1_nodes', '-')}",
         f"- Edges: {r.get('stage1_edges', '-')}",
         "",
-        "## Stage 2 — append --grow-schema",
+        "## Stage 2 — append-with-grow-schema",
         "",
         f"- New file: {r.get('new_file_state', '-')}",
         f"- **Schema delta empty?** {r.get('delta_empty', '-')}",

--- a/scripts/live_test_report.md
+++ b/scripts/live_test_report.md
@@ -1,0 +1,57 @@
+# mykg `--append --grow-schema` live test report
+
+_Generated: 2026-06-21 10:09:01Z_
+
+- **Profile:** `openrouter-free`
+- **Model:** `openrouter/free`
+
+## Commands run
+
+```
+mykg extract-graph _input_files --obsidian-vault
+mykg extract-graph _input_files --append --grow-schema --session 2026-06-21T09-54-15 --obsidian-vault
+```
+
+## Stage 1 — initial extract
+
+- Session: `2026-06-21T09-54-15`
+- Concepts: 3
+- Properties: 4
+- Nodes: 10
+- Edges: 9
+
+## Stage 2 — append --grow-schema
+
+- New file: copied
+- **Schema delta empty?** False
+- Concepts added: Technology
+- Concepts removed: (none)
+- Properties added: has_organization_owner, has_person_owner, uses_technology
+- Properties removed: has_contributor
+
+### schema_history (stage-2 deltas)
+
+- New history files: 0004_pass1_merge.json, 0005_schema_harmonize.json, 0006_schema_quality.json
+  - `0004_pass1_merge.json` trigger=`pass1_merge` +concepts=['Technology'] -concepts=[] +props=['has_organization_owner', 'has_person_owner', 'uses_technology'] -props=[]
+  - `0005_schema_harmonize.json` trigger=`schema_harmonize` +concepts=[] -concepts=[] +props=[] -props=['has_contributor']
+  - `0006_schema_quality.json` trigger=`schema_quality` +concepts=[] -concepts=[] +props=[] -props=[]
+
+### Back-fill evidence
+
+- Pass 2 invalidated/re-extracted files (stage 2): Active_Projects_Q2_Q3_2026.md, tech_stack.md
+- **OLD file re-extracted under grown schema:** True
+- raw_extractions.json rewritten: True (sha changed: True)
+- Old file shard: `None`
+- Per-file shard rewritten: False (sha changed: False) — only meaningful in per_file prep mode
+- New-concept nodes citing OLD file: 0
+- Summary: OLD file re-extracted under grown schema: True (pass2 invalidated 2 file(s): ['Active_Projects_Q2_Q3_2026.md', 'tech_stack.md']); raw_extractions.json rewritten: True; per-file shard rewritten: False (shard absent/stale under concat/batch prep modes — raw_extractions.json + invalidation log are the authoritative signals); new-concept nodes citing OLD file: 0
+
+## Node / edge change
+
+- Stage-2 nodes: 10 (net +0)
+- Stage-2 edges: 6 (net -3)
+
+## Diagnostics
+
+- failed_chunks entries: 0
+- rate-limit / 429 / 402 notes: 0

--- a/scripts/live_test_report.md
+++ b/scripts/live_test_report.md
@@ -1,46 +1,46 @@
-# mykg `--append --grow-schema` live test report
+# mykg `--append-with-grow-schema` live test report
 
-_Generated: 2026-06-21 10:09:01Z_
+_Generated: 2026-06-21 16:18:27Z_
 
-- **Profile:** `openrouter-free`
-- **Model:** `openrouter/free`
+- **Profile:** `openai`
+- **Model:** `gpt-5.4-mini-2026-03-17`
 
 ## Commands run
 
 ```
 mykg extract-graph _input_files --obsidian-vault
-mykg extract-graph _input_files --append --grow-schema --session 2026-06-21T09-54-15 --obsidian-vault
+mykg extract-graph _input_files --append-with-grow-schema --session 2026-06-21T16-18-03 --obsidian-vault
 ```
 
 ## Stage 1 — initial extract
 
-- Session: `2026-06-21T09-54-15`
+- Session: `2026-06-21T16-18-03`
 - Concepts: 3
-- Properties: 4
-- Nodes: 10
-- Edges: 9
+- Properties: 3
+- Nodes: 8
+- Edges: 8
 
-## Stage 2 — append --grow-schema
+## Stage 2 — append-with-grow-schema
 
 - New file: copied
 - **Schema delta empty?** False
 - Concepts added: Technology
 - Concepts removed: (none)
-- Properties added: has_organization_owner, has_person_owner, uses_technology
-- Properties removed: has_contributor
+- Properties added: owned_by_organization, uses_technology
+- Properties removed: (none)
 
 ### schema_history (stage-2 deltas)
 
 - New history files: 0004_pass1_merge.json, 0005_schema_harmonize.json, 0006_schema_quality.json
-  - `0004_pass1_merge.json` trigger=`pass1_merge` +concepts=['Technology'] -concepts=[] +props=['has_organization_owner', 'has_person_owner', 'uses_technology'] -props=[]
-  - `0005_schema_harmonize.json` trigger=`schema_harmonize` +concepts=[] -concepts=[] +props=[] -props=['has_contributor']
+  - `0004_pass1_merge.json` trigger=`pass1_merge` +concepts=['Technology'] -concepts=[] +props=['owned_by_organization', 'uses_technology'] -props=[]
+  - `0005_schema_harmonize.json` trigger=`schema_harmonize` +concepts=[] -concepts=[] +props=[] -props=[]
   - `0006_schema_quality.json` trigger=`schema_quality` +concepts=[] -concepts=[] +props=[] -props=[]
 
 ### Back-fill evidence
 
 - Pass 2 invalidated/re-extracted files (stage 2): Active_Projects_Q2_Q3_2026.md, tech_stack.md
 - **OLD file re-extracted under grown schema:** True
-- raw_extractions.json rewritten: True (sha changed: True)
+- raw_extractions.json rewritten: True (sha changed: False)
 - Old file shard: `None`
 - Per-file shard rewritten: False (sha changed: False) — only meaningful in per_file prep mode
 - New-concept nodes citing OLD file: 0
@@ -48,8 +48,8 @@ mykg extract-graph _input_files --append --grow-schema --session 2026-06-21T09-5
 
 ## Node / edge change
 
-- Stage-2 nodes: 10 (net +0)
-- Stage-2 edges: 6 (net -3)
+- Stage-2 nodes: 8 (net +0)
+- Stage-2 edges: 8 (net +0)
 
 ## Diagnostics
 

--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -594,12 +594,13 @@ def _print_next_steps(
     help="Skip Pass 1, re-run only on new/modified files, then re-assemble and re-export",
 )
 @click.option(
-    "--grow-schema",
+    "--append-with-grow-schema",
+    "grow_schema",
     is_flag=True,
-    help="With --append: run Pass 1 in LOCKED mode over changed files so the LLM may ADD "
-    "new concepts/properties to the existing schema, then surgically back-fill old files "
-    "when the schema grows. Requires --append; the session schema.ttl is auto-loaded as "
-    "the locked base, so --base-schema must not be passed.",
+    help="Implies --append AND runs Pass 1 in LOCKED mode over changed files so the LLM "
+    "may ADD new concepts/properties to the existing schema, then surgically back-fill "
+    "old files when the schema grows. The session schema.ttl is auto-loaded as the "
+    "locked base, so --base-schema must not be passed.",
 )
 @click.option(
     "--session",
@@ -641,6 +642,9 @@ def extract_graph(
     from mykg.logging import setup
     from mykg.orchestrator import PipelineContext, run
     from mykg.pipeline import STEPS
+
+    if grow_schema:
+        append = True
 
     sessions_root = _sessions_root()
 
@@ -698,23 +702,17 @@ def extract_graph(
         raise click.ClickException("--append and --from-step are mutually exclusive.")
 
     if grow_schema:
-        if not append:
-            raise click.ClickException("--grow-schema requires --append.")
-        # --grow-schema inherits append's mutual exclusion with --from-step (above)
-        # and auto-loads the session schema as the locked base, so an explicit
-        # --base-schema would conflict.
         if base_schema:
             raise click.ClickException(
-                "--grow-schema auto-loads the session's schema.ttl as the locked base; "
-                "do not pass --base-schema."
+                "--append-with-grow-schema auto-loads the session's schema.ttl as the "
+                "locked base; do not pass --base-schema."
             )
-        # Fail fast (before any adapter / API-key resolution) if there is no schema
-        # to lock — the base is parsed later, after the adapter is loaded.
         _session_schema_ttl = Path(intermediate_dir) / "schema.ttl"
         if not _session_schema_ttl.exists():
             raise click.ClickException(
-                f"--grow-schema needs an existing schema to lock, but {_session_schema_ttl} "
-                "was not found. Run without --grow-schema first to induce a schema."
+                f"--append-with-grow-schema needs an existing schema to lock, but "
+                f"{_session_schema_ttl} was not found. Run a full extract first to "
+                "induce a schema."
             )
 
     orphan_incremental = False
@@ -742,10 +740,6 @@ def extract_graph(
 
     base = None
     if grow_schema:
-        # Auto-load the session's existing schema as the locked base so Pass 1 runs
-        # in LOCKED mode (D52): the LLM may ADD entries but cannot rename/remove the
-        # locked ones. schema.ttl is the TBox-only view written after the prior run;
-        # its existence was already verified in the validation block above.
         from mykg.base_schema import parse_base_schema
 
         session_schema_ttl = Path(intermediate_dir) / "schema.ttl"

--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -534,9 +534,7 @@ def _print_next_steps(
         )
     elif profile == "agent-claude-code":
         _install_agent_skill(force=reinstall_skill)
-        claude_status = _write_claude_md_snippet(
-            Path.cwd(), refresh=force or reinstall_claude_md
-        )
+        claude_status = _write_claude_md_snippet(Path.cwd(), refresh=force or reinstall_claude_md)
         click.echo(f"[claude.md] {claude_status}")
         click.echo("\nThen, in Claude Code:")
         click.echo("  1. Restart the app so the skill loader picks up the new entry.")
@@ -596,6 +594,14 @@ def _print_next_steps(
     help="Skip Pass 1, re-run only on new/modified files, then re-assemble and re-export",
 )
 @click.option(
+    "--grow-schema",
+    is_flag=True,
+    help="With --append: run Pass 1 in LOCKED mode over changed files so the LLM may ADD "
+    "new concepts/properties to the existing schema, then surgically back-fill old files "
+    "when the schema grows. Requires --append; the session schema.ttl is auto-loaded as "
+    "the locked base, so --base-schema must not be passed.",
+)
+@click.option(
     "--session",
     default=None,
     help="Session name under mykg_sessions/ to resume or append; omit to auto-create",
@@ -625,6 +631,7 @@ def extract_graph(
     workers,
     confidence_agg,
     append,
+    grow_schema,
     session,
     obsidian_vault,
     neo4j_csv,
@@ -690,6 +697,26 @@ def extract_graph(
     if append and from_step:
         raise click.ClickException("--append and --from-step are mutually exclusive.")
 
+    if grow_schema:
+        if not append:
+            raise click.ClickException("--grow-schema requires --append.")
+        # --grow-schema inherits append's mutual exclusion with --from-step (above)
+        # and auto-loads the session schema as the locked base, so an explicit
+        # --base-schema would conflict.
+        if base_schema:
+            raise click.ClickException(
+                "--grow-schema auto-loads the session's schema.ttl as the locked base; "
+                "do not pass --base-schema."
+            )
+        # Fail fast (before any adapter / API-key resolution) if there is no schema
+        # to lock — the base is parsed later, after the adapter is loaded.
+        _session_schema_ttl = Path(intermediate_dir) / "schema.ttl"
+        if not _session_schema_ttl.exists():
+            raise click.ClickException(
+                f"--grow-schema needs an existing schema to lock, but {_session_schema_ttl} "
+                "was not found. Run without --grow-schema first to induce a schema."
+            )
+
     orphan_incremental = False
     if from_step:
         from_step, orphan_incremental = _resolve_from_step(from_step)
@@ -714,7 +741,17 @@ def extract_graph(
     logging.getLogger(__name__).info("LLM endpoint: %s", adapter.endpoint_label())
 
     base = None
-    if base_schema:
+    if grow_schema:
+        # Auto-load the session's existing schema as the locked base so Pass 1 runs
+        # in LOCKED mode (D52): the LLM may ADD entries but cannot rename/remove the
+        # locked ones. schema.ttl is the TBox-only view written after the prior run;
+        # its existence was already verified in the validation block above.
+        from mykg.base_schema import parse_base_schema
+
+        session_schema_ttl = Path(intermediate_dir) / "schema.ttl"
+        base = parse_base_schema(session_schema_ttl.read_text())
+        base["_source"] = str(session_schema_ttl)
+    elif base_schema:
         from mykg.base_schema import parse_base_schema
 
         base = parse_base_schema(Path(base_schema).read_text())
@@ -738,6 +775,7 @@ def extract_graph(
         pass2_workers=workers,
         confidence_agg=confidence_agg,
         append=append,
+        grow_schema=grow_schema,
         orphan_incremental=orphan_incremental,
     )
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -978,9 +1016,7 @@ def _build_parse_docs_targets(
         for f in files:
             resolved = f if f.is_absolute() else (input_path / f)
             ok, reason = _passes_filter(resolved)
-            rel_parent = (
-                f.parent if not f.is_absolute() and f.parent != Path(".") else Path()
-            )
+            rel_parent = f.parent if not f.is_absolute() and f.parent != Path(".") else Path()
             per_file_out = output_path / rel_parent
             if ok:
                 targets.append((resolved, per_file_out))
@@ -1119,9 +1155,7 @@ def parse_docs(
         )
 
     allowed_exts = None if no_filter else _cfg.PREPROCESS_EXTENSIONS
-    targets, skipped = _build_parse_docs_targets(
-        input_path, output_path, files, allowed_exts
-    )
+    targets, skipped = _build_parse_docs_targets(input_path, output_path, files, allowed_exts)
 
     if skipped:
         for src, reason in skipped:
@@ -1179,9 +1213,7 @@ def parse_docs(
             f"{len(failures)} failed — output under: {output_path}",
             err=True,
         )
-        raise click.ClickException(
-            f"{len(failures)} of {len(targets)} files failed conversion"
-        )
+        raise click.ClickException(f"{len(failures)} of {len(targets)} files failed conversion")
     click.echo(f"Done. Output written to: {output_path}")
 
 
@@ -1195,7 +1227,9 @@ def _github_clone_seed(seed_url, out_dir, _cfg, fw, *, ignored_notice=None):
     input_dir = out_dir / "input"
     click.echo(f"Cloning {owner}/{repo} (depth={_cfg.FETCH_GITHUB_CLONE_DEPTH}) → {repo_dir}")
     fw.clone_github_repo(
-        owner, repo, repo_dir,
+        owner,
+        repo,
+        repo_dir,
         depth=_cfg.FETCH_GITHUB_CLONE_DEPTH,
         timeout_seconds=_cfg.FETCH_GITHUB_CLONE_TIMEOUT_SECONDS,
     )
@@ -1220,14 +1254,22 @@ def _github_clone_seed(seed_url, out_dir, _cfg, fw, *, ignored_notice=None):
     }
 
 
-def _crawlee_ignored_options_notice(max_pages, max_depth, strategy, download_assets,
-                                     delay, concurrency, no_robots, force):
+def _crawlee_ignored_options_notice(
+    max_pages, max_depth, strategy, download_assets, delay, concurrency, no_robots, force
+):
     """One-line notice when Crawlee-only options are passed for a GitHub seed."""
-    non_default = any([
-        max_pages is not None, max_depth is not None, strategy is not None,
-        download_assets is not None, delay is not None, concurrency is not None,
-        no_robots, force,
-    ])
+    non_default = any(
+        [
+            max_pages is not None,
+            max_depth is not None,
+            strategy is not None,
+            download_assets is not None,
+            delay is not None,
+            concurrency is not None,
+            no_robots,
+            force,
+        ]
+    )
     if not non_default:
         return None
     return "Note: Crawlee options (--max-pages, --max-depth, etc.) are ignored for GitHub repo URLs (git-clone path)."
@@ -1235,27 +1277,57 @@ def _crawlee_ignored_options_notice(max_pages, max_depth, strategy, download_ass
 
 @cli.command("fetch-web")
 @click.argument("url", required=False)
-@click.option("--url-list", default=None, type=click.Path(exists=True, dir_okay=False, path_type=Path),
-              help="File of seed URLs (one per line, # comments ignored). "
-                   "Mutually exclusive with URL; requires --output.")
-@click.option("--output", default=None, type=click.Path(path_type=Path),
-              help="Target folder (default: ./<fetch.output_dir>/<domain>/; required with --url-list).")
+@click.option(
+    "--url-list",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="File of seed URLs (one per line, # comments ignored). "
+    "Mutually exclusive with URL; requires --output.",
+)
+@click.option(
+    "--output",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Target folder (default: ./<fetch.output_dir>/<domain>/; required with --url-list).",
+)
 @click.option("--max-pages", default=None, type=int, help="Cap on total fetched pages.")
-@click.option("--max-depth", default=None, type=int,
-              help="Max crawl depth from seed (default: inferred — 0 for a "
-                   "specific page, fetch.max_depth for a bare domain).")
-@click.option("--strategy", default=None,
-              type=click.Choice(["same-domain", "same-origin", "all"]),
-              help="Link-following scope (default from config; 'all' leaves the domain).")
-@click.option("--download-assets/--no-download-assets", default=None,
-              help="Download linked binaries in preprocess.extensions (default from config).")
+@click.option(
+    "--max-depth",
+    default=None,
+    type=int,
+    help="Max crawl depth from seed (default: inferred — 0 for a "
+    "specific page, fetch.max_depth for a bare domain).",
+)
+@click.option(
+    "--strategy",
+    default=None,
+    type=click.Choice(["same-domain", "same-origin", "all"]),
+    help="Link-following scope (default from config; 'all' leaves the domain).",
+)
+@click.option(
+    "--download-assets/--no-download-assets",
+    default=None,
+    help="Download linked binaries in preprocess.extensions (default from config).",
+)
 @click.option("--delay", default=None, type=float, help="Per-request delay seconds.")
 @click.option("--concurrency", default=None, type=int, help="Max concurrent requests.")
 @click.option("--no-robots", is_flag=True, help="Disable robots.txt compliance.")
 @click.option("--force", is_flag=True, help="Ignore prior manifest; re-fetch everything.")
 @click.option("--verbose", "-v", is_flag=True, help="Enable DEBUG-level logging.")
-def fetch_web(url, url_list, output, max_pages, max_depth, strategy, download_assets,
-              delay, concurrency, no_robots, force, verbose):
+def fetch_web(
+    url,
+    url_list,
+    output,
+    max_pages,
+    max_depth,
+    strategy,
+    download_assets,
+    delay,
+    concurrency,
+    no_robots,
+    force,
+    verbose,
+):
     """Crawl a website (or clone a GitHub repo) and write fetch_manifest.json.
 
     The folder is a normal `extract-graph` input: the preprocess step converts
@@ -1305,11 +1377,22 @@ def fetch_web(url, url_list, output, max_pages, max_depth, strategy, download_as
     dl_assets = _cfg.FETCH_DOWNLOAD_ASSETS if download_assets is None else download_assets
     allowed = sorted(_cfg.PREPROCESS_EXTENSIONS) if dl_assets else []
     ignored_notice = _crawlee_ignored_options_notice(
-        max_pages, max_depth, strategy, download_assets, delay, concurrency, no_robots, force,
+        max_pages,
+        max_depth,
+        strategy,
+        download_assets,
+        delay,
+        concurrency,
+        no_robots,
+        force,
     )
 
     def _seed_crawl_cfg(seed_url, seed_out_dir, prior):
-        depth = max_depth if max_depth is not None else fw.infer_max_depth(seed_url, _cfg.FETCH_MAX_DEPTH)
+        depth = (
+            max_depth
+            if max_depth is not None
+            else fw.infer_max_depth(seed_url, _cfg.FETCH_MAX_DEPTH)
+        )
         cfg = fw.build_crawl_config(
             seed_url=seed_url,
             output_dir=str(seed_out_dir),
@@ -1334,8 +1417,11 @@ def fetch_web(url, url_list, output, max_pages, max_depth, strategy, download_as
         if _cfg.FETCH_GITHUB_CLONE_ENABLED and fw.is_github_repo_url(url):
             entry = _github_clone_seed(url, out_dir, _cfg, fw, ignored_notice=ignored_notice)
             fw.write_manifest(
-                out_dir, seed_url=url, strategy="github_clone",
-                pages={}, stats=entry["stats"],
+                out_dir,
+                seed_url=url,
+                strategy="github_clone",
+                pages={},
+                stats=entry["stats"],
             )
             return
 
@@ -1345,7 +1431,9 @@ def fetch_web(url, url_list, output, max_pages, max_depth, strategy, download_as
         config_path = out_dir / ".fetch_config.json"
         config_path.write_text(json.dumps(crawl_cfg, indent=2), encoding="utf-8")
 
-        click.echo(f"Crawling {url} → {out_dir} (strategy={strat}, max_pages={crawl_cfg['max_pages']}, max_depth={crawl_cfg['max_depth']})")
+        click.echo(
+            f"Crawling {url} → {out_dir} (strategy={strat}, max_pages={crawl_cfg['max_pages']}, max_depth={crawl_cfg['max_depth']})"
+        )
         with ephemeral_venv(
             _cfg.FETCH_UV_PYTHON_VERSION,
             _cfg.FETCH_CRAWLEE_SPEC,
@@ -1375,8 +1463,11 @@ def fetch_web(url, url_list, output, max_pages, max_depth, strategy, download_as
         merged = dict(prior)
         merged.update(results.get("pages", {}))
         fw.write_manifest(
-            out_dir, seed_url=url, strategy=strat,
-            pages=merged, stats=results.get("stats", {}),
+            out_dir,
+            seed_url=url,
+            strategy=strat,
+            pages=merged,
+            stats=results.get("stats", {}),
             crawlee_version=results.get("crawlee_version", ""),
         )
         config_path.unlink(missing_ok=True)
@@ -1404,7 +1495,9 @@ def fetch_web(url, url_list, output, max_pages, max_depth, strategy, download_as
             owner, repo = fw.is_github_repo_url(seed_url)
             seed_out_dir = out_root / f"github.com_{owner}_{repo}"
             seed_out_dir.mkdir(parents=True, exist_ok=True)
-            entry = _github_clone_seed(seed_url, seed_out_dir, _cfg, fw, ignored_notice=ignored_notice)
+            entry = _github_clone_seed(
+                seed_url, seed_out_dir, _cfg, fw, ignored_notice=ignored_notice
+            )
             seed_entries.append(entry)
         else:
             seed_out_dir = out_root / fw.seed_subdir_name(seed_url)
@@ -1459,20 +1552,25 @@ def fetch_web(url, url_list, output, max_pages, max_depth, strategy, download_as
             merged.update(seed_result.get("pages", {}))
             stats = seed_result.get("stats", {})
             fw.write_manifest(
-                seed_out_dir, seed_url=seed_url, strategy=strat,
-                pages=merged, stats=stats,
+                seed_out_dir,
+                seed_url=seed_url,
+                strategy=strat,
+                pages=merged,
+                stats=stats,
                 crawlee_version=seed_result.get("crawlee_version", ""),
             )
             click.echo(
                 f"Done. {stats.get('pages', 0)} pages, {stats.get('assets', 0)} assets → {seed_out_dir}"
             )
-            seed_entries.append({
-                "seed_url": seed_url,
-                "strategy": strat,
-                "output_subdir": seed_out_dir.relative_to(out_root).as_posix(),
-                "stats": stats,
-                "pages": merged,
-            })
+            seed_entries.append(
+                {
+                    "seed_url": seed_url,
+                    "strategy": strat,
+                    "output_subdir": seed_out_dir.relative_to(out_root).as_posix(),
+                    "stats": stats,
+                    "pages": merged,
+                }
+            )
 
         config_path.unlink(missing_ok=True)
         results_path.unlink(missing_ok=True)
@@ -1486,12 +1584,13 @@ def fetch_web(url, url_list, output, max_pages, max_depth, strategy, download_as
                 summed_stats[key] = summed_stats.get(key, 0) + val
         union_pages.update(entry["pages"])
 
-    manifest_seeds = [
-        {k: v for k, v in entry.items() if k != "pages"} for entry in seed_entries
-    ]
+    manifest_seeds = [{k: v for k, v in entry.items() if k != "pages"} for entry in seed_entries]
     fw.write_manifest(
-        out_root, seed_url=None, strategy=None,
-        pages=union_pages, stats=summed_stats,
+        out_root,
+        seed_url=None,
+        strategy=None,
+        pages=union_pages,
+        stats=summed_stats,
         seeds=manifest_seeds,
     )
     click.echo(f"Done. {len(seed_entries)} seed(s) fetched → {out_root}")

--- a/src/mykg/config.py
+++ b/src/mykg/config.py
@@ -242,18 +242,14 @@ FETCH_STRATEGY: str = _get_opt("fetch", "strategy", "same-domain")
 FETCH_MAX_PAGES: int = int(_get_opt("fetch", "max_pages", 500))
 FETCH_MAX_DEPTH: int = int(_get_opt("fetch", "max_depth", 10))
 FETCH_RESPECT_ROBOTS: bool = bool(_get_opt("fetch", "respect_robots", True))
-FETCH_REQUEST_DELAY_SECONDS: float = float(
-    _get_opt("fetch", "request_delay_seconds", 0.5)
-)
+FETCH_REQUEST_DELAY_SECONDS: float = float(_get_opt("fetch", "request_delay_seconds", 0.5))
 FETCH_CONCURRENCY: int = int(_get_opt("fetch", "concurrency", 4))
 FETCH_DOWNLOAD_ASSETS: bool = bool(_get_opt("fetch", "download_assets", True))
 FETCH_TIMEOUT_SECONDS: int = int(_get_opt("fetch", "timeout_seconds", 1800))
 FETCH_UV_PATH: str = _get_opt("fetch", "uv_path", "uv")
 FETCH_UV_PYTHON_VERSION: str = _get_opt("fetch", "uv_python_version", "3.12")
 FETCH_CRAWLEE_SPEC: str = _get_opt("fetch", "crawlee_spec", "crawlee[beautifulsoup]")
-FETCH_INSTALL_TIMEOUT_SECONDS: int = int(
-    _get_opt("fetch", "install_timeout_seconds", 1800)
-)
+FETCH_INSTALL_TIMEOUT_SECONDS: int = int(_get_opt("fetch", "install_timeout_seconds", 1800))
 FETCH_GITHUB_CLONE_ENABLED: bool = bool(_get_opt("fetch", "github_clone_enabled", True))
 FETCH_GITHUB_CLONE_DEPTH: int = int(_get_opt("fetch", "github_clone_depth", 1))
 FETCH_GITHUB_CLONE_TIMEOUT_SECONDS: int = int(
@@ -294,6 +290,16 @@ MERGE_SURGICAL_TOP_K_CHUNKS_PER_PROPERTY: int = _get_opt(
     "merge_graphs", "surgical_top_k_chunks_per_property", 0
 )
 MERGE_ORPHAN_SCHEMA_MAX_RESTARTS: int = _get_opt("merge_graphs", "orphan_pass_max_restarts", 1)
+
+# ---------------------------------------------------------------------------
+# Append — incremental schema growth (--append --grow-schema, D52)
+# ---------------------------------------------------------------------------
+# Cap on how many old chunks are surgically re-extracted per newly added
+# concept/property when the locked Pass 1 grows the schema. 0 = disable
+# back-fill entirely. Mirrors merge_graphs.surgical_top_k_chunks_per_property.
+APPEND_GROW_SCHEMA_BACKFILL_TOP_K_CHUNKS_PER_TYPE: int = _get_opt(
+    "append", "grow_schema_backfill_top_k_chunks_per_type", 10
+)
 
 # ---------------------------------------------------------------------------
 # Agent provider (D49) — inbox/outbox filesystem contract with host skill

--- a/src/mykg/config.py
+++ b/src/mykg/config.py
@@ -292,7 +292,7 @@ MERGE_SURGICAL_TOP_K_CHUNKS_PER_PROPERTY: int = _get_opt(
 MERGE_ORPHAN_SCHEMA_MAX_RESTARTS: int = _get_opt("merge_graphs", "orphan_pass_max_restarts", 1)
 
 # ---------------------------------------------------------------------------
-# Append — incremental schema growth (--append --grow-schema, D52)
+# Append — incremental schema growth (--append-with-grow-schema, D52)
 # ---------------------------------------------------------------------------
 # Cap on how many old chunks are surgically re-extracted per newly added
 # concept/property when the locked Pass 1 grows the schema. 0 = disable

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -178,6 +178,8 @@ profiles:
         surgical_top_k_chunks_per_property: 5  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   anthropic-claude:
@@ -341,6 +343,8 @@ profiles:
         surgical_top_k_chunks_per_property: 5  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   claude-cli:
@@ -501,6 +505,8 @@ profiles:
         surgical_top_k_chunks_per_property: 5  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   openai:
@@ -670,6 +676,8 @@ profiles:
         surgical_top_k_chunks_per_property: 0  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   ollama-local:
@@ -833,6 +841,8 @@ profiles:
         surgical_top_k_chunks_per_property: 0  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
         human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
         orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
 
   # ---------------------------------------------------------------------------
   agent-claude-code:
@@ -986,3 +996,5 @@ profiles:
         surgical_top_k_chunks_per_property: 0
         human_review: false
         orphan_pass_max_restarts: 0
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (D52)

--- a/src/mykg/data/skills/mykg/SKILL.md
+++ b/src/mykg/data/skills/mykg/SKILL.md
@@ -50,6 +50,8 @@ Trigger this skill whenever the user types `/mykg <anything>`. Map the intent to
 | `/mykg extract more from ./more_docs` | `mykg extract-graph ./more_docs` (**fresh session** — "more" is NOT an explicit reuse signal; this is just another extract) |
 | `/mykg extract ./docs with human review` | `mykg extract-graph ./docs --review` (**fresh session — no `--session`**) |
 | `/mykg append the new notes in ./docs` | `mykg extract-graph ./docs --append --session <auto-detect-most-recent>` (explicit reuse via `append`) |
+| `/mykg append and grow schema from ./docs` | `mykg extract-graph ./docs --append --grow-schema --session <auto-detect-most-recent>` (explicit reuse via `append`; locked Pass 1 runs over changed files to expand the schema) |
+| `/mykg expand the schema with new docs in ./docs` | `mykg extract-graph ./docs --append --grow-schema --session <auto-detect-most-recent>` ("expand schema" → `--grow-schema`) |
 | `/mykg resume the last session` | `mykg extract-graph --session <most-recent>` (explicit reuse via `resume the last session`) |
 | `/mykg approve the schema` | `mykg approve-schema --session <most-recent>` (session-only subcommand) |
 | `/mykg make a walkthrough` | `mykg walkthrough --session <most-recent>` (session-only subcommand) |
@@ -109,9 +111,35 @@ From the user's `/mykg <free text>` message extract:
    6. **Reuse required but missing.** If rules 2/3/4 fire but no session exists under `$SESSIONS_DIR`, fail clearly: `"No existing sessions under <SESSIONS_DIR>. Run /mykg extract <dir> first to create one."`
 
 **Never auto-detect-most-recent purely because a previous skill turn produced a session.** The previous-turn memory only matters when the *current* user message also contains one of the explicit signals in rules 1-4. A bare `/mykg ./more_docs` after a prior session must still create a fresh session.
-4. **Flags** — anything the user named that maps to a flag the cached `--help` confirms (`--review`, `--append`, `--from-step <step>`, `--workers <N>`, `--obsidian-vault`, `--base-schema`, `--thesaurus`, `--verbose`, `--confidence-agg`, etc.). Forward verbatim.
+4. **Flags** — anything the user named that maps to a flag the cached `--help` confirms (`--review`, `--append`, `--from-step <step>`, `--workers <N>`, `--obsidian-vault`, `--base-schema`, `--thesaurus`, `--verbose`, `--confidence-agg`, `--grow-schema`, etc.). Forward verbatim.
 
 `extract-graph` without `--append` or `--from-step` does not need a pre-existing session — it auto-creates one.
+
+### `--grow-schema` — expanding the schema incrementally (D52)
+
+**Use case:** you have an existing session with an induced schema (e.g. Project, Person, Organization) and you add new documents that introduce entity types or relationships the current schema doesn't cover (e.g. a tech-stack document that describes technologies). Plain `--append` freezes the schema — Pass 1 is skipped, so new concept types and properties are never induced, and the new documents are extracted against the old vocabulary. `--grow-schema` solves this: it runs a **locked Pass 1** over the changed files only, allowing the LLM to propose new concepts and properties while preserving everything already in the schema.
+
+**How it works:**
+1. The session's existing `schema.ttl` is auto-loaded as a locked base schema — existing classes and properties cannot be renamed, removed, or re-parented.
+2. Pass 1 runs over **only the changed files** (not the whole corpus), so cost is O(changed files).
+3. The LLM may add new concepts, new properties, or new attributes to existing types. It cannot modify locked entries.
+4. Pass 2 extracts the new files against the grown schema. If new properties were added, a **surgical back-fill** may re-extract old chunks that contain nodes of the new properties' domain/range types (configurable via `append.grow_schema_backfill_top_k_chunks_per_type`, default 10; set 0 to disable).
+5. All downstream steps (assemble, orphan pass, validate) re-run over the full corpus so the graph stays consistent.
+
+**When the schema delta is empty** (the new documents don't introduce new types), the run collapses to a plain `--append` — no wasted LLM cost.
+
+**Intent triggers** — add `--grow-schema` when the user says any of: "grow schema", "expand schema", "grow the schema", "expand the vocabulary", "add new types", "learn new concepts from", "update the schema with". Always pair with `--append` (the CLI enforces this). `--grow-schema` is mutually exclusive with `--from-step` and `--base-schema`.
+
+**Confirmation note:** in Stage 2, mention that locked Pass 1 will run (costs LLM calls) vs plain `--append` which skips Pass 1:
+
+```
+About to run: uv run mykg extract-graph ./docs --append --grow-schema --session 2026-06-21T11-22-38
+
+This will run a locked Pass 1 over the new files (LLM calls) to expand the schema,
+then extract. Plain --append would skip Pass 1 and keep the schema frozen.
+
+Reply "yes" to run, or "just append" to skip schema growth.
+```
 
 ### `fetch-web` flags and special cases
 

--- a/src/mykg/data/skills/mykg/SKILL.md
+++ b/src/mykg/data/skills/mykg/SKILL.md
@@ -50,8 +50,8 @@ Trigger this skill whenever the user types `/mykg <anything>`. Map the intent to
 | `/mykg extract more from ./more_docs` | `mykg extract-graph ./more_docs` (**fresh session** — "more" is NOT an explicit reuse signal; this is just another extract) |
 | `/mykg extract ./docs with human review` | `mykg extract-graph ./docs --review` (**fresh session — no `--session`**) |
 | `/mykg append the new notes in ./docs` | `mykg extract-graph ./docs --append --session <auto-detect-most-recent>` (explicit reuse via `append`) |
-| `/mykg append and grow schema from ./docs` | `mykg extract-graph ./docs --append --grow-schema --session <auto-detect-most-recent>` (explicit reuse via `append`; locked Pass 1 runs over changed files to expand the schema) |
-| `/mykg expand the schema with new docs in ./docs` | `mykg extract-graph ./docs --append --grow-schema --session <auto-detect-most-recent>` ("expand schema" → `--grow-schema`) |
+| `/mykg append and grow schema from ./docs` | `mykg extract-graph ./docs --append-with-grow-schema --session <auto-detect-most-recent>` (explicit reuse via `append`; locked Pass 1 runs over changed files to expand the schema) |
+| `/mykg expand the schema with new docs in ./docs` | `mykg extract-graph ./docs --append-with-grow-schema --session <auto-detect-most-recent>` ("expand schema" → `--append-with-grow-schema`) |
 | `/mykg resume the last session` | `mykg extract-graph --session <most-recent>` (explicit reuse via `resume the last session`) |
 | `/mykg approve the schema` | `mykg approve-schema --session <most-recent>` (session-only subcommand) |
 | `/mykg make a walkthrough` | `mykg walkthrough --session <most-recent>` (session-only subcommand) |
@@ -111,13 +111,13 @@ From the user's `/mykg <free text>` message extract:
    6. **Reuse required but missing.** If rules 2/3/4 fire but no session exists under `$SESSIONS_DIR`, fail clearly: `"No existing sessions under <SESSIONS_DIR>. Run /mykg extract <dir> first to create one."`
 
 **Never auto-detect-most-recent purely because a previous skill turn produced a session.** The previous-turn memory only matters when the *current* user message also contains one of the explicit signals in rules 1-4. A bare `/mykg ./more_docs` after a prior session must still create a fresh session.
-4. **Flags** — anything the user named that maps to a flag the cached `--help` confirms (`--review`, `--append`, `--from-step <step>`, `--workers <N>`, `--obsidian-vault`, `--base-schema`, `--thesaurus`, `--verbose`, `--confidence-agg`, `--grow-schema`, etc.). Forward verbatim.
+4. **Flags** — anything the user named that maps to a flag the cached `--help` confirms (`--review`, `--append`, `--from-step <step>`, `--workers <N>`, `--obsidian-vault`, `--base-schema`, `--thesaurus`, `--verbose`, `--confidence-agg`, `--append-with-grow-schema`, etc.). Forward verbatim.
 
 `extract-graph` without `--append` or `--from-step` does not need a pre-existing session — it auto-creates one.
 
-### `--grow-schema` — expanding the schema incrementally (D52)
+### `--append-with-grow-schema` — expanding the schema incrementally (D52)
 
-**Use case:** you have an existing session with an induced schema (e.g. Project, Person, Organization) and you add new documents that introduce entity types or relationships the current schema doesn't cover (e.g. a tech-stack document that describes technologies). Plain `--append` freezes the schema — Pass 1 is skipped, so new concept types and properties are never induced, and the new documents are extracted against the old vocabulary. `--grow-schema` solves this: it runs a **locked Pass 1** over the changed files only, allowing the LLM to propose new concepts and properties while preserving everything already in the schema.
+**Use case:** you have an existing session with an induced schema (e.g. Project, Person, Organization) and you add new documents that introduce entity types or relationships the current schema doesn't cover (e.g. a tech-stack document that describes technologies). Plain `--append` freezes the schema — Pass 1 is skipped, so new concept types and properties are never induced, and the new documents are extracted against the old vocabulary. `--append-with-grow-schema` solves this: it implies `--append` and runs a **locked Pass 1** over the changed files only, allowing the LLM to propose new concepts and properties while preserving everything already in the schema.
 
 **How it works:**
 1. The session's existing `schema.ttl` is auto-loaded as a locked base schema — existing classes and properties cannot be renamed, removed, or re-parented.
@@ -128,12 +128,12 @@ From the user's `/mykg <free text>` message extract:
 
 **When the schema delta is empty** (the new documents don't introduce new types), the run collapses to a plain `--append` — no wasted LLM cost.
 
-**Intent triggers** — add `--grow-schema` when the user says any of: "grow schema", "expand schema", "grow the schema", "expand the vocabulary", "add new types", "learn new concepts from", "update the schema with". Always pair with `--append` (the CLI enforces this). `--grow-schema` is mutually exclusive with `--from-step` and `--base-schema`.
+**Intent triggers** — use `--append-with-grow-schema` when the user says any of: "grow schema", "expand schema", "grow the schema", "expand the vocabulary", "add new types", "learn new concepts from", "update the schema with". The flag implies `--append` (no need to pass both). `--append-with-grow-schema` is mutually exclusive with `--from-step` and `--base-schema`.
 
 **Confirmation note:** in Stage 2, mention that locked Pass 1 will run (costs LLM calls) vs plain `--append` which skips Pass 1:
 
 ```
-About to run: uv run mykg extract-graph ./docs --append --grow-schema --session 2026-06-21T11-22-38
+About to run: uv run mykg extract-graph ./docs --append-with-grow-schema --session 2026-06-21T11-22-38
 
 This will run a locked Pass 1 over the new files (LLM calls) to expand the schema,
 then extract. Plain --append would skip Pass 1 and keep the schema frozen.

--- a/src/mykg/orchestrator.py
+++ b/src/mykg/orchestrator.py
@@ -55,8 +55,8 @@ class PipelineContext(BaseModel):
     thesaurus: Any = None  # SynonymIndex | None — Any to avoid forward-ref issues
     review: bool = False
     append: bool = False
-    # --append --grow-schema (D52): run locked Pass 1 over changed files only so the
-    # LLM may ADD new concepts/properties to the existing (locked) schema, then
+    # --append-with-grow-schema (D52): run locked Pass 1 over changed files only so
+    # the LLM may ADD new concepts/properties to the existing (locked) schema, then
     # surgically back-fill old files when the schema actually grows.
     grow_schema: bool = False
     # Runtime fields populated by steps
@@ -290,11 +290,11 @@ def run(steps: list[Step], ctx: PipelineContext) -> None:
     while True:
         schema_restart_triggered = False
 
-        # In --grow-schema mode, pass1/schema_validate must run again so the locked
-        # Pass 1 can add new concepts/properties. human_review stays skipped unless
-        # --review is also set, in which case it is un-skipped so the gate (handled
-        # below via requires_review_flag) can pause for review of the grown schema.
-        # All other append skips remain in force (D52).
+        # In --append-with-grow-schema mode, pass1/schema_validate must run again so
+        # the locked Pass 1 can add new concepts/properties. human_review stays
+        # skipped unless --review is also set, in which case it is un-skipped so the
+        # gate (handled below via requires_review_flag) can pause for review of the
+        # grown schema. All other append skips remain in force (D52).
         append_skip = APPEND_SKIP_STEPS
         if ctx.grow_schema:
             append_skip = APPEND_SKIP_STEPS - {"pass1", "schema_validate"}
@@ -309,8 +309,8 @@ def run(steps: list[Step], ctx: PipelineContext) -> None:
             # In append mode, ingest must always run (detect new files) and pass2
             # must always run when new files exist (raw_extractions.json is preserved
             # for merge but still needs updating — _is_done would skip it otherwise).
-            # In --grow-schema mode, pass1 must also be force-run so a stale schema.json
-            # does not cause _is_done to skip the locked re-induction.
+            # In --append-with-grow-schema mode, pass1 must also be force-run so a
+            # stale schema.json doesn't cause _is_done to skip the locked re-induction.
             _append_force = ctx.append and step.name in (
                 "ingest",
                 *(("pass1", "schema_validate", "schema_flatten") if ctx.grow_schema else ()),

--- a/src/mykg/orchestrator.py
+++ b/src/mykg/orchestrator.py
@@ -55,6 +55,10 @@ class PipelineContext(BaseModel):
     thesaurus: Any = None  # SynonymIndex | None — Any to avoid forward-ref issues
     review: bool = False
     append: bool = False
+    # --append --grow-schema (D52): run locked Pass 1 over changed files only so the
+    # LLM may ADD new concepts/properties to the existing (locked) schema, then
+    # surgically back-fill old files when the schema actually grows.
+    grow_schema: bool = False
     # Runtime fields populated by steps
     all_chunks: list | None = None
     file_contents: dict[str, str] | None = None
@@ -286,16 +290,30 @@ def run(steps: list[Step], ctx: PipelineContext) -> None:
     while True:
         schema_restart_triggered = False
 
+        # In --grow-schema mode, pass1/schema_validate must run again so the locked
+        # Pass 1 can add new concepts/properties. human_review stays skipped unless
+        # --review is also set, in which case it is un-skipped so the gate (handled
+        # below via requires_review_flag) can pause for review of the grown schema.
+        # All other append skips remain in force (D52).
+        append_skip = APPEND_SKIP_STEPS
+        if ctx.grow_schema:
+            append_skip = APPEND_SKIP_STEPS - {"pass1", "schema_validate"}
+            if ctx.review:
+                append_skip = append_skip - {"human_review"}
+
         for step in steps:
-            if ctx.append and step.name in APPEND_SKIP_STEPS:
+            if ctx.append and step.name in append_skip:
                 log.info("SKIP %s — append mode", step.name)
                 continue
 
             # In append mode, ingest must always run (detect new files) and pass2
             # must always run when new files exist (raw_extractions.json is preserved
             # for merge but still needs updating — _is_done would skip it otherwise).
+            # In --grow-schema mode, pass1 must also be force-run so a stale schema.json
+            # does not cause _is_done to skip the locked re-induction.
             _append_force = ctx.append and step.name in (
                 "ingest",
+                *(("pass1", "schema_validate", "schema_flatten") if ctx.grow_schema else ()),
                 *(("pass2",) if ctx.append_new_files else ()),
             )
             if _is_done(step, ctx) and not _append_force:

--- a/src/mykg/steps/grow_schema_backfill.py
+++ b/src/mykg/steps/grow_schema_backfill.py
@@ -1,0 +1,169 @@
+"""grow_schema_backfill — chunk selector for --append --grow-schema (D52).
+
+When the locked Pass 1 grows the schema (new concepts and/or properties), the
+already-extracted OLD files are stale: they were extracted against the smaller
+schema and so cannot contain instances of the new types. This module decides,
+cheaply and with a bounded cost, WHICH old chunks are worth re-extracting against
+the grown schema.
+
+The selection is a HEURISTIC, not a guarantee (Invariant 16): it relies solely on
+``chunk_node_index.json`` (``filename::chunk_idx → [stable_node_ids]``) so no source
+text is re-read. A stable ID encodes its concept type as its prefix (D19:
+``node.type.lower()`` with non-alphanumerics stripped, joined to the name slug with
+``-``), so for any old chunk we already know which concept types it produced.
+
+Selection rule
+--------------
+* New property ``p (domain D → range R)`` — a chunk is a candidate IFF it already
+  contains ≥1 node of type ``D`` OR ``R`` (domain/range co-occurrence — mirrors the
+  merge_graphs surgical selector, D38).
+* New concept ``C`` — there is no edge signal, so the is-a hierarchy is used: target
+  chunks containing nodes of ``C``'s parent or sibling type(s) from ``new_schema``'s
+  concept hierarchy. A ROOT concept with no parent/siblings yields ZERO targeted
+  chunks.
+* Cap — candidates per type are ranked by co-occurrence count; only the top-K are
+  kept (``top_k`` from config). ``top_k == 0`` disables back-fill entirely.
+
+False negatives are backstopped by the orphan pass and future runs; false positives
+cost one no-op LLM call, bounded by top-K.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+
+from mykg.logging import get
+
+log = get("mykg.steps.grow_schema_backfill")
+
+
+def _type_prefix(node_type: str) -> str:
+    """Stable-ID type prefix per D19: lowercase, non-alphanumerics stripped."""
+    return re.sub(r"[^a-z0-9]", "", node_type.lower())
+
+
+def _stable_id_type(stable_id: str, prefix_to_type: dict[str, str]) -> str | None:
+    """Map a stable ID back to its concept type via its prefix (text before first '-')."""
+    prefix = stable_id.split("-", 1)[0]
+    return prefix_to_type.get(prefix)
+
+
+def _hierarchy_signal_types(concept_type: str, concepts: list[dict]) -> set[str]:
+    """Return parent + sibling type names for a concept from the is-a hierarchy.
+
+    A root concept (no parent) with no siblings sharing a parent yields an empty set.
+    """
+    by_name = {c["type"]: c for c in concepts}
+    target = by_name.get(concept_type)
+    if target is None:
+        return set()
+    parent = target.get("parent")
+    if not parent:
+        return set()
+    signal: set[str] = {parent}
+    # Siblings: concepts sharing the same parent (excluding the concept itself).
+    for c in concepts:
+        if c["type"] != concept_type and c.get("parent") == parent:
+            signal.add(c["type"])
+    return signal
+
+
+def compute_backfill_chunks(
+    added_concepts: list[str],
+    added_properties: list[dict],
+    new_schema: dict,
+    chunk_node_index: dict[str, dict[str, list[str]]],
+    top_k: int,
+) -> dict[str, set[int]]:
+    """Select old chunks to surgically re-extract after a grow-schema delta (D52).
+
+    Parameters
+    ----------
+    added_concepts:
+        Names of concept types newly added by the locked Pass 1 (absent before).
+    added_properties:
+        Newly added property dicts (``{"name", "domain", "range", ...}``) — the full
+        entry from ``new_schema["properties"]`` is needed for domain/range.
+    new_schema:
+        The grown schema (``{"concepts": [...], "properties": [...]}``); supplies the
+        is-a hierarchy used for the new-concept signal.
+    chunk_node_index:
+        ``{filename: {"1": [stable_id, ...], ...}}`` from chunk_node_index.json.
+        Chunk-index keys are 1-based strings.
+    top_k:
+        Per-type cap on candidate chunks, ranked by co-occurrence count. 0 disables
+        back-fill entirely (returns an empty map).
+
+    Returns
+    -------
+    ``{filename: {chunk_idx, ...}}`` with 1-based int chunk indices. Empty when there
+    is no delta, no signal, or ``top_k == 0``.
+    """
+    if top_k == 0:
+        return {}
+    if not added_concepts and not added_properties:
+        return {}
+    if not chunk_node_index:
+        return {}
+
+    concepts = new_schema.get("concepts", [])
+    prefix_to_type = {_type_prefix(c["type"]): c["type"] for c in concepts}
+
+    # Per type-source, collect the set of "signal types": a chunk scores if it contains
+    # ≥1 node of any signal type. Keyed by a human-readable label only for logging.
+    signal_sets: dict[str, set[str]] = {}
+
+    for prop in added_properties:
+        types = {t for t in (prop.get("domain"), prop.get("range")) if t}
+        if types:
+            signal_sets[f"property:{prop['name']}"] = types
+
+    for concept in added_concepts:
+        types = _hierarchy_signal_types(concept, concepts)
+        if types:
+            signal_sets[f"concept:{concept}"] = types
+        else:
+            log.debug(
+                "grow_schema back-fill: concept %s is root/sibling-less — no targeted chunks",
+                concept,
+            )
+
+    if not signal_sets:
+        log.info("grow_schema back-fill: no hierarchy/domain/range signal — nothing to back-fill")
+        return {}
+
+    targeted: dict[str, set[int]] = defaultdict(set)
+    for label, signal_types in signal_sets.items():
+        # Rank all chunks by count of signal-type nodes; keep top-K with score > 0.
+        scores: list[tuple[int, str, int]] = []
+        for fname, chunk_map in chunk_node_index.items():
+            for chunk_idx_str, stable_ids in chunk_map.items():
+                try:
+                    chunk_idx = int(chunk_idx_str)
+                except (ValueError, TypeError):
+                    continue
+                score = sum(
+                    1 for sid in stable_ids if _stable_id_type(sid, prefix_to_type) in signal_types
+                )
+                if score > 0:
+                    # Negative score → ascending sort puts highest co-occurrence first.
+                    scores.append((-score, fname, chunk_idx))
+        scores.sort()
+        for _, fname, chunk_idx in scores[:top_k]:
+            targeted[fname].add(chunk_idx)
+        log.debug(
+            "grow_schema back-fill: %s (signal=%s) → %d candidate chunk(s) (top_k=%d)",
+            label,
+            sorted(signal_types),
+            min(len(scores), top_k),
+            top_k,
+        )
+
+    result = dict(targeted)
+    log.info(
+        "grow_schema back-fill: selected %d old chunk(s) across %d file(s) for re-extraction",
+        sum(len(v) for v in result.values()),
+        len(result),
+    )
+    return result

--- a/src/mykg/steps/grow_schema_backfill.py
+++ b/src/mykg/steps/grow_schema_backfill.py
@@ -1,4 +1,4 @@
-"""grow_schema_backfill — chunk selector for --append --grow-schema (D52).
+"""grow_schema_backfill — chunk selector for --append-with-grow-schema (D52).
 
 When the locked Pass 1 grows the schema (new concepts and/or properties), the
 already-extracted OLD files are stale: they were extracted against the smaller

--- a/src/mykg/steps/step_pass1.py
+++ b/src/mykg/steps/step_pass1.py
@@ -15,7 +15,7 @@ log = get("mykg.steps.pass1")
 
 
 def run_pass1_step(ctx: PipelineContext) -> None:
-    # --append --grow-schema (D52): run the locked re-induction over ONLY the changed
+    # --append-with-grow-schema (D52): run the locked re-induction over ONLY the changed
     # files so the LLM sees just the new material when proposing additions. The append
     # ingest step does not chunk (it only hashes), so all_chunks must be (re)built here
     # from the changed files in the manifest. Falls through to the all-files paths below

--- a/src/mykg/steps/step_pass1.py
+++ b/src/mykg/steps/step_pass1.py
@@ -15,11 +15,32 @@ log = get("mykg.steps.pass1")
 
 
 def run_pass1_step(ctx: PipelineContext) -> None:
+    # --append --grow-schema (D52): run the locked re-induction over ONLY the changed
+    # files so the LLM sees just the new material when proposing additions. The append
+    # ingest step does not chunk (it only hashes), so all_chunks must be (re)built here
+    # from the changed files in the manifest. Falls through to the all-files paths below
+    # when not in grow-schema mode.
+    if ctx.grow_schema and ctx.append_new_files:
+        manifest_path = ctx.intermediate_dir / "file_manifest.json"
+        if not manifest_path.exists():
+            raise RuntimeError(
+                "grow_schema: file_manifest.json not found — re-run from the ingest step."
+            )
+        file_contents: dict[str, str | dict] = json.loads(manifest_path.read_text())
+        ctx.all_chunks = []
+        changed = [f for f in ctx.append_new_files if f in file_contents]
+        for fname in changed:
+            ctx.all_chunks.extend(chunk_file(fname, _content_from_entry(file_contents[fname])))
+        log.info(
+            "Step 2 — grow_schema: locked Pass 1 over %d changed file(s) → %d chunk(s)",
+            len(changed),
+            len(ctx.all_chunks),
+        )
     # Recovery path for --from-step pass1: ingest was skipped but file_manifest.json exists.
-    if ctx.all_chunks is None:
+    elif ctx.all_chunks is None:
         manifest_path = ctx.intermediate_dir / "file_manifest.json"
         if manifest_path.exists():
-            file_contents: dict[str, str | dict] = json.loads(manifest_path.read_text())
+            file_contents = json.loads(manifest_path.read_text())
             ctx.all_chunks = []
             for fname, entry in file_contents.items():
                 ctx.all_chunks.extend(chunk_file(fname, _content_from_entry(entry)))

--- a/src/mykg/steps/step_pass2.py
+++ b/src/mykg/steps/step_pass2.py
@@ -170,11 +170,11 @@ def _run(
             _log_and_write(ctx, existing_raw, existing_chunk)
             return
 
-    # --append --grow-schema (D52): when the locked Pass 1 grew the schema, surgically
-    # back-fill the OLD files so instances of the new types are picked up there too.
-    # Changed files are excluded — they are (re-)extracted in full by the todo path
-    # below against the already-grown schema. When the delta is empty this is a no-op
-    # and the run collapses to a plain append (changed files only).
+    # --append-with-grow-schema (D52): when the locked Pass 1 grew the schema,
+    # surgically back-fill the OLD files so instances of the new types are picked up
+    # there too. Changed files are excluded — they are (re-)extracted in full by the
+    # todo path below against the already-grown schema. When the delta is empty this
+    # is a no-op and the run collapses to a plain append (changed files only).
     if ctx.grow_schema and existing_raw:
         _grow_schema_backfill(ctx, manifest, schema, flat, existing_raw, existing_chunk, concat_map)
 

--- a/src/mykg/steps/step_pass2.py
+++ b/src/mykg/steps/step_pass2.py
@@ -8,6 +8,7 @@ from mykg.orchestrator import PipelineContext
 from mykg.pass2 import run_pass2, run_pass2_batched
 from mykg.pass2_concat import build_concat_batches, make_virtual_files
 from mykg.schema_flattener import flatten_schema
+from mykg.steps.grow_schema_backfill import compute_backfill_chunks
 
 log = get("mykg.steps.pass2")
 
@@ -169,6 +170,14 @@ def _run(
             _log_and_write(ctx, existing_raw, existing_chunk)
             return
 
+    # --append --grow-schema (D52): when the locked Pass 1 grew the schema, surgically
+    # back-fill the OLD files so instances of the new types are picked up there too.
+    # Changed files are excluded — they are (re-)extracted in full by the todo path
+    # below against the already-grown schema. When the delta is empty this is a no-op
+    # and the run collapses to a plain append (changed files only).
+    if ctx.grow_schema and existing_raw:
+        _grow_schema_backfill(ctx, manifest, schema, flat, existing_raw, existing_chunk, concat_map)
+
     if not todo:
         _log_and_write(ctx, existing_raw, existing_chunk)
         return
@@ -245,3 +254,123 @@ def _log_and_write(
     (ctx.intermediate_dir / "raw_extractions.done").write_text("")
     ctx.raw_extractions = raw
     ctx.chunk_node_index = chunk_node_index
+
+
+def _grow_schema_delta(base_schema: dict | None, schema: dict) -> tuple[list[str], list[dict]]:
+    """Return (added_concepts, added_properties) of the grown schema vs the locked base.
+
+    The locked base (ctx.base_schema) holds the ORIGINAL pre-growth vocabulary as
+    locked_classes/locked_properties, so the delta is exactly what the locked Pass 1
+    added. added_properties are the full property dicts from the grown schema (needed
+    for domain/range), filtered to the newly-added names.
+    """
+    locked_classes = (base_schema or {}).get("locked_classes", {})
+    locked_properties = (base_schema or {}).get("locked_properties", {})
+    added_concepts = [
+        c["type"] for c in schema.get("concepts", []) if c["type"] not in locked_classes
+    ]
+    added_properties = [
+        p for p in schema.get("properties", []) if p["name"] not in locked_properties
+    ]
+    return added_concepts, added_properties
+
+
+def _grow_schema_backfill(
+    ctx: PipelineContext,
+    manifest: dict,
+    schema: dict,
+    flat: dict,
+    existing_raw: dict,
+    existing_chunk: dict,
+    concat_map: dict,
+) -> None:
+    """Surgically re-extract OLD files for newly-added schema types (D52, Invariant 16).
+
+    Mutates existing_raw / existing_chunk in place and rewrites the affected shards.
+    No-op when the schema did not grow, when back-fill is disabled (top_k == 0), or
+    when no old chunk carries a relevant signal type. Handles concat prep mode by
+    resolving virtual batch contents from the concat map (existing_raw is keyed by
+    virtual batch name in that mode).
+    """
+    added_concepts, added_properties = _grow_schema_delta(ctx.base_schema, schema)
+    if not added_concepts and not added_properties:
+        log.info("Step 6 — grow_schema: schema unchanged, no back-fill needed")
+        return
+
+    log.info(
+        "Step 6 — grow_schema delta: +%d concept(s) %s, +%d property(ies) %s",
+        len(added_concepts),
+        added_concepts,
+        len(added_properties),
+        [p["name"] for p in added_properties],
+    )
+
+    top_k = _cfg.APPEND_GROW_SCHEMA_BACKFILL_TOP_K_CHUNKS_PER_TYPE
+    backfill = compute_backfill_chunks(
+        added_concepts, added_properties, schema, existing_chunk, top_k
+    )
+    # In concat mode, existing_raw is keyed by virtual batch names; resolve their
+    # contents from the concat map so back-fill targets can be re-extracted.
+    if concat_map:
+        real_contents = {f: _content_from_entry(manifest[f]) for f in manifest}
+        virtual_contents = make_virtual_files(real_contents, concat_map)
+        manifest = {**manifest, **virtual_contents}
+        changed_real = ctx.append_new_files or set()
+        # A virtual batch is "changed" iff it bundles a changed real file (it will be
+        # re-extracted in full by the todo path), so exclude it from back-fill.
+        changed = {
+            vname
+            for vname, entry in concat_map.items()
+            if any(rf in changed_real for rf in entry.get("files", []))
+        }
+    else:
+        changed = ctx.append_new_files or set()
+
+    # Never re-extract the changed files here — they are (re-)extracted in full by the
+    # normal todo path against the already-grown schema.
+    backfill = {f: idxs for f, idxs in backfill.items() if f in existing_raw and f not in changed}
+    if not backfill:
+        log.info("Step 6 — grow_schema: no old chunks selected for back-fill")
+        return
+
+    affected = {f: _content_from_entry(manifest[f]) for f in backfill if f in manifest}
+    if not affected:
+        log.warning("Step 6 — grow_schema: back-fill targets not in manifest; skipping")
+        return
+
+    log.info(
+        "Step 6 — grow_schema back-fill: re-extracting %d old file(s), chunks %s",
+        len(affected),
+        {f: sorted(idxs) for f, idxs in backfill.items()},
+    )
+
+    shard_dir = ctx.intermediate_dir / "raw_extractions_shards"
+    chunk_shard_dir = ctx.intermediate_dir / "chunk_index_shards"
+    shard_dir.mkdir(exist_ok=True)
+    chunk_shard_dir.mkdir(exist_ok=True)
+
+    def _on_file_done_backfill(fname: str, result: dict, file_idx: dict) -> None:
+        existing_raw[fname] = result
+        existing_chunk[fname] = file_idx
+        slug = _fname_slug(fname)
+        (shard_dir / f"{slug}.json").write_text(
+            json.dumps({"_fname": fname, "data": result}, indent=_cfg.JSON_INDENT)
+        )
+        (chunk_shard_dir / f"{slug}.json").write_text(
+            json.dumps({"_fname": fname, "data": file_idx}, indent=_cfg.JSON_INDENT)
+        )
+
+    new_raw, new_chunk, _failed = run_pass2(
+        affected,
+        schema,
+        flat,
+        ctx.adapter,
+        max_workers=ctx.pass2_workers,
+        on_file_done=_on_file_done_backfill,
+        error_gate=ctx.error_gate,
+        reextract_chunks=backfill,
+        prior_extractions=existing_raw,
+        prior_chunk_index=existing_chunk,
+    )
+    existing_raw.update(new_raw)
+    existing_chunk.update(new_chunk)

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -269,6 +269,57 @@ def test_orchestrator_skips_pass1_when_output_exists(tmp_path):
     assert "pass2" in executed
 
 
+def test_orchestrator_grow_schema_forces_pass1_and_schema_steps(tmp_path):
+    """In --append --grow-schema mode pass1/schema_validate/schema_flatten must RUN
+    again even though their outputs already exist (D52), while human_review stays
+    skipped (no --review)."""
+    ctx = _make_ctx(tmp_path, append=True)
+    ctx.grow_schema = True
+
+    # Pre-populate all schema outputs so plain append would skip them.
+    (ctx.intermediate_dir / "schema.json").write_text('{"concepts":[],"properties":[]}')
+    (ctx.intermediate_dir / "schema.ttl").write_text("")
+    (ctx.intermediate_dir / "schema_validate.done").write_text("done")
+    (ctx.intermediate_dir / "schema_approved.flag").write_text("auto-approved")
+    (ctx.intermediate_dir / "flattened_schema.json").write_text("{}")
+
+    executed = []
+
+    def ingest_fn(c):
+        executed.append("ingest")
+        c.append_new_files = {"new.md"}  # simulate a detected new file
+
+    def make(name):
+        def _fn(c):
+            executed.append(name)
+
+        return _fn
+
+    def pass2_fn(c):
+        executed.append("pass2")
+        (c.intermediate_dir / "raw_extractions.json").write_text("{}")
+        (c.intermediate_dir / "chunk_node_index.json").write_text("{}")
+
+    steps = [
+        Step(name="ingest", fn=ingest_fn, outputs=["file_manifest.json"]),
+        Step(
+            name="pass1", fn=make("pass1"), outputs=["schema.json", "schema.ttl"], is_llm_step=True
+        ),
+        Step(name="schema_validate", fn=make("schema_validate"), outputs=["schema_validate.done"]),
+        Step(name="human_review", fn=make("human_review"), outputs=["schema_approved.flag"]),
+        Step(name="schema_flatten", fn=make("schema_flatten"), outputs=["flattened_schema.json"]),
+        Step(name="pass2", fn=pass2_fn, outputs=["raw_extractions.json", "chunk_node_index.json"]),
+    ]
+
+    run(steps, ctx)
+
+    assert "pass1" in executed, "pass1 must be force-run in grow_schema mode"
+    assert "schema_validate" in executed, "schema_validate must be force-run in grow_schema mode"
+    assert "schema_flatten" in executed, "schema_flatten must be force-run in grow_schema mode"
+    assert "human_review" not in executed, "human_review stays skipped without --review"
+    assert "pass2" in executed
+
+
 # ---------------------------------------------------------------------------
 # 7. Orchestrator: missing schema error
 # ---------------------------------------------------------------------------

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -270,7 +270,7 @@ def test_orchestrator_skips_pass1_when_output_exists(tmp_path):
 
 
 def test_orchestrator_grow_schema_forces_pass1_and_schema_steps(tmp_path):
-    """In --append --grow-schema mode pass1/schema_validate/schema_flatten must RUN
+    """In --append-with-grow-schema mode pass1/schema_validate/schema_flatten must RUN
     again even though their outputs already exist (D52), while human_review stays
     skipped (no --review)."""
     ctx = _make_ctx(tmp_path, append=True)

--- a/tests/test_cli_grow_schema.py
+++ b/tests/test_cli_grow_schema.py
@@ -1,4 +1,4 @@
-"""CLI validation tests for --grow-schema (Unit 1 / D52).
+"""CLI validation tests for --append-with-grow-schema (Unit 1 / D52).
 
 These exercise the early validation gates only — they never reach an LLM call.
 """
@@ -15,25 +15,28 @@ def test_grow_schema_help_lists_flag():
     runner = CliRunner()
     result = runner.invoke(cli, ["extract-graph", "--help"])
     assert result.exit_code == 0
-    assert "--grow-schema" in result.output
+    assert "--append-with-grow-schema" in result.output
 
 
-def test_grow_schema_requires_append(tmp_path):
-    """--grow-schema without --append must fail with a clear message."""
+def test_grow_schema_implies_append(tmp_path):
+    """--append-with-grow-schema without explicit --append must still work
+    (the flag implies --append). This test only checks that the 'requires
+    --append' error does NOT fire — it will fail later when no session schema
+    exists, which is the expected next gate."""
     runner = CliRunner()
     input_dir = tmp_path / "input"
     input_dir.mkdir()
     result = runner.invoke(
         cli,
-        ["extract-graph", str(input_dir), "--grow-schema"],
-        catch_exceptions=False,
+        ["extract-graph", str(input_dir), "--append-with-grow-schema"],
+        catch_exceptions=True,
     )
-    assert result.exit_code != 0
-    assert "requires --append" in result.output
+    # Must NOT fail with "requires --append"
+    assert "requires --append" not in (result.output or "")
 
 
 def test_grow_schema_excludes_explicit_base_schema(tmp_path, monkeypatch):
-    """--grow-schema must reject an explicit --base-schema (it auto-loads the session)."""
+    """--append-with-grow-schema must reject an explicit --base-schema (it auto-loads the session)."""
     runner = CliRunner()
     sessions = tmp_path / "mykg_sessions"
     session = sessions / "s1"
@@ -52,8 +55,7 @@ def test_grow_schema_excludes_explicit_base_schema(tmp_path, monkeypatch):
         [
             "extract-graph",
             str(src),
-            "--append",
-            "--grow-schema",
+            "--append-with-grow-schema",
             "--session",
             "s1",
             "--base-schema",
@@ -66,13 +68,12 @@ def test_grow_schema_excludes_explicit_base_schema(tmp_path, monkeypatch):
 
 
 def test_grow_schema_errors_when_session_schema_ttl_missing(tmp_path, monkeypatch):
-    """--grow-schema must fail clearly if the session has no schema.ttl to lock."""
+    """--append-with-grow-schema must fail clearly if the session has no schema.ttl to lock."""
     runner = CliRunner()
     sessions = tmp_path / "mykg_sessions"
     session = sessions / "s1"
     (session / "intermediate").mkdir(parents=True)
     (session / "input").mkdir()
-    # schema.json present so append's "no existing pipeline" guard passes, but no schema.ttl
     (session / "intermediate" / "schema.json").write_text("{}")
     monkeypatch.setattr("mykg.cli._sessions_root", lambda: sessions)
 
@@ -83,8 +84,7 @@ def test_grow_schema_errors_when_session_schema_ttl_missing(tmp_path, monkeypatc
         [
             "extract-graph",
             str(src),
-            "--append",
-            "--grow-schema",
+            "--append-with-grow-schema",
             "--session",
             "s1",
         ],
@@ -95,7 +95,7 @@ def test_grow_schema_errors_when_session_schema_ttl_missing(tmp_path, monkeypatc
 
 
 def test_grow_schema_and_from_step_mutually_exclusive(tmp_path):
-    """--grow-schema inherits append's mutual exclusion with --from-step."""
+    """--append-with-grow-schema inherits append's mutual exclusion with --from-step."""
     runner = CliRunner()
     input_dir = tmp_path / "input"
     input_dir.mkdir()
@@ -104,8 +104,7 @@ def test_grow_schema_and_from_step_mutually_exclusive(tmp_path):
         [
             "extract-graph",
             str(input_dir),
-            "--append",
-            "--grow-schema",
+            "--append-with-grow-schema",
             "--from-step",
             "pass2",
         ],

--- a/tests/test_cli_grow_schema.py
+++ b/tests/test_cli_grow_schema.py
@@ -1,0 +1,119 @@
+"""CLI validation tests for --grow-schema (Unit 1 / D52).
+
+These exercise the early validation gates only — they never reach an LLM call.
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from mykg.cli import cli
+
+
+def test_grow_schema_help_lists_flag():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["extract-graph", "--help"])
+    assert result.exit_code == 0
+    assert "--grow-schema" in result.output
+
+
+def test_grow_schema_requires_append(tmp_path):
+    """--grow-schema without --append must fail with a clear message."""
+    runner = CliRunner()
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    result = runner.invoke(
+        cli,
+        ["extract-graph", str(input_dir), "--grow-schema"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    assert "requires --append" in result.output
+
+
+def test_grow_schema_excludes_explicit_base_schema(tmp_path, monkeypatch):
+    """--grow-schema must reject an explicit --base-schema (it auto-loads the session)."""
+    runner = CliRunner()
+    sessions = tmp_path / "mykg_sessions"
+    session = sessions / "s1"
+    (session / "intermediate").mkdir(parents=True)
+    (session / "input").mkdir()
+    (session / "intermediate" / "schema.json").write_text("{}")
+    monkeypatch.setattr("mykg.cli._sessions_root", lambda: sessions)
+
+    base_ttl = tmp_path / "base.ttl"
+    base_ttl.write_text("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n")
+
+    src = tmp_path / "src"
+    src.mkdir()
+    result = runner.invoke(
+        cli,
+        [
+            "extract-graph",
+            str(src),
+            "--append",
+            "--grow-schema",
+            "--session",
+            "s1",
+            "--base-schema",
+            str(base_ttl),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    assert "base-schema" in result.output.lower()
+
+
+def test_grow_schema_errors_when_session_schema_ttl_missing(tmp_path, monkeypatch):
+    """--grow-schema must fail clearly if the session has no schema.ttl to lock."""
+    runner = CliRunner()
+    sessions = tmp_path / "mykg_sessions"
+    session = sessions / "s1"
+    (session / "intermediate").mkdir(parents=True)
+    (session / "input").mkdir()
+    # schema.json present so append's "no existing pipeline" guard passes, but no schema.ttl
+    (session / "intermediate" / "schema.json").write_text("{}")
+    monkeypatch.setattr("mykg.cli._sessions_root", lambda: sessions)
+
+    src = tmp_path / "src"
+    src.mkdir()
+    result = runner.invoke(
+        cli,
+        [
+            "extract-graph",
+            str(src),
+            "--append",
+            "--grow-schema",
+            "--session",
+            "s1",
+        ],
+        catch_exceptions=True,
+    )
+    assert result.exit_code != 0
+    assert "schema.ttl" in result.output
+
+
+def test_grow_schema_and_from_step_mutually_exclusive(tmp_path):
+    """--grow-schema inherits append's mutual exclusion with --from-step."""
+    runner = CliRunner()
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    result = runner.invoke(
+        cli,
+        [
+            "extract-graph",
+            str(input_dir),
+            "--append",
+            "--grow-schema",
+            "--from-step",
+            "pass2",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()
+
+
+if __name__ == "__main__":
+    pytest.main([str(Path(__file__))])

--- a/tests/test_grow_schema_backfill.py
+++ b/tests/test_grow_schema_backfill.py
@@ -1,0 +1,136 @@
+"""Unit tests for the grow-schema back-fill chunk selector (Unit 4 / D52)."""
+
+from mykg.steps.grow_schema_backfill import compute_backfill_chunks
+
+# A small grown schema with a hierarchy:
+#   MilitaryUnit (root)
+#     Brigade is-a MilitaryUnit   (newly added concept)
+#   Officer (root)
+# Properties: commands (Officer -> MilitaryUnit) is newly added.
+NEW_SCHEMA = {
+    "concepts": [
+        {"type": "MilitaryUnit", "parent": None, "attributes": ["name"]},
+        {"type": "Brigade", "parent": "MilitaryUnit", "attributes": ["name"]},
+        {"type": "Officer", "parent": None, "attributes": ["name"]},
+    ],
+    "properties": [
+        {"name": "commands", "domain": "Officer", "range": "MilitaryUnit", "attributes": []},
+    ],
+}
+
+# chunk_node_index: stable-id prefix encodes the type (D19): officer-*, militaryunit-*.
+CHUNK_INDEX = {
+    "old1.md": {
+        "1": ["officer-patton", "militaryunit-thirdarmy"],
+        "2": ["officer-bradley"],
+    },
+    "old2.md": {
+        "1": ["militaryunit-firstinfantry"],
+        "2": ["person-someone"],  # unrelated type
+    },
+}
+
+
+def test_new_property_targets_domain_or_range_chunks():
+    """A new property D->R selects chunks containing a D or R node."""
+    result = compute_backfill_chunks(
+        added_concepts=[],
+        added_properties=[NEW_SCHEMA["properties"][0]],
+        new_schema=NEW_SCHEMA,
+        chunk_node_index=CHUNK_INDEX,
+        top_k=10,
+    )
+    # chunks with Officer or MilitaryUnit nodes: old1#1, old1#2, old2#1
+    assert result["old1.md"] == {1, 2}
+    assert result["old2.md"] == {1}
+    # old2#2 (person only) is never selected
+    assert 2 not in result.get("old2.md", set())
+
+
+def test_new_concept_uses_hierarchy_signal_parent():
+    """A new subclass concept targets chunks containing its PARENT-type nodes."""
+    result = compute_backfill_chunks(
+        added_concepts=["Brigade"],  # is-a MilitaryUnit
+        added_properties=[],
+        new_schema=NEW_SCHEMA,
+        chunk_node_index=CHUNK_INDEX,
+        top_k=10,
+    )
+    # parent = MilitaryUnit → chunks with militaryunit-* nodes: old1#1, old2#1
+    assert result.get("old1.md") == {1}
+    assert result.get("old2.md") == {1}
+
+
+def test_root_concept_with_no_siblings_yields_no_targets():
+    """A brand-new ROOT concept (no parent, no siblings) selects ZERO chunks."""
+    schema = {
+        "concepts": [
+            {"type": "Country", "parent": None, "attributes": ["name"]},
+            {"type": "MilitaryUnit", "parent": None, "attributes": ["name"]},
+            {"type": "Officer", "parent": None, "attributes": ["name"]},
+        ],
+        "properties": [],
+    }
+    result = compute_backfill_chunks(
+        added_concepts=["Country"],
+        added_properties=[],
+        new_schema=schema,
+        chunk_node_index=CHUNK_INDEX,
+        top_k=10,
+    )
+    assert result == {}
+
+
+def test_top_k_zero_disables_backfill():
+    result = compute_backfill_chunks(
+        added_concepts=["Brigade"],
+        added_properties=[NEW_SCHEMA["properties"][0]],
+        new_schema=NEW_SCHEMA,
+        chunk_node_index=CHUNK_INDEX,
+        top_k=0,
+    )
+    assert result == {}
+
+
+def test_empty_delta_returns_empty():
+    result = compute_backfill_chunks(
+        added_concepts=[],
+        added_properties=[],
+        new_schema=NEW_SCHEMA,
+        chunk_node_index=CHUNK_INDEX,
+        top_k=10,
+    )
+    assert result == {}
+
+
+def test_top_k_cap_keeps_only_highest_cooccurrence():
+    """With top_k=1, only the single highest-co-occurrence chunk per signal survives."""
+    schema = {
+        "concepts": [{"type": "Officer", "parent": None, "attributes": ["name"]}],
+        "properties": [
+            {"name": "commands", "domain": "Officer", "range": "Officer", "attributes": []}
+        ],
+    }
+    idx = {
+        "a.md": {"1": ["officer-x", "officer-y", "officer-z"]},  # score 3
+        "b.md": {"1": ["officer-q"]},  # score 1
+    }
+    result = compute_backfill_chunks(
+        added_concepts=[],
+        added_properties=schema["properties"],
+        new_schema=schema,
+        chunk_node_index=idx,
+        top_k=1,
+    )
+    assert result == {"a.md": {1}}
+
+
+def test_empty_chunk_index_returns_empty():
+    result = compute_backfill_chunks(
+        added_concepts=["Brigade"],
+        added_properties=[NEW_SCHEMA["properties"][0]],
+        new_schema=NEW_SCHEMA,
+        chunk_node_index={},
+        top_k=10,
+    )
+    assert result == {}

--- a/tests/test_grow_schema_backfill.py
+++ b/tests/test_grow_schema_backfill.py
@@ -134,3 +134,59 @@ def test_empty_chunk_index_returns_empty():
         top_k=10,
     )
     assert result == {}
+
+
+def test_unknown_added_concept_yields_no_targets():
+    """A concept name not present in new_schema's concepts contributes no chunks."""
+    result = compute_backfill_chunks(
+        added_concepts=["Nonexistent"],  # not in NEW_SCHEMA["concepts"]
+        added_properties=[],
+        new_schema=NEW_SCHEMA,
+        chunk_node_index=CHUNK_INDEX,
+        top_k=10,
+    )
+    assert result == {}
+
+
+def test_malformed_chunk_index_key_is_skipped():
+    """Non-integer chunk-index keys are ignored rather than raising."""
+    idx = {
+        "old.md": {
+            "1": ["officer-patton"],  # valid → selected
+            "notanint": ["officer-bradley"],  # malformed key → skipped
+        },
+    }
+    result = compute_backfill_chunks(
+        added_concepts=[],
+        added_properties=[NEW_SCHEMA["properties"][0]],  # Officer is domain
+        new_schema=NEW_SCHEMA,
+        chunk_node_index=idx,
+        top_k=10,
+    )
+    assert result == {"old.md": {1}}
+
+
+def test_new_concept_with_siblings_targets_sibling_type_chunks():
+    """A new subclass also targets chunks containing SIBLING-type nodes."""
+    schema = {
+        "concepts": [
+            {"type": "MilitaryUnit", "parent": None, "attributes": ["name"]},
+            {"type": "Division", "parent": "MilitaryUnit", "attributes": ["name"]},
+            {"type": "Brigade", "parent": "MilitaryUnit", "attributes": ["name"]},  # new
+        ],
+        "properties": [],
+    }
+    idx = {
+        "a.md": {"1": ["division-first"]},  # sibling type
+        "b.md": {"1": ["militaryunit-generic"]},  # parent type
+        "c.md": {"1": ["officer-x"]},  # unrelated
+    }
+    result = compute_backfill_chunks(
+        added_concepts=["Brigade"],
+        added_properties=[],
+        new_schema=schema,
+        chunk_node_index=idx,
+        top_k=10,
+    )
+    # parent (MilitaryUnit) and sibling (Division) chunks selected; officer chunk not
+    assert result == {"a.md": {1}, "b.md": {1}}

--- a/tests/test_grow_schema_e2e.py
+++ b/tests/test_grow_schema_e2e.py
@@ -1,0 +1,288 @@
+"""End-to-end integration test for --append --grow-schema (Unit 7 / D52).
+
+Uses a content-aware stub LLM adapter (no network). Verifies:
+  (a) initial build over a small corpus;
+  (b) re-run with a new doc + grow_schema where locked Pass 1 returns ONE new
+      concept + ONE new property;
+  (c) the grown schema keeps the locked-old entries AND gains the new ones;
+  (d) old-file shards are surgically re-extracted for the affected chunks;
+  (e) final nodes.jsonl/edges.jsonl include instances of the new type sourced
+      from BOTH the old and the new docs;
+  (f) a no-delta append collapses to a plain append (no back-fill, no full
+      re-extract of old files).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import mykg.config as _cfg
+from mykg.base_schema import parse_base_schema
+from mykg.llm.adapter import LLMAdapter
+from mykg.orchestrator import PipelineContext, run
+from mykg.pipeline import STEPS
+
+
+@pytest.fixture(autouse=True)
+def _per_file_prep(monkeypatch):
+    """Pin per-file Pass 2 prep so shards are keyed by real filenames, isolating the
+    grow-schema back-fill logic from concat/batch batching. per_file is a supported
+    prep mode; the back-fill itself is concat-aware in production."""
+    monkeypatch.setattr(_cfg, "PASS2_PREP_MODE", "per_file")
+
+
+# --- canned schema proposals -------------------------------------------------
+
+BASE_SCHEMA_PROPOSAL = json.dumps(
+    {
+        "concepts": [
+            {"type": "Person", "parent": None, "attributes": ["name"]},
+            {"type": "Organization", "parent": None, "attributes": ["name"]},
+        ],
+        "properties": [
+            {"name": "works_at", "domain": "Person", "range": "Organization", "attributes": []},
+        ],
+    }
+)
+
+# Locked Pass 1 over the NEW doc proposes one new concept (Project) + one new
+# property (leads: Person -> Project). The locked merge will union these into the
+# existing schema.
+GROWN_SCHEMA_PROPOSAL = json.dumps(
+    {
+        "concepts": [
+            {"type": "Person", "parent": None, "attributes": ["name"]},
+            {"type": "Project", "parent": None, "attributes": ["name"]},
+        ],
+        "properties": [
+            {"name": "leads", "domain": "Person", "range": "Project", "attributes": []},
+        ],
+    }
+)
+
+
+def _node(nid: str, ntype: str, name: str) -> dict:
+    return {
+        "id": nid,
+        "type": ntype,
+        "confidence": 0.95,
+        "attributes": {"name": {"value": name, "confidence": 0.99}},
+    }
+
+
+def _edge(eid: str, etype: str, frm: str, to: str) -> dict:
+    return {"id": eid, "type": etype, "from": frm, "to": to, "confidence": 0.9, "attributes": {}}
+
+
+class GrowSchemaMockAdapter(LLMAdapter):
+    """Content-aware stub. Branches on system prompt + user text.
+
+    grow: when True, Pass 1 (over the new doc) returns the grown proposal and
+    Pass 2 over chunks mentioning Prometheus returns a Project node + leads edge.
+    """
+
+    def __init__(self, grow: bool):
+        self.grow = grow
+        self.pass1_calls = 0
+        self.pass2_users: list[str] = []
+
+    def complete(
+        self,
+        system: str,
+        user: str,
+        context_label: str = "",
+        max_tokens: int | None = None,
+        timeout: int | None = None,
+    ) -> str:
+        # Harmonize / quality cleanup passes — return invalid JSON so the pipeline
+        # keeps the merged schema unchanged (documented fallback behavior).
+        if "harmonize" in system.lower() or "review a knowledge graph schema" in system.lower():
+            return "not json {"
+
+        # Pass 1 schema induction.
+        if "rdfs ontology expert" in system.lower() and "extract a schema" in system.lower():
+            self.pass1_calls += 1
+            return GROWN_SCHEMA_PROPOSAL if self.grow else BASE_SCHEMA_PROPOSAL
+
+        # Pass 2 instance extraction.
+        if "knowledge graph extraction expert" in system.lower():
+            self.pass2_users.append(user)
+            nodes = []
+            edges = []
+            if "Alice" in user or "Acme" in user:
+                nodes += [
+                    _node("person-alice", "Person", "Alice"),
+                    _node("organization-acme-corp", "Organization", "Acme Corp"),
+                ]
+                edges += [_edge("e-wa", "works_at", "person-alice", "organization-acme-corp")]
+            # Prometheus appears in BOTH the old projects doc and the new doc — the
+            # Project type only exists after the schema grew, so the grown-schema
+            # extraction (back-fill on old + extraction on new) emits Project nodes.
+            if self.grow and "Prometheus" in user:
+                nodes += [
+                    _node("person-alice", "Person", "Alice"),
+                    _node("project-prometheus", "Project", "Prometheus"),
+                ]
+                edges += [_edge("e-leads", "leads", "person-alice", "project-prometheus")]
+            return json.dumps({"nodes": nodes, "edges": edges})
+
+        # Name normalization — empty map (no aliases).
+        if "different surface forms" in system.lower():
+            return "{}"
+
+        # Orphan stage-2 / chunk recovery / schema-gap — no new edges, no schema gap.
+        if "orphan" in system.lower():
+            return "[]"
+
+        # Default: empty extraction.
+        return json.dumps({"nodes": [], "edges": []})
+
+    def endpoint_label(self) -> str:
+        return "grow-mock"
+
+
+def _make_corpus(tmp_path: Path) -> Path:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    (input_dir / "people.md").write_text("Alice works at Acme Corp.")
+    # Old doc that mentions Prometheus but, at first build, only as plain text —
+    # there is no Project type yet so nothing Project-shaped is extracted.
+    (input_dir / "projects.md").write_text("Acme Corp is building Prometheus. Alice is involved.")
+    return input_dir
+
+
+def _ctx(input_dir: Path, tmp_path: Path, adapter, **kw) -> PipelineContext:
+    output_dir = tmp_path / "output"
+    intermediate_dir = tmp_path / "intermediate"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    intermediate_dir.mkdir(parents=True, exist_ok=True)
+    return PipelineContext(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        intermediate_dir=intermediate_dir,
+        adapter=adapter,
+        base_schema=kw.pop("base_schema", None),
+        thesaurus=None,
+        review=False,
+        **kw,
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().strip().splitlines() if line.strip()]
+
+
+def test_grow_schema_end_to_end(tmp_path):
+    input_dir = _make_corpus(tmp_path)
+
+    # (a) initial build
+    ctx = _ctx(input_dir, tmp_path, GrowSchemaMockAdapter(grow=False))
+    run(STEPS, ctx)
+
+    schema0 = json.loads((ctx.intermediate_dir / "schema.json").read_text())
+    types0 = {c["type"] for c in schema0["concepts"]}
+    assert "Person" in types0 and "Organization" in types0
+    assert "Project" not in types0
+
+    # (b) add a new doc, re-run with --append --grow-schema (schema.ttl auto-loaded)
+    (input_dir / "new_project.md").write_text("Alice leads the Prometheus project at Acme Corp.")
+    base = parse_base_schema((ctx.intermediate_dir / "schema.ttl").read_text())
+
+    grow_adapter = GrowSchemaMockAdapter(grow=True)
+    ctx2 = _ctx(
+        input_dir,
+        tmp_path,
+        grow_adapter,
+        base_schema=base,
+        append=True,
+        grow_schema=True,
+    )
+    run(STEPS, ctx2)
+
+    # (c) grown schema keeps locked-old + gains new
+    schema1 = json.loads((ctx2.intermediate_dir / "schema.json").read_text())
+    types1 = {c["type"] for c in schema1["concepts"]}
+    props1 = {p["name"] for p in schema1["properties"]}
+    assert {"Person", "Organization", "Project"} <= types1, types1
+    assert {"works_at", "leads"} <= props1, props1
+
+    # schema_history records the additions
+    history = sorted((ctx2.intermediate_dir / "schema_history").glob("*.json"))
+    added_concepts = set()
+    added_props = set()
+    for f in history:
+        d = json.loads(f.read_text())
+        added_concepts.update(d.get("concepts_added", []))
+        added_props.update(d.get("properties_added", []))
+    assert "Project" in added_concepts
+    assert "leads" in added_props
+
+    # (d) the OLD projects.md shard was surgically re-extracted (now carries a Project)
+    old_shard = ctx2.intermediate_dir / "raw_extractions_shards" / "projects.md.json"
+    assert old_shard.exists()
+    old_data = json.loads(old_shard.read_text())["data"]
+    old_types = {n["type"] for n in old_data["nodes"]}
+    assert "Project" in old_types, f"back-fill did not add Project to old shard: {old_types}"
+
+    # (e) final outputs include Project instances from BOTH old and new docs
+    nodes = _read_jsonl(ctx2.output_dir / "nodes.jsonl")
+    project_nodes = [n for n in nodes if n["type"] == "Project"]
+    assert project_nodes, "no Project node in final nodes.jsonl"
+    project_sources = set()
+    for n in project_nodes:
+        project_sources.update(n.get("source_files", []))
+    assert "projects.md" in project_sources, project_sources  # old doc (back-filled)
+    assert "new_project.md" in project_sources, project_sources  # new doc
+
+    edges = _read_jsonl(ctx2.output_dir / "edges.jsonl")
+    assert any(e["type"] == "leads" for e in edges), "no 'leads' edge in final edges.jsonl"
+
+
+def test_grow_schema_no_delta_collapses_to_plain_append(tmp_path):
+    """When the locked Pass 1 proposes nothing new, grow_schema must NOT re-extract old
+    files (no back-fill) and the schema is unchanged."""
+    input_dir = _make_corpus(tmp_path)
+
+    ctx = _ctx(input_dir, tmp_path, GrowSchemaMockAdapter(grow=False))
+    run(STEPS, ctx)
+    schema0 = json.loads((ctx.intermediate_dir / "schema.json").read_text())
+
+    # Capture old shard contents before the append re-run.
+    old_shard = ctx.intermediate_dir / "raw_extractions_shards" / "projects.md.json"
+    before = old_shard.read_text()
+
+    # New doc, but the locked Pass 1 (grow=False) proposes only already-locked entries
+    # → empty delta.
+    (input_dir / "extra.md").write_text("Bob works at Acme Corp.")
+    base = parse_base_schema((ctx.intermediate_dir / "schema.ttl").read_text())
+
+    no_delta_adapter = GrowSchemaMockAdapter(grow=False)
+    ctx2 = _ctx(
+        input_dir,
+        tmp_path,
+        no_delta_adapter,
+        base_schema=base,
+        append=True,
+        grow_schema=True,
+    )
+    run(STEPS, ctx2)
+
+    schema1 = json.loads((ctx2.intermediate_dir / "schema.json").read_text())
+    assert {c["type"] for c in schema1["concepts"]} == {c["type"] for c in schema0["concepts"]}, (
+        "schema must be unchanged when no new concepts are proposed"
+    )
+
+    # Old shard for projects.md was NOT re-extracted (back-fill skipped on empty delta).
+    after = old_shard.read_text()
+    assert before == after, "old shard must be untouched when the schema did not grow"
+
+    # The new file was still extracted.
+    extra_shard = ctx2.intermediate_dir / "raw_extractions_shards" / "extra.md.json"
+    assert extra_shard.exists()
+
+
+if __name__ == "__main__":
+    pytest.main([str(Path(__file__)), "-v"])

--- a/tests/test_grow_schema_e2e.py
+++ b/tests/test_grow_schema_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end integration test for --append --grow-schema (Unit 7 / D52).
+"""End-to-end integration test for --append-with-grow-schema (Unit 7 / D52).
 
 Uses a content-aware stub LLM adapter (no network). Verifies:
   (a) initial build over a small corpus;
@@ -187,7 +187,7 @@ def test_grow_schema_end_to_end(tmp_path):
     assert "Person" in types0 and "Organization" in types0
     assert "Project" not in types0
 
-    # (b) add a new doc, re-run with --append --grow-schema (schema.ttl auto-loaded)
+    # (b) add a new doc, re-run with --append-with-grow-schema (schema.ttl auto-loaded)
     (input_dir / "new_project.md").write_text("Alice leads the Prometheus project at Acme Corp.")
     base = parse_base_schema((ctx.intermediate_dir / "schema.ttl").read_text())
 

--- a/tests/test_pass1.py
+++ b/tests/test_pass1.py
@@ -398,7 +398,7 @@ def test_run_pass1_step_propagates_locked_block_to_cleanup_prompts(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Unit 3 — --grow-schema scopes locked Pass 1 to changed files only (D52)
+# Unit 3 — --append-with-grow-schema scopes locked Pass 1 to changed files only (D52)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_pass1.py
+++ b/tests/test_pass1.py
@@ -376,9 +376,7 @@ def test_run_pass1_step_propagates_locked_block_to_cleanup_prompts(tmp_path):
     adapter = SequenceAdapter([response, response, response])
     ctx = _make_step_ctx(tmp_path, adapter)
     ctx.base_schema = {
-        "locked_classes": {
-            "Vehicle": {"type": "Vehicle", "parent": None, "attributes": ["name"]}
-        },
+        "locked_classes": {"Vehicle": {"type": "Vehicle", "parent": None, "attributes": ["name"]}},
         "locked_properties": {
             "owns": {"name": "owns", "domain": "Person", "range": "Vehicle", "attributes": []}
         },
@@ -397,6 +395,59 @@ def test_run_pass1_step_propagates_locked_block_to_cleanup_prompts(tmp_path):
         assert "Vehicle" in system, "locked class name missing from cleanup prompt"
         assert "owns" in system, "locked property name missing from cleanup prompt"
         assert "DO NOT RENAME, REMOVE, OR DUPLICATE" in system
+
+
+# ---------------------------------------------------------------------------
+# Unit 3 — --grow-schema scopes locked Pass 1 to changed files only (D52)
+# ---------------------------------------------------------------------------
+
+
+def test_grow_schema_pass1_uses_only_changed_files(tmp_path):
+    """With grow_schema + append_new_files, locked Pass 1 must chunk ONLY the changed
+    files from the manifest, never the unchanged old files."""
+    response = json.dumps(
+        {
+            "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+            "properties": [],
+        }
+    )
+    adapter = SequenceAdapter([response, response, response])
+    ctx = _make_step_ctx(tmp_path, adapter)
+    ctx.all_chunks = None  # append ingest does not chunk
+    ctx.grow_schema = True
+    ctx.append = True
+    ctx.append_new_files = {"new.md"}
+
+    manifest = {
+        "old.md": {"content": "OLDFILEMARKER content about Acme.", "sha256": "x"},
+        "new.md": {"content": "NEWFILEMARKER content about Bob.", "sha256": "y"},
+    }
+    (ctx.intermediate_dir / "file_manifest.json").write_text(json.dumps(manifest))
+
+    run_pass1_step(ctx)
+
+    all_user_text = "\n".join(user for _, user in adapter.calls)
+    assert "NEWFILEMARKER" in all_user_text, "changed file content must reach Pass 1"
+    assert "OLDFILEMARKER" not in all_user_text, "unchanged file must NOT reach locked Pass 1"
+
+
+def test_grow_schema_pass1_ignores_changed_files_absent_from_manifest(tmp_path):
+    """A changed-file name not present in the manifest is skipped (no crash)."""
+    response = json.dumps(
+        {"concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}], "properties": []}
+    )
+    adapter = SequenceAdapter([response, response, response])
+    ctx = _make_step_ctx(tmp_path, adapter)
+    ctx.all_chunks = None
+    ctx.grow_schema = True
+    ctx.append = True
+    ctx.append_new_files = {"new.md", "ghost.md"}
+    manifest = {"new.md": {"content": "NEWFILEMARKER text.", "sha256": "y"}}
+    (ctx.intermediate_dir / "file_manifest.json").write_text(json.dumps(manifest))
+
+    run_pass1_step(ctx)  # must not raise
+    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text())
+    assert any(c["type"] == "Person" for c in schema["concepts"])
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "mykg"
-version = "0.2.31"
+version = "0.2.32"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Adds **Option 3 — Locked-Incremental Schema Growth**, triggered by `mykg extract-graph <dir> --append --grow-schema --session <name>`.

Previously `--append` froze the schema (Pass 1 skipped). With `--grow-schema`:
- Pass 1 runs in **locked** mode over the **changed files only** — the existing schema is preserved (auto-loaded from the session's `intermediate/schema.ttl`), but the LLM may **add** new concepts/properties.
- Pass 2 preserves prior extractions and extracts only changed files.
- When the schema actually grows, old files are **surgically back-filled** so the graph stays consistent at bounded cost (Invariants 14 & 16; mirrors D37/D38).

Reuses existing machinery throughout (locked merge, surgical `run_pass2(reextract_chunks=...)`, schema-history diff, `chunk_node_index`).

## Units
1. **CLI** — `--grow-schema` flag; requires `--append`; mutually exclusive with `--from-step` / explicit `--base-schema`; auto-loads session `schema.ttl` (fail-fast if missing).
2. **Orchestrator** — `grow_schema` on `PipelineContext`; un-skips locked `pass1`/`schema_validate` (force-run) in this mode.
3. **Locked Pass 1 scope** — chunks built from changed files only when growing.
4. **Back-fill** — new `grow_schema_backfill.py`: domain/range co-occurrence selector for new properties; is-a parent/sibling signal for new concepts (zero for roots); top-K cap (0 disables). Wired into the existing surgical Pass 2 path; empty delta collapses to plain append.
5. **Config** — `append.grow_schema_backfill_top_k_chunks_per_type` (default 10) in all 6 profiles of both YAML files (Invariants 7 & 17).
6. **Docs** — design decision documented in `docs/architecture.md`.
7. **Tests** — selector rules, CLI flag/validation, and a full delta + no-delta e2e with a content-aware stub adapter.

## Verification
- Full suite: **1124 passed, 4 skipped**; ruff check + format clean.
- CLI help shows `--grow-schema`; `--grow-schema` without `--append` exits non-zero with the "requires --append" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce locked incremental schema growth for append mode and wire it through CLI, orchestrator, and pass steps, including selective back-fill of old chunks when the schema expands.

New Features:
- Add --grow-schema flag to extract-graph CLI to enable incremental schema growth on top of append mode, auto-loading the session schema as a locked base and validating incompatible options.
- Support grow_schema mode in the pipeline context and orchestrator, rerunning locked Pass 1 and schema validation on changed files only while preserving append semantics.
- Implement incremental schema back-fill logic that re-extracts selected old chunks based on new concepts/properties and chunk_node_index, keeping graphs consistent after schema growth.

Enhancements:
- Update Pass 1 and Pass 2 steps to operate on changed files only in grow_schema mode and to surgically update existing raw extraction shards and chunk indexes.
- Add configuration for append.grow_schema_backfill_top_k_chunks_per_type across profiles and document incremental schema growth behavior in the architecture docs.
- Tidy various CLI helpers and fetch-web plumbing for readability and style consistency.

Tests:
- Add unit tests for grow_schema Pass 1 scoping, orchestrator step forcing, the back-fill selector, CLI validation of the new flag, and an end-to-end grow-schema flow using a stub LLM adapter.