### PR TITLE
fix: streaming I/O for JSONL reads

### DIFF
--- a/src/mykg/exporters/neo4j/_common.py
+++ b/src/mykg/exporters/neo4j/_common.py
@@ -23,8 +23,10 @@ def load_session(session_root: Path) -> tuple[list[dict], list[dict], dict]:
     if not schema_path.exists():
         raise FileNotFoundError(f"schema.json not found at {schema_path}")
 
-    nodes = [json.loads(line) for line in nodes_path.read_text().splitlines() if line.strip()]
-    edges = [json.loads(line) for line in edges_path.read_text().splitlines() if line.strip()]
+    with open(nodes_path, encoding="utf-8") as f:
+        nodes = [json.loads(line) for line in f if line.strip()]
+    with open(edges_path, encoding="utf-8") as f:
+        edges = [json.loads(line) for line in f if line.strip()]
     schema = json.loads(schema_path.read_text())
     return nodes, edges, schema
 

--- a/src/mykg/exporters/neo4j/_common.py
+++ b/src/mykg/exporters/neo4j/_common.py
@@ -23,9 +23,9 @@ def load_session(session_root: Path) -> tuple[list[dict], list[dict], dict]:
     if not schema_path.exists():
         raise FileNotFoundError(f"schema.json not found at {schema_path}")
 
-    with open(nodes_path, encoding="utf-8") as f:
+    with nodes_path.open(encoding="utf-8") as f:
         nodes = [json.loads(line) for line in f if line.strip()]
-    with open(edges_path, encoding="utf-8") as f:
+    with edges_path.open(encoding="utf-8") as f:
         edges = [json.loads(line) for line in f if line.strip()]
     schema = json.loads(schema_path.read_text())
     return nodes, edges, schema

--- a/src/mykg/mcp_server.py
+++ b/src/mykg/mcp_server.py
@@ -460,10 +460,13 @@ async def mykg_get_stats(ctx: Context) -> str:
         log_path = session_root / "run.log"
         try:
             if log_path.exists():
-                for line in log_path.read_text(encoding="utf-8").splitlines()[:5]:
-                    if "extract-graph " in line:
-                        original_input_dir = line.split("extract-graph ", 1)[1].split(" --")[0].strip()
-                        break
+                with log_path.open(encoding="utf-8") as f:
+                    for i, line in enumerate(f):
+                        if i >= 5:
+                            break
+                        if "extract-graph " in line:
+                            original_input_dir = line.split("extract-graph ", 1)[1].split(" --")[0].strip()
+                            break
         except OSError:
             pass
 
@@ -765,10 +768,10 @@ async def mykg_list_sessions(ctx: Context) -> str:
         node_count = 0
         edge_count = 0
         if nodes_path.exists():
-            with open(nodes_path, encoding="utf-8") as f:
+            with nodes_path.open(encoding="utf-8") as f:
                 node_count = sum(1 for line in f if line.strip())
         if edges_path.exists():
-            with open(edges_path, encoding="utf-8") as f:
+            with edges_path.open(encoding="utf-8") as f:
                 edge_count = sum(1 for line in f if line.strip())
 
         sessions.append({

--- a/src/mykg/walkthrough.py
+++ b/src/mykg/walkthrough.py
@@ -32,17 +32,18 @@ def _parse_log_lines(log_path: Path) -> list[dict]:
     if not log_path.exists():
         return []
     results: list[dict] = []
-    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
-        m = _TS_RE.match(line.strip())
-        if m:
-            results.append(
-                {
-                    "ts": m.group(1),
-                    "level": m.group(2),
-                    "logger": m.group(3),
-                    "message": m.group(4),
-                }
-            )
+    with log_path.open(encoding="utf-8", errors="replace") as f:
+        for line in f:
+            m = _TS_RE.match(line.strip())
+            if m:
+                results.append(
+                    {
+                        "ts": m.group(1),
+                        "level": m.group(2),
+                        "logger": m.group(3),
+                        "message": m.group(4),
+                    }
+                )
     return results
 
 
@@ -304,13 +305,14 @@ def _section_llm_stats(session_root: Path) -> str:
         return "\n".join(out)
 
     records: list[dict] = []
-    for line in llm_log.read_text(encoding="utf-8", errors="replace").splitlines():
-        line = line.strip()
-        if line:
-            try:
-                records.append(json.loads(line))
-            except Exception:
-                continue
+    with llm_log.open(encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    records.append(json.loads(line))
+                except Exception:
+                    continue
 
     if not records:
         out.append("\n*No LLM calls recorded.*")
@@ -633,13 +635,14 @@ def _section_node_edge_trace(session_root: Path) -> str | None:
     llm_log = session_root / "llm.log"
     reextract_calls = 0
     if llm_log.exists():
-        for line in llm_log.read_text(encoding="utf-8", errors="replace").splitlines():
-            try:
-                rec = json.loads(line)
-                if re.search(r"pass2|reextract", rec.get("context", ""), re.I):
-                    reextract_calls += 1
-            except Exception:
-                continue
+        with llm_log.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    rec = json.loads(line)
+                    if re.search(r"pass2|reextract", rec.get("context", ""), re.I):
+                        reextract_calls += 1
+                except Exception:
+                    continue
 
     # Merged schema
     merged_schema = _load_json(session_root / "intermediate" / "schema.json") or {}

--- a/src/mykg/walkthrough.py
+++ b/src/mykg/walkthrough.py
@@ -705,10 +705,10 @@ def _section_node_edge_trace(session_root: Path) -> str | None:
     nodes_jsonl = output_dir / "nodes.jsonl"
     edges_jsonl = output_dir / "edges.jsonl"
     if nodes_jsonl.exists():
-        with open(nodes_jsonl, encoding="utf-8") as f:
+        with nodes_jsonl.open(encoding="utf-8") as f:
             nodes_jsonl_count = sum(1 for ln in f if ln.strip())
     if edges_jsonl.exists():
-        with open(edges_jsonl, encoding="utf-8") as f:
+        with edges_jsonl.open(encoding="utf-8") as f:
             edges_jsonl_count = sum(1 for ln in f if ln.strip())
 
     delta_b = manifest.get("schema_delta_session_b") or []

--- a/src/mykg/walkthrough.py
+++ b/src/mykg/walkthrough.py
@@ -705,13 +705,11 @@ def _section_node_edge_trace(session_root: Path) -> str | None:
     nodes_jsonl = output_dir / "nodes.jsonl"
     edges_jsonl = output_dir / "edges.jsonl"
     if nodes_jsonl.exists():
-        nodes_jsonl_count = sum(
-            1 for ln in nodes_jsonl.read_text(encoding="utf-8").splitlines() if ln.strip()
-        )
+        with open(nodes_jsonl, encoding="utf-8") as f:
+            nodes_jsonl_count = sum(1 for ln in f if ln.strip())
     if edges_jsonl.exists():
-        edges_jsonl_count = sum(
-            1 for ln in edges_jsonl.read_text(encoding="utf-8").splitlines() if ln.strip()
-        )
+        with open(edges_jsonl, encoding="utf-8") as f:
+            edges_jsonl_count = sum(1 for ln in f if ln.strip())
 
     delta_b = manifest.get("schema_delta_session_b") or []
     reextract_note = (

--- a/tests/test_walkthrough.py
+++ b/tests/test_walkthrough.py
@@ -734,6 +734,24 @@ def test_node_edge_trace_returns_string_when_valid(tmp_path):
     assert len(result) > 100
 
 
+def test_node_edge_trace_counts_output_jsonl(tmp_path):
+    """Streaming read of nodes.jsonl/edges.jsonl in output/ is exercised."""
+    _, merged, _, _ = _make_merge_sessions(tmp_path)
+    output = merged / "output"
+    output.mkdir(exist_ok=True)
+    output.joinpath("nodes.jsonl").write_text(
+        '{"id":"person-alice","type":"Person"}\n'
+        '{"id":"org-acme","type":"Organization"}\n'
+    )
+    output.joinpath("edges.jsonl").write_text(
+        '{"type":"works_at","from":"person-alice","to":"org-acme"}\n'
+    )
+    result = _section_node_edge_trace(merged)
+    assert result is not None
+    assert "2" in result  # 2 nodes in output
+    assert "1" in result  # 1 edge in output
+
+
 # ---------------------------------------------------------------------------
 # _section_merge_provenance tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace `.read_text().splitlines()` with streaming `with open(...) as f` iteration in `_common.py` (neo4j exporter) and `walkthrough.py` (line counter)
- Aligns with Invariant 19: prefer streaming over whole-file reads for line-oriented data

## Test plan
- [ ] Run `mykg extract-graph` with neo4j CSV export enabled — verify `load_session()` loads nodes/edges correctly
- [ ] Run walkthrough generation on a merge session — verify node/edge counts in the merge provenance section are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prefer streaming iteration over whole-file reads for JSONL node and edge data in walkthrough schema counting and Neo4j exporter session loading.

Enhancements:
- Update walkthrough schema count logic to iterate over JSONL files via file handles instead of loading entire file contents into memory.
- Change Neo4j exporter session loader to stream JSONL nodes and edges from disk when constructing in-memory structures.