### PR TITLE
feat: add mykg_get_source MCP tool for bounded source-text excerpts

### DIFF
--- a/src/mykg/mcp_server.py
+++ b/src/mykg/mcp_server.py
@@ -1,7 +1,7 @@
 """MCP server exposing a mykg knowledge graph session for LLM-powered Q&A.
 
 Loads nodes.jsonl, edges.jsonl, and schema.json from a session, builds an
-in-memory NetworkX DiGraph, and exposes 11 query tools + 2 resources via the
+in-memory NetworkX DiGraph, and exposes 15 query tools + 2 resources via the
 Model Context Protocol.
 """
 from __future__ import annotations
@@ -15,8 +15,10 @@ from pathlib import Path
 
 import networkx as nx
 
+from mykg import config as _cfg
 from mykg.exporters.neo4j._common import load_session
 from mykg.exporter import _build_nx_graph
+from mykg.orphan_connector import build_chunk_texts
 
 # ---------------------------------------------------------------------------
 # KnowledgeGraph — in-memory session data + indexes
@@ -36,14 +38,39 @@ class KnowledgeGraph:
     nodes_by_id: dict[str, dict] = field(default_factory=dict)
     nodes_by_type: dict[str, list[dict]] = field(default_factory=dict)
     edges_by_node: dict[str, list[dict]] = field(default_factory=dict)
+    edges_by_id: dict[str, dict] = field(default_factory=dict)
     name_index: list[tuple[str, str, str]] = field(default_factory=list)
     alias_index: dict[str, str] = field(default_factory=dict)
+
+    file_manifest: dict | None = field(default=None)
+    raw_chunk_node_index: dict | None = field(default=None)
+    chunk_node_index_by_id: dict[str, list[str]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         self.nodes, self.edges, self.schema = load_session(self.session_root)
         edge_metadata = {e["id"]: e for e in self.edges}
         self.graph = _build_nx_graph(self.nodes, edge_metadata)
+        self._load_chunk_artifacts()
         self._build_indexes()
+
+    def _load_chunk_artifacts(self) -> None:
+        intermediate = self.session_root / "intermediate"
+
+        self.file_manifest = None
+        manifest_path = intermediate / "file_manifest.json"
+        try:
+            if manifest_path.exists():
+                self.file_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+
+        self.raw_chunk_node_index = None
+        index_path = intermediate / "chunk_node_index.json"
+        try:
+            if index_path.exists():
+                self.raw_chunk_node_index = json.loads(index_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
 
     def _build_indexes(self) -> None:
         for node in self.nodes:
@@ -62,8 +89,16 @@ class KnowledgeGraph:
                 self.name_index.append((alias.lower(), nid, alias))
 
         for edge in self.edges:
+            self.edges_by_id[edge["id"]] = edge
             self.edges_by_node.setdefault(edge["from"], []).append(edge)
             self.edges_by_node.setdefault(edge["to"], []).append(edge)
+
+        if self.raw_chunk_node_index:
+            for filename, chunks in self.raw_chunk_node_index.items():
+                for chunk_idx, ids in chunks.items():
+                    chunk_key = f"{filename}::{chunk_idx}"
+                    for sid in ids:
+                        self.chunk_node_index_by_id.setdefault(sid, []).append(chunk_key)
 
     def reload(self, session_root: Path | None = None) -> None:
         """Re-read session files and rebuild the in-memory graph + indexes."""
@@ -75,8 +110,11 @@ class KnowledgeGraph:
         self.nodes_by_id = {}
         self.nodes_by_type = {}
         self.edges_by_node = {}
+        self.edges_by_id = {}
         self.name_index = []
         self.alias_index = {}
+        self.chunk_node_index_by_id = {}
+        self._load_chunk_artifacts()
         self._build_indexes()
 
     @property
@@ -104,6 +142,69 @@ def _node_summary(node: dict) -> dict:
         "name": _node_name(node),
         "confidence": node.get("confidence", 0.0),
     }
+
+
+def _node_names_for_excerpt(node: dict) -> list[str]:
+    names = [_node_name(node)]
+    names.extend(node.get("aliases") or [])
+    return [n for n in names if n]
+
+
+def _extract_relevant_excerpt(
+    text: str,
+    names: list[str],
+    window: int = _cfg.ORPHAN_EXCERPT_WINDOW,
+    context: int = _cfg.ORPHAN_EXCERPT_CONTEXT,
+    max_total: int = _cfg.ORPHAN_EXCERPT_MAX_TOTAL,
+) -> str:
+    """Return excerpts around ALL mentions of any of the given names in text.
+
+    Local copy of orphan_connector._extract_relevant_excerpt's algorithm —
+    intentionally not imported, so this module has no dependency on the
+    orphan-pass module. Each mention contributes one window. Overlapping
+    windows are merged. Falls back to the first `window` characters if none
+    of the names are found. Total output is capped at max_total characters.
+    """
+    text_lower = text.lower()
+
+    positions: list[int] = []
+    for name in names:
+        name_lower = name.lower()
+        start = 0
+        while True:
+            pos = text_lower.find(name_lower, start)
+            if pos == -1:
+                break
+            positions.append(pos)
+            start = pos + 1
+
+    if not positions:
+        excerpt = text[:window]
+        return excerpt + ("…" if len(text) > window else "")
+
+    positions.sort()
+    spans: list[tuple[int, int]] = []
+    for pos in positions:
+        s = max(0, pos - context)
+        e = min(len(text), s + window)
+        if spans and s <= spans[-1][1]:
+            spans[-1] = (spans[-1][0], max(spans[-1][1], e))
+        else:
+            spans.append((s, e))
+
+    parts: list[str] = []
+    total = 0
+    for s, e in spans:
+        chunk = text[s:e]
+        if total + len(chunk) > max_total:
+            remaining = max_total - total
+            if remaining > 80:
+                parts.append(("…" if s > 0 else "") + chunk[:remaining] + "…")
+            break
+        parts.append(("…" if s > 0 else "") + chunk + ("…" if e < len(text) else ""))
+        total += len(chunk)
+
+    return "\n---\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -666,6 +767,136 @@ async def mykg_orphan_nodes(ctx: Context) -> str:
         "total_nodes": len(kg.nodes),
         "orphans": orphans,
     }, indent=2)
+
+
+def _excerpts_for_chunk_keys(
+    kg: KnowledgeGraph,
+    chunk_keys: list[str],
+    names: list[str],
+    max_chunks: int,
+) -> tuple[int, list[dict]]:
+    """Resolve a list of "filename::chunk_idx" keys to bounded excerpts.
+
+    Returns (total_chunks, excerpts) where excerpts is capped at max_chunks
+    and each entry's text is narrowed to the windows around `names`.
+    """
+    total_chunks = len(chunk_keys)
+    selected = chunk_keys[:max_chunks]
+    chunk_texts = build_chunk_texts(kg.file_manifest)
+
+    excerpts: list[dict] = []
+    for chunk_key in selected:
+        full_text = chunk_texts.get(chunk_key)
+        if full_text is None:
+            continue
+        filename, _, chunk_idx = chunk_key.rpartition("::")
+        excerpt_text = _extract_relevant_excerpt(full_text, names)
+        excerpts.append({
+            "source_file": filename,
+            "chunk_index": int(chunk_idx),
+            "text": excerpt_text,
+        })
+
+    return total_chunks, excerpts
+
+
+def _resolve_node_excerpt(kg: KnowledgeGraph, node_id: str, max_chunks: int) -> dict:
+    node = kg.nodes_by_id.get(node_id)
+    if node is None:
+        return {"error": f"Node '{node_id}' not found. Use mykg_search_nodes to find valid IDs."}
+
+    chunk_keys = kg.chunk_node_index_by_id.get(node_id, [])
+    names = _node_names_for_excerpt(node)
+    total_chunks, excerpts = _excerpts_for_chunk_keys(kg, chunk_keys, names, max_chunks)
+
+    return {
+        "node_id": node_id,
+        "total_chunks": total_chunks,
+        "returned_chunks": len(excerpts),
+        "excerpts": excerpts,
+    }
+
+
+def _resolve_edge_excerpt(kg: KnowledgeGraph, edge_id: str, max_chunks: int) -> dict:
+    edge = kg.edges_by_id.get(edge_id)
+    if edge is None:
+        return {"error": f"Edge '{edge_id}' not found."}
+
+    from_chunks = kg.chunk_node_index_by_id.get(edge["from"], [])
+    to_chunks = kg.chunk_node_index_by_id.get(edge["to"], [])
+    intersection = [ck for ck in from_chunks if ck in set(to_chunks)]
+
+    if intersection:
+        chunk_keys = intersection
+        exact_chunk_overlap = True
+    else:
+        chunk_keys = list(dict.fromkeys(from_chunks + to_chunks))
+        exact_chunk_overlap = False
+
+    names: list[str] = []
+    for nid in (edge["from"], edge["to"]):
+        node = kg.nodes_by_id.get(nid)
+        if node is not None:
+            names.extend(_node_names_for_excerpt(node))
+
+    total_chunks, excerpts = _excerpts_for_chunk_keys(kg, chunk_keys, names, max_chunks)
+
+    return {
+        "edge_id": edge_id,
+        "exact_chunk_overlap": exact_chunk_overlap,
+        "total_chunks": total_chunks,
+        "returned_chunks": len(excerpts),
+        "excerpts": excerpts,
+    }
+
+
+@mcp.tool(
+    name="mykg_get_source",
+    annotations={
+        "title": "Get Source Chunk Excerpts",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def mykg_get_source(
+    ctx: Context,
+    node_id: str | None = None,
+    edge_id: str | None = None,
+    max_chunks: int = 3,
+) -> str:
+    """Get bounded source-text excerpts for a node, an edge, or both.
+
+    Resolves the node's (or edge's endpoints') source chunk(s) via
+    chunk_node_index.json, then narrows each chunk down to the passages
+    actually mentioning the relevant name(s) — not the full ~2000-token
+    chunk. For an edge, chunks where both endpoints co-occur are preferred
+    (exact_chunk_overlap: true); if endpoints never share a chunk, the union
+    of their chunks is used instead (exact_chunk_overlap: false).
+
+    Requires the session's intermediate/chunk_node_index.json and
+    intermediate/file_manifest.json — pass at least one of node_id or
+    edge_id; both may be given to resolve both in one call.
+    """
+    if node_id is None and edge_id is None:
+        return "Error: provide node_id, edge_id, or both."
+
+    kg = _get_kg(ctx)
+    if kg.raw_chunk_node_index is None or kg.file_manifest is None:
+        return (
+            "Error: this session is missing intermediate/chunk_node_index.json "
+            "or intermediate/file_manifest.json — source chunk lookup is unavailable."
+        )
+
+    node_result = _resolve_node_excerpt(kg, node_id, max_chunks) if node_id is not None else None
+    edge_result = _resolve_edge_excerpt(kg, edge_id, max_chunks) if edge_id is not None else None
+
+    if node_id is not None and edge_id is None:
+        return json.dumps(node_result, indent=2)
+    if edge_id is not None and node_id is None:
+        return json.dumps(edge_result, indent=2)
+    return json.dumps({"node": node_result, "edge": edge_result}, indent=2)
 
 
 @mcp.tool(

--- a/src/mykg/mcp_server.py
+++ b/src/mykg/mcp_server.py
@@ -7,6 +7,7 @@ Model Context Protocol.
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -19,6 +20,8 @@ from mykg import config as _cfg
 from mykg.exporters.neo4j._common import load_session
 from mykg.exporter import _build_nx_graph
 from mykg.orphan_connector import build_chunk_texts
+
+_log = logging.getLogger("mykg.mcp_server")
 
 # ---------------------------------------------------------------------------
 # KnowledgeGraph — in-memory session data + indexes
@@ -62,7 +65,7 @@ class KnowledgeGraph:
             if manifest_path.exists():
                 self.file_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
-            pass
+            _log.warning("Failed to load %s — source chunk lookup will be unavailable", manifest_path, exc_info=True)
 
         self.raw_chunk_node_index = None
         index_path = intermediate / "chunk_node_index.json"
@@ -70,7 +73,7 @@ class KnowledgeGraph:
             if index_path.exists():
                 self.raw_chunk_node_index = json.loads(index_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
-            pass
+            _log.warning("Failed to load %s — source chunk lookup will be unavailable", index_path, exc_info=True)
 
     def _build_indexes(self) -> None:
         for node in self.nodes:
@@ -820,11 +823,12 @@ def _resolve_node_excerpt(kg: KnowledgeGraph, node_id: str, max_chunks: int) -> 
 def _resolve_edge_excerpt(kg: KnowledgeGraph, edge_id: str, max_chunks: int) -> dict:
     edge = kg.edges_by_id.get(edge_id)
     if edge is None:
-        return {"error": f"Edge '{edge_id}' not found."}
+        return {"error": f"Edge '{edge_id}' not found. Use mykg_query_graph or mykg_search_nodes to find valid IDs."}
 
     from_chunks = kg.chunk_node_index_by_id.get(edge["from"], [])
     to_chunks = kg.chunk_node_index_by_id.get(edge["to"], [])
-    intersection = [ck for ck in from_chunks if ck in set(to_chunks)]
+    to_set = set(to_chunks)
+    intersection = [ck for ck in from_chunks if ck in to_set]
 
     if intersection:
         chunk_keys = intersection

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,9 +1,11 @@
 """Tests for the mykg MCP server module."""
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -13,6 +15,7 @@ from mykg.mcp_server import (
     _node_summary,
     _resolve_edge_excerpt,
     _resolve_node_excerpt,
+    mykg_get_source,
 )
 
 
@@ -206,6 +209,26 @@ class TestKnowledgeGraphLoading:
         vault = kg.session_root / "output" / "obsidian_vault"
         vault.mkdir(parents=True)
         assert kg.vault_dir == vault
+
+    def test_reload_rebuilds_indexes(self, kg_with_chunks: KnowledgeGraph):
+        kg_with_chunks.reload()
+        assert "person-alice" in kg_with_chunks.nodes_by_id
+        assert "edge-001" in kg_with_chunks.edges_by_id
+        assert "person-alice" in kg_with_chunks.chunk_node_index_by_id
+
+    def test_reload_with_new_session_root(self, kg: KnowledgeGraph, tmp_path: Path):
+        other_root = tmp_path / "other_session"
+        output = other_root / "output"
+        output.mkdir(parents=True)
+        intermediate = other_root / "intermediate"
+        intermediate.mkdir()
+        (output / "nodes.jsonl").write_text("", encoding="utf-8")
+        (output / "edges.jsonl").write_text("", encoding="utf-8")
+        (intermediate / "schema.json").write_text("{}", encoding="utf-8")
+
+        kg.reload(session_root=other_root)
+        assert kg.session_root == other_root
+        assert kg.nodes == []
 
 
 # ---------------------------------------------------------------------------
@@ -415,6 +438,18 @@ class TestSourceChunks:
         assert "error" in result
         assert "nonexistent" in result["error"]
 
+    def test_node_excerpt_skips_chunk_key_missing_from_manifest(
+        self, kg_with_chunks: KnowledgeGraph
+    ):
+        # Points at a chunk index that build_chunk_texts() never produces
+        # (team.md only re-chunks to index "1") — exercises the
+        # full_text is None / continue branch in _excerpts_for_chunk_keys.
+        kg_with_chunks.chunk_node_index_by_id["person-alice"] = ["team.md::99"]
+        result = _resolve_node_excerpt(kg_with_chunks, "person-alice", max_chunks=3)
+        assert result["total_chunks"] == 1
+        assert result["returned_chunks"] == 0
+        assert result["excerpts"] == []
+
     def test_node_excerpt_truncated_by_max_chunks(self, kg_with_chunks: KnowledgeGraph):
         # person-alice only has 1 chunk in the fixture; force a smaller cap
         # to exercise total_chunks vs returned_chunks bookkeeping directly.
@@ -463,3 +498,56 @@ class TestSourceChunks:
             kg = KnowledgeGraph(session_root=session_dir)
         assert kg.raw_chunk_node_index is None
         assert any("chunk_node_index.json" in record.message for record in caplog.records)
+
+    def test_malformed_file_manifest_logged(self, session_dir: Path, caplog):
+        (session_dir / "intermediate" / "file_manifest.json").write_text(
+            "not valid json", encoding="utf-8"
+        )
+        with caplog.at_level(logging.WARNING, logger="mykg.mcp_server"):
+            kg = KnowledgeGraph(session_root=session_dir)
+        assert kg.file_manifest is None
+        assert any("file_manifest.json" in record.message for record in caplog.records)
+
+
+def _fake_ctx(kg: KnowledgeGraph):
+    """Minimal stand-in for FastMCP's Context — _get_kg only reads this path."""
+    return SimpleNamespace(
+        request_context=SimpleNamespace(lifespan_context=SimpleNamespace(kg=kg))
+    )
+
+
+class TestMykgGetSourceTool:
+    """Exercises the mykg_get_source MCP tool function directly (not just its helpers)."""
+
+    def test_node_id_only(self, kg_with_chunks: KnowledgeGraph):
+        result = json.loads(
+            asyncio.run(mykg_get_source(_fake_ctx(kg_with_chunks), node_id="person-alice"))
+        )
+        assert result["node_id"] == "person-alice"
+        assert "error" not in result
+
+    def test_edge_id_only(self, kg_with_chunks: KnowledgeGraph):
+        result = json.loads(
+            asyncio.run(mykg_get_source(_fake_ctx(kg_with_chunks), edge_id="edge-001"))
+        )
+        assert result["edge_id"] == "edge-001"
+        assert "error" not in result
+
+    def test_both_node_and_edge(self, kg_with_chunks: KnowledgeGraph):
+        result = json.loads(
+            asyncio.run(
+                mykg_get_source(
+                    _fake_ctx(kg_with_chunks), node_id="person-alice", edge_id="edge-001"
+                )
+            )
+        )
+        assert result["node"]["node_id"] == "person-alice"
+        assert result["edge"]["edge_id"] == "edge-001"
+
+    def test_neither_id_given(self, kg_with_chunks: KnowledgeGraph):
+        result = asyncio.run(mykg_get_source(_fake_ctx(kg_with_chunks)))
+        assert result.startswith("Error:")
+
+    def test_missing_chunk_artifacts_returns_error(self, kg: KnowledgeGraph):
+        result = asyncio.run(mykg_get_source(_fake_ctx(kg), node_id="person-alice"))
+        assert result.startswith("Error:")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 import pytest
 
-from mykg.mcp_server import KnowledgeGraph, _node_name, _node_summary
+from mykg.mcp_server import (
+    KnowledgeGraph,
+    _node_name,
+    _node_summary,
+    _resolve_edge_excerpt,
+    _resolve_node_excerpt,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -111,6 +117,42 @@ def session_dir(tmp_path: Path) -> Path:
 def kg(session_dir: Path) -> KnowledgeGraph:
     """Load a KnowledgeGraph from the temp session."""
     return KnowledgeGraph(session_root=session_dir)
+
+
+TEAM_MD_TEXT = (
+    "Alice Smith is a software engineer at Acme Corp. "
+    "Bob Jones manages the infrastructure team at Acme Corp."
+)
+PARTNERS_MD_TEXT = "Acme Corp partners with several technology vendors in the region."
+
+CHUNK_NODE_INDEX = {
+    "team.md": {"1": ["person-alice", "person-bob"]},
+    "partners.md": {"1": ["organization-acme"]},
+}
+
+FILE_MANIFEST = {
+    "team.md": {"content": TEAM_MD_TEXT, "sha256": "deadbeef", "token_count": 20},
+    "partners.md": {"content": PARTNERS_MD_TEXT, "sha256": "cafef00d", "token_count": 12},
+}
+
+
+@pytest.fixture
+def chunked_session_dir(session_dir: Path) -> Path:
+    """Extend session_dir with chunk_node_index.json + file_manifest.json."""
+    intermediate = session_dir / "intermediate"
+    (intermediate / "chunk_node_index.json").write_text(
+        json.dumps(CHUNK_NODE_INDEX), encoding="utf-8"
+    )
+    (intermediate / "file_manifest.json").write_text(
+        json.dumps(FILE_MANIFEST), encoding="utf-8"
+    )
+    return session_dir
+
+
+@pytest.fixture
+def kg_with_chunks(chunked_session_dir: Path) -> KnowledgeGraph:
+    """Load a KnowledgeGraph with chunk artifacts present."""
+    return KnowledgeGraph(session_root=chunked_session_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -340,10 +382,73 @@ class TestMCPServerRegistration:
             "mykg_query_graph",
             "mykg_hub_nodes",
             "mykg_orphan_nodes",
+            "mykg_get_source",
             "mykg_read_note",
             "mykg_list_sessions",
             "mykg_reload",
         ]
         for name in expected:
             assert name in tool_names, f"Tool '{name}' not registered"
-        assert len(tool_names) == 14
+        assert len(tool_names) == 15
+
+
+# ---------------------------------------------------------------------------
+# mykg_get_source: node/edge source-chunk excerpt resolution
+# ---------------------------------------------------------------------------
+
+
+class TestSourceChunks:
+    def test_node_excerpt_contains_name(self, kg_with_chunks: KnowledgeGraph):
+        result = _resolve_node_excerpt(kg_with_chunks, "person-alice", max_chunks=3)
+        assert "error" not in result
+        assert result["total_chunks"] == 1
+        assert result["returned_chunks"] == 1
+        excerpt = result["excerpts"][0]
+        assert excerpt["source_file"] == "team.md"
+        assert excerpt["chunk_index"] == 1
+        assert "Alice Smith" in excerpt["text"]
+        assert len(excerpt["text"]) <= len(TEAM_MD_TEXT)
+
+    def test_node_excerpt_unknown_node(self, kg_with_chunks: KnowledgeGraph):
+        result = _resolve_node_excerpt(kg_with_chunks, "nonexistent", max_chunks=3)
+        assert "error" in result
+        assert "nonexistent" in result["error"]
+
+    def test_node_excerpt_truncated_by_max_chunks(self, kg_with_chunks: KnowledgeGraph):
+        # person-alice only has 1 chunk in the fixture; force a smaller cap
+        # to exercise total_chunks vs returned_chunks bookkeeping directly.
+        kg_with_chunks.chunk_node_index_by_id["person-alice"] = [
+            "team.md::1", "partners.md::1",
+        ]
+        result = _resolve_node_excerpt(kg_with_chunks, "person-alice", max_chunks=1)
+        assert result["total_chunks"] == 2
+        assert result["returned_chunks"] == 1
+
+    def test_edge_excerpt_exact_overlap(self, kg_with_chunks: KnowledgeGraph):
+        # edge-001: person-alice -> organization-acme. Force both endpoints
+        # to share a chunk so the intersection path is exercised.
+        kg_with_chunks.chunk_node_index_by_id["organization-acme"] = ["team.md::1"]
+        result = _resolve_edge_excerpt(kg_with_chunks, "edge-001", max_chunks=3)
+        assert "error" not in result
+        assert result["exact_chunk_overlap"] is True
+        excerpt = result["excerpts"][0]
+        assert "Alice Smith" in excerpt["text"] or "Acme" in excerpt["text"]
+
+    def test_edge_excerpt_union_fallback(self, kg_with_chunks: KnowledgeGraph):
+        # Fixture as-shipped: person-alice is only in team.md::1,
+        # organization-acme is only in partners.md::1 — no overlap.
+        result = _resolve_edge_excerpt(kg_with_chunks, "edge-001", max_chunks=3)
+        assert "error" not in result
+        assert result["exact_chunk_overlap"] is False
+        assert result["total_chunks"] == 2
+        sources = {e["source_file"] for e in result["excerpts"]}
+        assert sources == {"team.md", "partners.md"}
+
+    def test_edge_excerpt_unknown_edge(self, kg_with_chunks: KnowledgeGraph):
+        result = _resolve_edge_excerpt(kg_with_chunks, "nonexistent", max_chunks=3)
+        assert "error" in result
+
+    def test_missing_chunk_artifacts(self, kg: KnowledgeGraph):
+        # plain `kg` fixture has no chunk_node_index.json / file_manifest.json
+        assert kg.raw_chunk_node_index is None
+        assert kg.file_manifest is None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -447,8 +448,18 @@ class TestSourceChunks:
     def test_edge_excerpt_unknown_edge(self, kg_with_chunks: KnowledgeGraph):
         result = _resolve_edge_excerpt(kg_with_chunks, "nonexistent", max_chunks=3)
         assert "error" in result
+        assert "nonexistent" in result["error"]
 
     def test_missing_chunk_artifacts(self, kg: KnowledgeGraph):
         # plain `kg` fixture has no chunk_node_index.json / file_manifest.json
         assert kg.raw_chunk_node_index is None
         assert kg.file_manifest is None
+
+    def test_malformed_chunk_artifacts_logged(self, session_dir: Path, caplog):
+        (session_dir / "intermediate" / "chunk_node_index.json").write_text(
+            "not valid json", encoding="utf-8"
+        )
+        with caplog.at_level(logging.WARNING, logger="mykg.mcp_server"):
+            kg = KnowledgeGraph(session_root=session_dir)
+        assert kg.raw_chunk_node_index is None
+        assert any("chunk_node_index.json" in record.message for record in caplog.records)

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "mykg"
-version = "0.3.7"
+version = "0.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Adds a new `mykg_get_source` MCP tool that resolves source-text excerpts for a node, an edge, or both, using `chunk_node_index.json` + `file_manifest.json`
- Narrows each source chunk down to the passages actually mentioning the relevant name(s) instead of returning the full ~2000-token chunk
- For edges, prefers chunks where both endpoints co-occur (`exact_chunk_overlap: true`); falls back to the union of endpoint chunks otherwise
- Adds `edges_by_id`, `file_manifest`, and `chunk_node_index_by_id` indexes to `KnowledgeGraph`, loaded/rebuilt on `reload()`

## Test plan
- [x] `uv run pytest tests/test_mcp_server.py -q` — 40 passed
- [ ] Manual MCP smoke test: call `mykg_get_source` with a known node_id / edge_id against a real session and confirm excerpts are returned

## Summary by Sourcery

Add a new MCP tool to retrieve bounded source-text excerpts for nodes and edges, backed by new chunk and file manifest indexes in the knowledge graph.

New Features:
- Introduce the mykg_get_source MCP tool that returns focused source-text excerpts for a node, an edge, or both.

Enhancements:
- Extend KnowledgeGraph with indexes for edges by ID and chunk-to-node mappings derived from chunk_node_index.json and file_manifest.json.
- Load and reuse intermediate chunk and file manifest artifacts when initializing or reloading knowledge graph sessions.

Tests:
- Add fixture-backed tests covering node and edge excerpt resolution, overlap vs union behavior, truncation by max_chunks, and missing chunk artifact handling.
- Update MCP server tool registration test to include the new mykg_get_source tool and adjusted tool count.