### PR TITLE
feat: auto-preprocess new non-MD files in append mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
   - [Locked Base Schema](#locked-base-schema---base-schema)
   - [SKOS Thesaurus](#skos-thesaurus---thesaurus)
   - [Website / Repo Fetching](#website--repo-fetching-mykg-fetch-web)
+  - [Standalone Document Conversion](#standalone-document-conversion-mykg-parse-docs)
   - [Append Mode](#append-mode)
     - [Incremental Schema Growth](#incremental-schema-growth---append-with-grow-schema)
   - [Merging Sessions](#merging-sessions)
@@ -567,6 +568,28 @@ All knobs live under `fetch:` in `mykg_config.yaml` — see [docs/architecture.m
 
 All work: the skill picks the right `fetch-web` invocation (single page, GitHub clone, or `--url-list` batch with an auto-generated temp file for inline URLs), runs it, and — for the "and extract" intents — chains straight into `extract-graph` on the fetched output (one fresh session per seed for multi-seed fetches), confirming with you before the LLM-bearing extraction step.
 
+### Standalone Document Conversion (`mykg parse-docs`)
+
+`extract-graph` already converts non-Markdown inputs (PDF, DOCX, images, …) to Markdown automatically via the `preprocess` step — on both the initial run and on `--append`. You only need `parse-docs` when you want to convert documents **on their own**, without running a pipeline or creating a session: inspecting MinerU output, building a Markdown corpus to commit, or feeding another tool.
+
+```bash
+# Convert a single file
+mykg parse-docs --input report.pdf --output ./md/
+
+# Convert every non-.md file under a directory (recursive; structure preserved)
+mykg parse-docs --input raw_docs/ --output ./md/
+
+# Convert only specific files (relative to --input; repeatable)
+mykg parse-docs --input raw_docs/ --output ./md/ --file a.pdf --file sub/b.docx
+```
+
+- **MinerU in an ephemeral venv** — conversion runs MinerU inside a throwaway `uv`-managed venv that is built per invocation and deleted on exit; nothing is installed into mykg's own interpreter. The multi-GB install is paid once per call and reused across every file in that call.
+- **Extension allowlist** — candidate files are filtered through `preprocess.extensions` from `mykg_config.yaml` (the same allowlist `extract-graph` uses). `.html`/`.htm` are always hard-skipped (MinerU cannot convert HTML — use `extract-graph`, which routes HTML through `markdownify`). Pass `--no-filter` to send every non-`.md` file to MinerU regardless of suffix.
+- **Large corpora** — use `--file-list <path>` (one rel-path per line) instead of repeated `--file` flags to avoid the OS argv-size limit. `--file` and `--file-list` are mutually exclusive.
+- **No session** — `parse-docs` is a pure file-to-file utility: it does not create a session or touch `mykg_sessions/`. Per-file failures are logged and the run continues, exiting non-zero at the end if any file failed.
+
+Run `mykg parse-docs --help` for the complete flag list. **From Claude Code**, `/mykg convert pdfs in ./inbox to ./md` maps to the right invocation automatically.
+
 ### Append Mode
 
 Re-run the pipeline on new or modified files without re-running Pass 1:
@@ -574,6 +597,8 @@ Re-run the pipeline on new or modified files without re-running Pass 1:
 ```bash
 mykg extract-graph my_notes/ --session <name> --append
 ```
+
+The input directory may contain PDF, DOCX, HTML, TXT, and image files alongside `.md` — newly-added non-Markdown files are converted automatically during the append run (the same incremental `preprocess` step the initial run uses, subject to `preprocess.enabled`). No separate `mykg parse-docs` step is needed. Only new or changed source files are converted; unchanged ones are skipped by content hash.
 
 #### Incremental Schema Growth (`--append-with-grow-schema`)
 
@@ -587,14 +612,7 @@ This runs a **locked Pass 1** over only the changed files: the LLM may add new c
 
 The flag implies `--append` (no need to pass both) and is mutually exclusive with `--from-step` and `--base-schema` (the session's existing `schema.ttl` is auto-loaded as the locked base).
 
-> **Note:** Append mode currently only supports adding or updating `.md` files. Mixed-format inputs (PDF, DOCX, HTML, etc. — i.e. anything requiring the `preprocess` step) are not yet supported on the `--append` code path. As a workaround, convert non-Markdown files to Markdown manually with `mykg parse-docs` first, then point `--append` at the converted output:
->
-> ```bash
-> mykg parse-docs --input raw_docs/ --output my_notes/
-> mykg extract-graph my_notes/ --session <name> --append
-> ```
->
-> `parse-docs` recurses subdirectories and preserves their structure at the output; per-file failures (e.g. an unsupported format in the input tree) are logged and the run continues, exiting non-zero at the end if any file failed.
+> **Mixed-format inputs:** Both `--append` and `--append-with-grow-schema` automatically preprocess newly-added non-Markdown files (PDF, DOCX, HTML, TXT, images). Just drop the new files into the input directory and append — the `preprocess` step runs incrementally, converting only the new or changed sources (unchanged files are skipped by content hash) and feeding the converted Markdown straight into extraction. No separate `mykg parse-docs` step is required.
 
 ### Merging Sessions
 

--- a/src/mykg/orchestrator.py
+++ b/src/mykg/orchestrator.py
@@ -306,12 +306,17 @@ def run(steps: list[Step], ctx: PipelineContext) -> None:
                 log.info("SKIP %s — append mode", step.name)
                 continue
 
-            # In append mode, ingest must always run (detect new files) and pass2
+            # In append mode, preprocess and ingest must always run, and pass2
             # must always run when new files exist (raw_extractions.json is preserved
             # for merge but still needs updating — _is_done would skip it otherwise).
+            # preprocess is force-run so its own SHA-based change detection (D49) can
+            # convert newly-added non-MD files; _is_done would otherwise skip it because
+            # the preprocess.done sentinel survives from the initial run. The step is a
+            # cheap no-op when no source files changed (and when preprocess is disabled).
             # In --append-with-grow-schema mode, pass1 must also be force-run so a
             # stale schema.json doesn't cause _is_done to skip the locked re-induction.
             _append_force = ctx.append and step.name in (
+                "preprocess",
                 "ingest",
                 *(("pass1", "schema_validate", "schema_flatten") if ctx.grow_schema else ()),
                 *(("pass2",) if ctx.append_new_files else ()),

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -9,14 +9,17 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
 from mykg.cli import cli
 from mykg.orchestrator import PipelineContext, Step, run
-from mykg.steps.step_ingest import _load_manifest, _sha256, run_ingest
+from mykg.steps.step_ingest import _load_manifest, _run_append_ingest, _sha256, run_ingest
+from mykg.steps.step_preprocess import run_preprocess
 
 # ---------------------------------------------------------------------------
 # 1. SHA256 helper
@@ -318,6 +321,197 @@ def test_orchestrator_grow_schema_forces_pass1_and_schema_steps(tmp_path):
     assert "schema_flatten" in executed, "schema_flatten must be force-run in grow_schema mode"
     assert "human_review" not in executed, "human_review stays skipped without --review"
     assert "pass2" in executed
+
+
+# ---------------------------------------------------------------------------
+# 6b. Orchestrator: preprocess force-run in append mode (non-MD support)
+# ---------------------------------------------------------------------------
+
+
+def _preprocess_force_steps(executed: list) -> list[Step]:
+    """Build a minimal step list whose preprocess step records execution.
+
+    The preprocess output (preprocess.done) is pre-created by the caller so that
+    _is_done would normally skip it — the test proves _append_force overrides that.
+    """
+
+    def preprocess_fn(c):
+        executed.append("preprocess")
+
+    def ingest_fn(c):
+        executed.append("ingest")
+        c.append_new_files = set()  # no downstream work needed for this assertion
+
+    return [
+        Step(name="preprocess", fn=preprocess_fn, outputs=["preprocess.done"]),
+        Step(name="ingest", fn=ingest_fn, outputs=["file_manifest.json"]),
+    ]
+
+
+def test_orchestrator_append_forces_preprocess_despite_sentinel(tmp_path):
+    """In plain --append mode preprocess must RUN again even though preprocess.done
+    already exists (so its SHA-based change detection can convert new non-MD files)."""
+    ctx = _make_ctx(tmp_path, append=True)
+
+    # Required by the append pre-check in run(), plus the preprocess + ingest
+    # outputs so _is_done returns True for them.
+    (ctx.intermediate_dir / "schema.json").write_text("{}")
+    (ctx.intermediate_dir / "preprocess.done").write_text("done")
+    (ctx.intermediate_dir / "file_manifest.json").write_text("{}")
+
+    executed: list = []
+    run(_preprocess_force_steps(executed), ctx)
+
+    assert "preprocess" in executed, (
+        "preprocess must be force-run in append mode despite the surviving sentinel"
+    )
+
+
+def test_orchestrator_grow_schema_forces_preprocess_despite_sentinel(tmp_path):
+    """--append-with-grow-schema must also force-run preprocess (it implies --append,
+    and _append_force keys off ctx.append, so the same fix covers both flavors)."""
+    ctx = _make_ctx(tmp_path, append=True)
+    ctx.grow_schema = True
+
+    (ctx.intermediate_dir / "schema.json").write_text("{}")
+    (ctx.intermediate_dir / "preprocess.done").write_text("done")
+    (ctx.intermediate_dir / "file_manifest.json").write_text("{}")
+
+    executed: list = []
+    run(_preprocess_force_steps(executed), ctx)
+
+    assert "preprocess" in executed, (
+        "preprocess must be force-run in --append-with-grow-schema mode too"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6c. Real delta flow through run_preprocess (HTML/TXT — no MinerU, no LLM)
+# ---------------------------------------------------------------------------
+
+
+def _preprocess_ctx(tmp_path: Path) -> PipelineContext:
+    input_dir = tmp_path / "input"
+    intermediate_dir = tmp_path / "intermediate"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    intermediate_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return PipelineContext(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        intermediate_dir=intermediate_dir,
+        adapter=None,
+    )
+
+
+def _preprocess_subdir(ctx: PipelineContext) -> Path:
+    import mykg.config as _cfg
+
+    return ctx.input_dir / _cfg.PREPROCESS_SUBDIR if _cfg.PREPROCESS_SUBDIR else ctx.input_dir
+
+
+def test_append_delta_converts_new_non_md_file(tmp_path):
+    """Two-stage delta: an initial non-MD file is converted, then a NEW one is added
+    and only that new file is converted on re-run (the first is reused by SHA).
+
+    Uses .txt input so the whole flow runs in-process (shutil.copy2) — no MinerU
+    subprocess, no LLM. This is the real append delta the orchestrator fix enables.
+    """
+    ctx = _preprocess_ctx(tmp_path)
+    (ctx.input_dir / "first.txt").write_text("first document content")
+
+    with patch("mykg.config.PREPROCESS_ENABLED", True):
+        # Stage 1 — initial conversion.
+        run_preprocess(ctx)
+
+        sub = _preprocess_subdir(ctx)
+        assert (sub / "first.md").exists()
+        manifest = json.loads((ctx.intermediate_dir / "preprocess_manifest.json").read_text())
+        assert "first.txt" in manifest["source_files"]
+        first_sha = manifest["source_files"]["first.txt"]["sha256"]
+
+        # Stage 2 — drop a NEW file and re-run (sentinel + manifest now exist,
+        # mirroring an --append re-entry where preprocess is force-run).
+        (ctx.input_dir / "second.txt").write_text("second document content")
+        run_preprocess(ctx)
+
+    manifest2 = json.loads((ctx.intermediate_dir / "preprocess_manifest.json").read_text())
+    # Both sources are now recorded.
+    assert "first.txt" in manifest2["source_files"]
+    assert "second.txt" in manifest2["source_files"]
+    # The new file's markdown exists.
+    assert (sub / "second.md").exists()
+    # The first file was NOT re-converted — its SHA entry is unchanged and exactly
+    # one file was skipped as unchanged.
+    assert manifest2["source_files"]["first.txt"]["sha256"] == first_sha
+    assert manifest2["unchanged_count"] == 1
+
+
+def test_append_delta_ingest_picks_up_preprocessed_md(tmp_path):
+    """The preprocess→ingest handoff: a freshly-converted .md under _preprocessed/
+    is discovered by _run_append_ingest and lands in ctx.append_new_files."""
+    ctx = _preprocess_ctx(tmp_path)
+    ctx.append = True
+    (ctx.input_dir / "note.txt").write_text("some note content")
+
+    with patch("mykg.config.PREPROCESS_ENABLED", True):
+        run_preprocess(ctx)
+
+    # An existing manifest with no entries simulates a prior session that had no
+    # markdown from this source yet; the converted note.md must be detected as new.
+    (ctx.intermediate_dir / "file_manifest.json").write_text("{}")
+    _run_append_ingest(ctx)
+
+    sub_name = _preprocess_subdir(ctx).name
+    matches = [f for f in ctx.append_new_files if f.endswith("note.md")]
+    assert matches, (
+        f"ingest must discover the converted .md under {sub_name}/; "
+        f"append_new_files={ctx.append_new_files}"
+    )
+
+
+@pytest.mark.live
+def test_append_delta_real_mineru_pdf(tmp_path):
+    """Real MinerU PDF→MD through the append delta (gated by -m live; not in default run).
+
+    Exercises the actual ephemeral-venv MinerU path — no mocking. Stops at the
+    preprocess/manifest layer, so no LLM/API key is needed (MinerU is LLM-free).
+    """
+    if shutil.which("uv") is None:
+        pytest.skip("uv not available for the ephemeral MinerU venv")
+
+    pdf_src = (
+        Path(__file__).resolve().parents[1]
+        / "_input_files3"
+        / "ODNI-UAP-D001, USPER NARRATIVE, SENIOR USIC OFFICIAL.pdf"
+    )
+    if not pdf_src.exists():
+        pytest.skip(f"PDF fixture not found at {pdf_src}")
+
+    ctx = _preprocess_ctx(tmp_path)
+    shutil.copy2(pdf_src, ctx.input_dir / "doc.pdf")
+
+    with patch("mykg.config.PREPROCESS_ENABLED", True):
+        # Stage 1 — real MinerU conversion of the PDF.
+        run_preprocess(ctx)
+        sub = _preprocess_subdir(ctx)
+        converted = sub / "doc.md"
+        assert converted.exists(), "MinerU must produce doc.md under the preprocess subdir"
+        assert converted.read_text().strip(), "converted markdown must be non-empty"
+
+        manifest = json.loads((ctx.intermediate_dir / "preprocess_manifest.json").read_text())
+        pdf_sha = manifest["source_files"]["doc.pdf"]["sha256"]
+
+        # Stage 2 — add a cheap .txt file and re-run; the PDF must be reused by SHA
+        # (not re-converted), proving the incremental delta works across formats.
+        (ctx.input_dir / "extra.txt").write_text("extra note")
+        run_preprocess(ctx)
+
+    manifest2 = json.loads((ctx.intermediate_dir / "preprocess_manifest.json").read_text())
+    assert manifest2["source_files"]["doc.pdf"]["sha256"] == pdf_sha
+    assert "extra.txt" in manifest2["source_files"]
+    assert manifest2["unchanged_count"] >= 1, "the already-converted PDF must be skipped on re-run"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Append mode (`--append` and `--append --grow-schema`) now converts newly-added PDF / DOCX / HTML / TXT / image files to Markdown automatically, collapsing the previous two-command workaround (`parse-docs` then `extract-graph --append`) into a single `extract-graph` invocation.

The fix adds `preprocess` to the orchestrator's `_append_force` set so the step runs despite the surviving `preprocess.done` sentinel. The step's own SHA-based change detection (D49) converts only new/changed sources and is a no-op when nothing changed or preprocess is disabled — keeping append cost ~O(new files).

## Changes

- **`src/mykg/orchestrator.py`** — force-run `preprocess` in append mode (both `--append` and `--append --grow-schema`).
- **`tests/test_append.py`** — orchestrator force-run coverage for both append flavors; hermetic TXT convert-only-new + `preprocess`→`ingest` handoff test; live MinerU PDF delta test (`-m live`, passed in 101s on a real PDF).
- **`README.md`** — removed the stale limitation note, documented mixed-format append support, added a standalone `parse-docs` subsection.

## Test plan

- [x] Orchestrator force-run tests pass for both append flavors
- [x] Hermetic TXT delta + handoff test passes
- [x] Live MinerU PDF delta test passes (`-m live`, 101s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable automatic preprocessing of newly added non-Markdown files during append-mode runs and document the updated append and parse-docs behavior.

Bug Fixes:
- Ensure the preprocess step is force-run in append and append-with-grow-schema modes even when its sentinel file exists, allowing SHA-based detection to convert new non-Markdown inputs without reprocessing unchanged files.

Enhancements:
- Add tests covering append-mode preprocessing, incremental non-Markdown conversion, preprocess-to-ingest handoff, and live MinerU PDF delta flows.
- Update documentation to describe standalone document conversion via mykg parse-docs and clarify that append modes now support mixed-format inputs with incremental preprocessing.