### PR TITLE
feat: add --freeze-schema for bring-your-own-schema extraction

### DIFF
--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -566,6 +566,11 @@ def _print_next_steps(
 )
 @click.option("--verbose", "-v", is_flag=True, help="Enable DEBUG-level logging")
 @click.option("--base-schema", default=None, type=click.Path(exists=True), help="Locked TBox TTL")
+@click.option(
+    "--freeze-schema",
+    is_flag=True,
+    help="Use --base-schema verbatim: skip Pass 1 LLM induction entirely",
+)
 @click.option("--thesaurus", default=None, type=click.Path(exists=True), help="SKOS TTL thesaurus")
 @click.option("--review", is_flag=True, help="Pause for human schema review after Pass 1")
 @click.option(
@@ -627,6 +632,7 @@ def extract_graph(
     log_file,
     verbose,
     base_schema,
+    freeze_schema,
     thesaurus,
     review,
     from_step,
@@ -646,6 +652,20 @@ def extract_graph(
 
     if grow_schema:
         append = True
+
+    if freeze_schema:
+        if not base_schema:
+            raise click.ClickException(
+                "--freeze-schema requires --base-schema <path-to-ttl>"
+            )
+        if grow_schema:
+            raise click.ClickException(
+                "--freeze-schema and --append-with-grow-schema are mutually exclusive."
+            )
+        if append:
+            raise click.ClickException(
+                "--freeze-schema and --append are mutually exclusive."
+            )
 
     original_input_dir = str(input_dir.resolve())
     sessions_root = _sessions_root()
@@ -772,6 +792,7 @@ def extract_graph(
         confidence_agg=confidence_agg,
         append=append,
         grow_schema=grow_schema,
+        freeze_schema=freeze_schema,
         orphan_incremental=orphan_incremental,
     )
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/src/mykg/orchestrator.py
+++ b/src/mykg/orchestrator.py
@@ -59,6 +59,8 @@ class PipelineContext(BaseModel):
     # the LLM may ADD new concepts/properties to the existing (locked) schema, then
     # surgically back-fill old files when the schema actually grows.
     grow_schema: bool = False
+    # --freeze-schema: use base_schema verbatim — skip LLM schema induction entirely.
+    freeze_schema: bool = False
     # Runtime fields populated by steps
     all_chunks: list | None = None
     file_contents: dict[str, str] | None = None

--- a/src/mykg/schema_history.py
+++ b/src/mykg/schema_history.py
@@ -43,6 +43,7 @@ TRIGGER_SCHEMA_GAP = "schema_gap"
 TRIGGER_SCHEMA_GAP_CORRECT = "schema_gap_correct"
 TRIGGER_SCHEMA_QUALITY = "schema_quality"
 TRIGGER_SESSION_MERGE = "session_merge"
+TRIGGER_FREEZE_SCHEMA = "freeze_schema"
 
 
 def write_schema(

--- a/src/mykg/steps/step_pass1.py
+++ b/src/mykg/steps/step_pass1.py
@@ -15,6 +15,26 @@ log = get("mykg.steps.pass1")
 
 
 def run_pass1_step(ctx: PipelineContext) -> None:
+    if ctx.freeze_schema:
+        locked_classes = ctx.base_schema.get("locked_classes", {}) if ctx.base_schema else {}
+        locked_properties = ctx.base_schema.get("locked_properties", {}) if ctx.base_schema else {}
+        schema, _ = merge_proposals([], locked_classes, locked_properties, ctx.thesaurus)
+        n_concepts = len(schema.get("concepts", []))
+        n_props = len(schema.get("properties", []))
+        log.info(
+            "Step 2 — freeze-schema: using base schema verbatim (%d concept(s), %d property(ies))",
+            n_concepts,
+            n_props,
+        )
+        from mykg.schema_history import TRIGGER_FREEZE_SCHEMA, write_schema
+
+        write_schema(schema, ctx.intermediate_dir, TRIGGER_FREEZE_SCHEMA)
+        ttl = export_ttl(schema, [], {})
+        (ctx.intermediate_dir / "schema.ttl").write_text(ttl)
+        merge_log_path = ctx.intermediate_dir / "merge_log.json"
+        merge_log_path.write_text(json.dumps([], indent=_cfg.JSON_INDENT))
+        return
+
     # --append-with-grow-schema (D52): run the locked re-induction over ONLY the changed
     # files so the LLM sees just the new material when proposing additions. The append
     # ingest step does not chunk (it only hashes), so all_chunks must be (re)built here

--- a/src/mykg/steps/step_pass1.py
+++ b/src/mykg/steps/step_pass1.py
@@ -16,8 +16,13 @@ log = get("mykg.steps.pass1")
 
 def run_pass1_step(ctx: PipelineContext) -> None:
     if ctx.freeze_schema:
-        locked_classes = ctx.base_schema.get("locked_classes", {}) if ctx.base_schema else {}
-        locked_properties = ctx.base_schema.get("locked_properties", {}) if ctx.base_schema else {}
+        if not ctx.base_schema:
+            raise RuntimeError(
+                "freeze_schema is set but no base_schema was provided. "
+                "Pass --base-schema <path-to-ttl> on the CLI, or set base_schema on PipelineContext."
+            )
+        locked_classes = ctx.base_schema.get("locked_classes", {})
+        locked_properties = ctx.base_schema.get("locked_properties", {})
         schema, _ = merge_proposals([], locked_classes, locked_properties, ctx.thesaurus)
         n_concepts = len(schema.get("concepts", []))
         n_props = len(schema.get("properties", []))

--- a/tests/test_cli_freeze_schema.py
+++ b/tests/test_cli_freeze_schema.py
@@ -1,0 +1,143 @@
+"""CLI validation tests for --freeze-schema.
+
+These exercise the early validation gates and the pass1 short-circuit.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import json
+import pytest
+from click.testing import CliRunner
+
+from mykg.cli import cli
+
+
+def test_freeze_schema_help_lists_flag():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["extract-graph", "--help"])
+    assert result.exit_code == 0
+    assert "--freeze-schema" in result.output
+
+
+def test_freeze_schema_requires_base_schema(tmp_path):
+    runner = CliRunner()
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    result = runner.invoke(
+        cli,
+        ["extract-graph", str(input_dir), "--freeze-schema"],
+        catch_exceptions=True,
+    )
+    assert result.exit_code != 0
+    assert "--base-schema" in result.output
+
+
+def test_freeze_schema_excludes_append(tmp_path):
+    runner = CliRunner()
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    base_ttl = tmp_path / "base.ttl"
+    base_ttl.write_text("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n")
+    result = runner.invoke(
+        cli,
+        [
+            "extract-graph",
+            str(input_dir),
+            "--freeze-schema",
+            "--base-schema",
+            str(base_ttl),
+            "--append",
+        ],
+        catch_exceptions=True,
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()
+
+
+def test_freeze_schema_excludes_grow_schema(tmp_path):
+    runner = CliRunner()
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    base_ttl = tmp_path / "base.ttl"
+    base_ttl.write_text("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n")
+    result = runner.invoke(
+        cli,
+        [
+            "extract-graph",
+            str(input_dir),
+            "--freeze-schema",
+            "--base-schema",
+            str(base_ttl),
+            "--append-with-grow-schema",
+        ],
+        catch_exceptions=True,
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()
+
+
+def test_freeze_schema_pass1_skips_llm(tmp_path):
+    """run_pass1_step with freeze_schema=True writes schema.json/schema.ttl
+    from the base schema without making any LLM calls."""
+    from mykg.orchestrator import PipelineContext
+
+    intermediate = tmp_path / "intermediate"
+    intermediate.mkdir()
+    (intermediate / "schema_history").mkdir()
+
+    adapter = MagicMock()
+
+    ctx = PipelineContext(
+        input_dir=tmp_path / "input",
+        output_dir=tmp_path / "output",
+        intermediate_dir=intermediate,
+        adapter=adapter,
+        base_schema={
+            "locked_classes": {
+                "Person": {"type": "Person", "parent": None, "attributes": ["name", "email"]},
+                "Organization": {
+                    "type": "Organization",
+                    "parent": None,
+                    "attributes": ["name"],
+                },
+            },
+            "locked_properties": {
+                "works_at": {
+                    "name": "works_at",
+                    "domain": "Person",
+                    "range": "Organization",
+                    "attributes": ["role"],
+                },
+            },
+        },
+        freeze_schema=True,
+    )
+
+    from mykg.steps.step_pass1 import run_pass1_step
+
+    run_pass1_step(ctx)
+
+    schema = json.loads((intermediate / "schema.json").read_text())
+    assert len(schema["concepts"]) == 2
+    assert len(schema["properties"]) == 1
+
+    concept_types = {c["type"] for c in schema["concepts"]}
+    assert concept_types == {"Person", "Organization"}
+
+    prop_names = {p["name"] for p in schema["properties"]}
+    assert prop_names == {"works_at"}
+
+    assert (intermediate / "schema.ttl").exists()
+    ttl = (intermediate / "schema.ttl").read_text()
+    assert "Person" in ttl
+    assert "works_at" in ttl
+
+    merge_log = json.loads((intermediate / "merge_log.json").read_text())
+    assert merge_log == []
+
+    adapter.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest.main([str(Path(__file__))])

--- a/tests/test_cli_freeze_schema.py
+++ b/tests/test_cli_freeze_schema.py
@@ -139,5 +139,54 @@ def test_freeze_schema_pass1_skips_llm(tmp_path):
     adapter.assert_not_called()
 
 
+def test_freeze_schema_pass1_empty_base_schema(tmp_path):
+    """freeze_schema with a base_schema that has no locked_classes/locked_properties
+    produces a valid but empty schema."""
+    from mykg.orchestrator import PipelineContext
+
+    intermediate = tmp_path / "intermediate"
+    intermediate.mkdir()
+    (intermediate / "schema_history").mkdir()
+
+    adapter = MagicMock()
+    ctx = PipelineContext(
+        input_dir=tmp_path / "input",
+        output_dir=tmp_path / "output",
+        intermediate_dir=intermediate,
+        adapter=adapter,
+        base_schema={"locked_classes": {}, "locked_properties": {}},
+        freeze_schema=True,
+    )
+
+    from mykg.steps.step_pass1 import run_pass1_step
+
+    run_pass1_step(ctx)
+
+    schema = json.loads((intermediate / "schema.json").read_text())
+    assert schema["concepts"] == []
+    assert schema["properties"] == []
+    assert (intermediate / "schema.ttl").exists()
+    assert json.loads((intermediate / "merge_log.json").read_text()) == []
+    adapter.assert_not_called()
+
+
+def test_freeze_schema_pass1_errors_without_base_schema(tmp_path):
+    """freeze_schema=True without base_schema raises RuntimeError."""
+    from mykg.orchestrator import PipelineContext
+
+    ctx = PipelineContext(
+        input_dir=tmp_path / "input",
+        output_dir=tmp_path / "output",
+        intermediate_dir=tmp_path / "intermediate",
+        adapter=MagicMock(),
+        freeze_schema=True,
+    )
+
+    from mykg.steps.step_pass1 import run_pass1_step
+
+    with pytest.raises(RuntimeError, match="freeze_schema.*no base_schema"):
+        run_pass1_step(ctx)
+
+
 if __name__ == "__main__":
     pytest.main([str(Path(__file__))])


### PR DESCRIPTION
## Summary

- Adds `--freeze-schema` flag to `mykg extract-graph` that skips Pass 1 LLM induction entirely and uses the `--base-schema` TTL verbatim
- Pass 1 short-circuits via `merge_proposals([], locked_classes, locked_properties)` — no new conversion code needed
- Schema validation (`schema_validate`) and human review (`--review`) still run normally
- Mutually exclusive with `--append` and `--append-with-grow-schema`

## Files changed

- `src/mykg/cli.py` — new `--freeze-schema` click option + validation gates
- `src/mykg/orchestrator.py` — `freeze_schema: bool` field on `PipelineContext`
- `src/mykg/schema_history.py` — `TRIGGER_FREEZE_SCHEMA` constant for audit trail
- `src/mykg/steps/step_pass1.py` — early return branch when `ctx.freeze_schema` is set
- `tests/test_cli_freeze_schema.py` — 5 tests (CLI validation + pass1 unit test)

## Test plan

- [x] All 5 new tests pass (`pytest tests/test_cli_freeze_schema.py`)
- [x] Full test suite passes (1180 tests, 0 failures)
- [ ] Manual: `mykg extract-graph <dir> --base-schema my.ttl --freeze-schema --session test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a CLI option to freeze schema induction and use the provided base schema verbatim during graph extraction.

New Features:
- Introduce a --freeze-schema flag for mykg extract-graph to bypass Pass 1 LLM schema induction and rely solely on the supplied base schema.

Enhancements:
- Extend PipelineContext and Pass 1 orchestration to support a freeze-schema mode that writes schema artifacts and merge logs without invoking the LLM.
- Add an audit trail trigger for freeze-schema runs in schema history.

Tests:
- Add CLI and pass1 tests verifying flag visibility, argument validation, mutual exclusivity with append modes, and that freeze-schema runs produce schema outputs without LLM calls.