### PR TITLE
fix: add encoding='utf-8' to all file I/O (issue #32 Bug 4)

### DIFF
--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -1804,7 +1804,7 @@ def mcp_serve(session, transport, host, port, stop):
                 os.kill(pid, signal.SIGTERM)
             click.echo(f"MCP server stopped (PID {pid}).")
         except ProcessLookupError:
-            click.echo(f"MCP server process (PID {pid_path.read_text(encoding='utf-8').strip()}) not found — stale PID file removed.")
+            click.echo(f"MCP server process (PID {pid}) not found — stale PID file removed.")
         except ValueError:
             click.echo("Corrupt PID file — removing.")
         pid_path.unlink(missing_ok=True)

--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -175,7 +175,7 @@ def init_config(
         # `pip install -U mykg`.
         if reinstall_skill or reinstall_claude_md:
             try:
-                existing = dest.read_text()
+                existing = dest.read_text(encoding="utf-8")
             except OSError:
                 existing = ""
             if "profile: agent-claude-code" in existing:
@@ -231,11 +231,11 @@ def init_config(
     import re
 
     template = Path(__file__).parent / "data" / "mykg_config.yaml"
-    content = template.read_text()
+    content = template.read_text(encoding="utf-8")
     content = re.sub(r"^profile:.*$", f"profile: {profile}", content, count=1, flags=re.MULTILINE)
     if model:
         content = _patch_profile_model(content, profile, model)
-    dest.write_text(content)
+    dest.write_text(content, encoding="utf-8")
     model_note = f", model: {model}" if model else ""
     click.echo(f"\nCreated mykg_config.yaml in {Path.cwd()} (profile: {profile}{model_note})")
 
@@ -256,7 +256,7 @@ def init_config(
     # Check if key is already set
     existing_key = None
     if env_file.exists():
-        for line in env_file.read_text().splitlines():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
             if line.startswith(f"{var}=") and line[len(var) + 1 :].strip():
                 existing_key = line[len(var) + 1 :].strip()
                 break
@@ -304,7 +304,7 @@ def _patch_profile_model(content: str, profile: str, model: str) -> str:
 
 def _write_env_key(env_file: Path, var: str, value: str) -> None:
     """Write or update a single key in .env.mykg, preserving other lines."""
-    lines = env_file.read_text().splitlines() if env_file.exists() else []
+    lines = env_file.read_text(encoding="utf-8").splitlines() if env_file.exists() else []
     updated = False
     for i, line in enumerate(lines):
         if line.startswith(f"{var}="):
@@ -313,7 +313,7 @@ def _write_env_key(env_file: Path, var: str, value: str) -> None:
             break
     if not updated:
         lines.append(f"{var}={value}")
-    env_file.write_text("\n".join(lines) + "\n")
+    env_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 _SKILL_VERSION_STAMP = ".mykg_skill_version"
@@ -402,7 +402,7 @@ def _install_agent_skill(*, force: bool = False) -> None:
                 return
         elif stamp.is_file():
             try:
-                installed_version = stamp.read_text().strip()
+                installed_version = stamp.read_text(encoding="utf-8").strip()
             except OSError:
                 installed_version = "(unreadable)"
             if installed_version == mykg.__version__ and not force:
@@ -451,7 +451,7 @@ def _install_agent_skill(*, force: bool = False) -> None:
         return
 
     try:
-        (target / _SKILL_VERSION_STAMP).write_text(mykg.__version__)
+        (target / _SKILL_VERSION_STAMP).write_text(mykg.__version__, encoding="utf-8")
     except OSError as exc:
         click.echo(f"[skill] Warning: could not write version stamp: {exc}")
 
@@ -765,19 +765,19 @@ def extract_graph(
         from mykg.base_schema import parse_base_schema
 
         session_schema_ttl = Path(intermediate_dir) / "schema.ttl"
-        base = parse_base_schema(session_schema_ttl.read_text())
+        base = parse_base_schema(session_schema_ttl.read_text(encoding="utf-8"))
         base["_source"] = str(session_schema_ttl)
     elif base_schema:
         from mykg.base_schema import parse_base_schema
 
-        base = parse_base_schema(Path(base_schema).read_text())
+        base = parse_base_schema(Path(base_schema).read_text(encoding="utf-8"))
         base["_source"] = str(base_schema)
 
     thes = None
     if thesaurus:
         from mykg.thesaurus import parse_thesaurus
 
-        thes = parse_thesaurus(Path(thesaurus).read_text(), source=str(thesaurus))
+        thes = parse_thesaurus(Path(thesaurus).read_text(encoding="utf-8"), source=str(thesaurus))
 
     ctx = PipelineContext(
         input_dir=input_dir,
@@ -845,15 +845,15 @@ def approve_schema(intermediate_dir, log_file, verbose, session):
     if not schema_path.exists():
         raise click.ClickException(f"schema.json not found in {intermediate_dir}")
 
-    schema = json.loads(schema_path.read_text())
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
 
     from mykg.exporter import export_ttl
 
     ttl = export_ttl(schema, [], {})
-    (Path(intermediate_dir) / "schema.ttl").write_text(ttl)
+    (Path(intermediate_dir) / "schema.ttl").write_text(ttl, encoding="utf-8")
 
     flag = Path(intermediate_dir) / "schema_approved.flag"
-    flag.write_text("approved")
+    flag.write_text("approved", encoding="utf-8")
     click.echo(
         "Schema approved. schema.ttl regenerated. Resume with the original extract-graph command."
     )
@@ -968,14 +968,14 @@ def merge_graphs(
     if base_schema:
         from mykg.base_schema import parse_base_schema
 
-        base = parse_base_schema(Path(base_schema).read_text())
+        base = parse_base_schema(Path(base_schema).read_text(encoding="utf-8"))
         base["_source"] = str(base_schema)
 
     thes = None
     if thesaurus:
         from mykg.thesaurus import parse_thesaurus
 
-        thes = parse_thesaurus(Path(thesaurus).read_text(), source=str(thesaurus))
+        thes = parse_thesaurus(Path(thesaurus).read_text(encoding="utf-8"), source=str(thesaurus))
 
     from mykg.config import MERGE_GRAPHS_HUMAN_REVIEW
     from mykg.merge_orchestrator import run_merge_graphs
@@ -1797,14 +1797,14 @@ def mcp_serve(session, transport, host, port, stop):
             click.echo("No MCP server is running (no PID file found).")
             return
         try:
-            pid = int(pid_path.read_text().strip())
+            pid = int(pid_path.read_text(encoding="utf-8").strip())
             if sys.platform == "win32":
                 os.kill(pid, signal.CTRL_BREAK_EVENT)
             else:
                 os.kill(pid, signal.SIGTERM)
             click.echo(f"MCP server stopped (PID {pid}).")
         except ProcessLookupError:
-            click.echo(f"MCP server process (PID {pid_path.read_text().strip()}) not found — stale PID file removed.")
+            click.echo(f"MCP server process (PID {pid_path.read_text(encoding='utf-8').strip()}) not found — stale PID file removed.")
         except ValueError:
             click.echo("Corrupt PID file — removing.")
         pid_path.unlink(missing_ok=True)
@@ -1854,7 +1854,7 @@ def mcp_serve(session, transport, host, port, stop):
     port = port or getattr(cfg, "MCP_PORT", 3100)
 
     if transport == "streamable_http":
-        pid_path.write_text(str(os.getpid()))
+        pid_path.write_text(str(os.getpid()), encoding="utf-8")
 
     click.echo(
         f"Serving session '{session_root.name}' via {transport}"

--- a/src/mykg/config.py
+++ b/src/mykg/config.py
@@ -34,7 +34,7 @@ def _find_config() -> Path:
 
 def _load() -> dict:
     path = _find_config()
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 

--- a/src/mykg/exporter.py
+++ b/src/mykg/exporter.py
@@ -739,7 +739,7 @@ def export_networkx(nodes: list[dict], edge_metadata: dict, output_dir: Path) ->
         nx.write_pajek(G, str(nx_dir / "knowledge_graph.net"))
     written.append("knowledge_graph.net")
 
-    with open(nx_dir / "knowledge_graph.json", "w") as f:
+    with open(nx_dir / "knowledge_graph.json", "w", encoding="utf-8") as f:
         json.dump(json_graph.node_link_data(G), f, indent=_cfg.JSON_INDENT)
     written.append("knowledge_graph.json")
 

--- a/src/mykg/exporters/neo4j/_common.py
+++ b/src/mykg/exporters/neo4j/_common.py
@@ -27,7 +27,7 @@ def load_session(session_root: Path) -> tuple[list[dict], list[dict], dict]:
         nodes = [json.loads(line) for line in f if line.strip()]
     with edges_path.open(encoding="utf-8") as f:
         edges = [json.loads(line) for line in f if line.strip()]
-    schema = json.loads(schema_path.read_text())
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
     return nodes, edges, schema
 
 

--- a/src/mykg/exporters/neo4j/emit_load_csv.py
+++ b/src/mykg/exporters/neo4j/emit_load_csv.py
@@ -53,11 +53,11 @@ def main(argv: list[str] | None = None) -> int:
     csvs = build_plain_csvs(nodes, edges, schema)
 
     for rel_path, content in csvs.items():
-        (out_dir / rel_path.name).write_text(content)
+        (out_dir / rel_path.name).write_text(content, encoding="utf-8")
 
-    (out_dir / "import_browser.cypher").write_text(build_browser_cypher(csvs))
-    (out_dir / "import_shell.cypher").write_text(build_shell_cypher(csvs, out_dir))
-    (out_dir / "README.md").write_text(build_readme(out_dir, list(csvs.keys())))
+    (out_dir / "import_browser.cypher").write_text(build_browser_cypher(csvs), encoding="utf-8")
+    (out_dir / "import_shell.cypher").write_text(build_shell_cypher(csvs, out_dir), encoding="utf-8")
+    (out_dir / "README.md").write_text(build_readme(out_dir, list(csvs.keys())), encoding="utf-8")
 
     _print_recipe(out_dir, len(csvs))
     return 0

--- a/src/mykg/exporters/neo4j/load_csv.py
+++ b/src/mykg/exporters/neo4j/load_csv.py
@@ -326,16 +326,16 @@ def export_neo4j_csv(
 
     written: list[str] = []
     for rel_path, content in csvs.items():
-        (vault_dir / rel_path.name).write_text(content)
+        (vault_dir / rel_path.name).write_text(content, encoding="utf-8")
         written.append(f"{_cfg.NEO4J_CSV_DIR}/{rel_path.name}")
 
-    (vault_dir / "import_browser.cypher").write_text(build_browser_cypher(csvs))
+    (vault_dir / "import_browser.cypher").write_text(build_browser_cypher(csvs), encoding="utf-8")
     written.append(f"{_cfg.NEO4J_CSV_DIR}/import_browser.cypher")
 
-    (vault_dir / "import_shell.cypher").write_text(build_shell_cypher(csvs, vault_dir_abs))
+    (vault_dir / "import_shell.cypher").write_text(build_shell_cypher(csvs, vault_dir_abs), encoding="utf-8")
     written.append(f"{_cfg.NEO4J_CSV_DIR}/import_shell.cypher")
 
-    (vault_dir / "README.md").write_text(build_readme(vault_dir_abs, list(csvs.keys())))
+    (vault_dir / "README.md").write_text(build_readme(vault_dir_abs, list(csvs.keys())), encoding="utf-8")
     written.append(f"{_cfg.NEO4J_CSV_DIR}/README.md")
 
     return written

--- a/src/mykg/feedback.py
+++ b/src/mykg/feedback.py
@@ -45,7 +45,7 @@ def _validate_schema_response(corrected: object) -> None:
 
 def _fix_schema(error: str, ctx: PipelineContext) -> None:
     schema_path = ctx.intermediate_dir / "schema.json"
-    current = schema_path.read_text() if schema_path.exists() else "{}"
+    current = schema_path.read_text(encoding="utf-8") if schema_path.exists() else "{}"
     prompt = FEEDBACK_PROMPT.format(
         step_name="schema",
         error=error,
@@ -75,7 +75,7 @@ def _regenerate_schema_ttl(schema: dict, ctx: PipelineContext) -> None:
     from mykg.exporter import export_ttl
 
     ttl = export_ttl(schema, [], {})
-    (ctx.intermediate_dir / "schema.ttl").write_text(ttl)
+    (ctx.intermediate_dir / "schema.ttl").write_text(ttl, encoding="utf-8")
 
 
 def _fix_schema_extend(error: str, ctx: PipelineContext) -> None:
@@ -86,8 +86,8 @@ def _fix_schema_extend(error: str, ctx: PipelineContext) -> None:
     """
     schema_path = ctx.intermediate_dir / "schema.json"
     proposals_path = ctx.intermediate_dir / "schema_gap_proposals.json"
-    current_schema = schema_path.read_text() if schema_path.exists() else "{}"
-    proposals = proposals_path.read_text() if proposals_path.exists() else "{}"
+    current_schema = schema_path.read_text(encoding="utf-8") if schema_path.exists() else "{}"
+    proposals = proposals_path.read_text(encoding="utf-8") if proposals_path.exists() else "{}"
     prompt = FEEDBACK_PROMPT.format(
         step_name="schema_extend",
         error=error,
@@ -111,7 +111,7 @@ def _fix_schema_extend(error: str, ctx: PipelineContext) -> None:
 
 def _fix_normalization(error: str, ctx: PipelineContext) -> None:
     norm_path = ctx.intermediate_dir / "name_normalization.json"
-    current = norm_path.read_text() if norm_path.exists() else "{}"
+    current = norm_path.read_text(encoding="utf-8") if norm_path.exists() else "{}"
     prompt = FEEDBACK_PROMPT.format(
         step_name="normalize_names",
         error=error,
@@ -127,15 +127,15 @@ def _fix_normalization(error: str, ctx: PipelineContext) -> None:
             f"LLM returned invalid normalization structure — expected "
             f'{{"mappings": {{...}}}}, got: {str(corrected)[:200]}'
         )
-    norm_path.write_text(json.dumps(corrected, indent=_cfg.JSON_INDENT))
+    norm_path.write_text(json.dumps(corrected, indent=_cfg.JSON_INDENT), encoding="utf-8")
     log.info("Feedback applied to name_normalization.json")
 
 
 def _fix_orphan_connect(error: str, ctx: PipelineContext) -> None:
     candidates_path = ctx.intermediate_dir / "orphan_candidates.json"
     connections_path = ctx.intermediate_dir / "orphan_connections.json"
-    candidates = candidates_path.read_text() if candidates_path.exists() else "{}"
-    current = connections_path.read_text() if connections_path.exists() else "{}"
+    candidates = candidates_path.read_text(encoding="utf-8") if candidates_path.exists() else "{}"
+    current = connections_path.read_text(encoding="utf-8") if connections_path.exists() else "{}"
     prompt = FEEDBACK_PROMPT.format(
         step_name="orphan_connect",
         error=error,
@@ -154,7 +154,7 @@ def _fix_orphan_connect(error: str, ctx: PipelineContext) -> None:
             f"LLM returned invalid orphan_connections structure — expected a dict, "
             f"got: {str(corrected)[:200]}"
         )
-    connections_path.write_text(json.dumps(corrected, indent=_cfg.JSON_INDENT))
+    connections_path.write_text(json.dumps(corrected, indent=_cfg.JSON_INDENT), encoding="utf-8")
     log.info("Feedback applied to orphan_connections.json")
 
 

--- a/src/mykg/llm/agent_adapter.py
+++ b/src/mykg/llm/agent_adapter.py
@@ -90,7 +90,7 @@ class AgentAdapter(LLMAdapter):
     @staticmethod
     def _atomic_write_json(path: Path, payload: dict) -> None:
         tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps(payload, indent=2))
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         tmp.replace(path)
 
     def complete(
@@ -154,7 +154,7 @@ class AgentAdapter(LLMAdapter):
         t0: float,
     ) -> str:
         """Read the answer, log the call, return the (fence-stripped) string."""
-        answer = json.loads(answer_path.read_text()).get("answer", "")
+        answer = json.loads(answer_path.read_text(encoding="utf-8")).get("answer", "")
         record_llm_call(
             provider="agent",
             model="claude-code",

--- a/src/mykg/merge_run.py
+++ b/src/mykg/merge_run.py
@@ -184,9 +184,9 @@ def run_merge(ctx: MergeContext) -> None:
 
                     from mykg.exporter import export_ttl as _export_ttl
 
-                    _updated_schema = json.loads(_schema_json_path.read_text())
+                    _updated_schema = json.loads(_schema_json_path.read_text(encoding="utf-8"))
                     _ttl_text = _export_ttl(_updated_schema, [], {})
-                    (ctx.intermediate_dir / "schema.ttl").write_text(_ttl_text)
+                    (ctx.intermediate_dir / "schema.ttl").write_text(_ttl_text, encoding="utf-8")
                     log.info(
                         "Schema-gap restart — regenerated schema.ttl "
                         "(%d concept(s), %d property/properties)",

--- a/src/mykg/orchestrator.py
+++ b/src/mykg/orchestrator.py
@@ -152,7 +152,7 @@ class PipelineState(BaseModel):
             "errors": self.errors,
         }
         (intermediate_dir / "pipeline_state.json").write_text(
-            json.dumps(payload, indent=_cfg.JSON_INDENT)
+            json.dumps(payload, indent=_cfg.JSON_INDENT), encoding="utf-8"
         )
 
     @classmethod
@@ -160,7 +160,7 @@ class PipelineState(BaseModel):
         path = intermediate_dir / "pipeline_state.json"
         if not path.exists():
             return cls(step_names=step_names)
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         state = cls(step_names=step_names)
         state.steps = data.get("steps", {})
         state.errors = data.get("errors", {})
@@ -434,9 +434,9 @@ def run(steps: list[Step], ctx: PipelineContext) -> None:
                 if _schema_json_path.exists():
                     from mykg.exporter import export_ttl as _export_ttl
 
-                    _updated_schema = json.loads(_schema_json_path.read_text())
+                    _updated_schema = json.loads(_schema_json_path.read_text(encoding="utf-8"))
                     _ttl_text = _export_ttl(_updated_schema, [], {})
-                    (ctx.intermediate_dir / "schema.ttl").write_text(_ttl_text)
+                    (ctx.intermediate_dir / "schema.ttl").write_text(_ttl_text, encoding="utf-8")
                     log.info(
                         "Schema-gap restart — regenerated schema.ttl "
                         "(%d concept(s), %d property/properties)",

--- a/src/mykg/pass2.py
+++ b/src/mykg/pass2.py
@@ -557,7 +557,7 @@ def run_pass2(
     failed_entries = failed_log.entries()
     if intermediate_dir is not None:
         (intermediate_dir / "failed_chunks.json").write_text(
-            json.dumps(failed_entries, indent=_cfg.JSON_INDENT)
+            json.dumps(failed_entries, indent=_cfg.JSON_INDENT), encoding="utf-8"
         )
 
     return results, chunk_index, failed_entries
@@ -621,7 +621,7 @@ def run_pass2_batched(
             "failed": 0,
             "batches": {name: {**entry, "status": "pending"} for name, entry in batch_map.items()},
         }
-        progress_path.write_text(json.dumps(progress, indent=2))
+        progress_path.write_text(json.dumps(progress, indent=2), encoding="utf-8")
 
     # Accumulated per-file results (keyed by source_file).
     file_nodes: dict[str, list[dict]] = {f: [] for f in files}
@@ -692,7 +692,7 @@ def run_pass2_batched(
                 entry["error"] = error
             progress["failed"] += 1
         tmp = progress_path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(progress, indent=2))
+        tmp.write_text(json.dumps(progress, indent=2), encoding="utf-8")
         tmp.replace(progress_path)
 
     batch_start = time.monotonic()

--- a/src/mykg/schema_history.py
+++ b/src/mykg/schema_history.py
@@ -64,7 +64,7 @@ def write_schema(
     prev: dict = {}
     if schema_path.exists():
         try:
-            prev = json.loads(schema_path.read_text())
+            prev = json.loads(schema_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
 
@@ -79,7 +79,7 @@ def write_schema(
     properties_removed = sorted(prev_props - curr_props)
 
     # Write schema.json.
-    schema_path.write_text(json.dumps(schema, indent=_cfg.JSON_INDENT))
+    schema_path.write_text(json.dumps(schema, indent=_cfg.JSON_INDENT), encoding="utf-8")
 
     # Write delta entry.
     history_dir = intermediate_dir / SCHEMA_HISTORY_DIR
@@ -104,7 +104,7 @@ def write_schema(
         delta.update(extra)
 
     delta_path = history_dir / f"{seq:04d}_{trigger}.json"
-    delta_path.write_text(json.dumps(delta, indent=_cfg.JSON_INDENT))
+    delta_path.write_text(json.dumps(delta, indent=_cfg.JSON_INDENT), encoding="utf-8")
 
     log.debug(
         "schema_history — delta %04d (%s): +%d concept(s), +%d property(ies)",

--- a/src/mykg/steps/step_assemble.py
+++ b/src/mykg/steps/step_assemble.py
@@ -28,14 +28,14 @@ def _annotate_aliases(raw_with_ids: dict, alias_index: dict[str, dict[str, list[
 
 
 def run_assemble(ctx: PipelineContext) -> None:
-    raw = json.loads((ctx.intermediate_dir / "raw_extractions.json").read_text())
+    raw = json.loads((ctx.intermediate_dir / "raw_extractions.json").read_text(encoding="utf-8"))
     log.info("Steps 7–9 — assigning stable IDs and deduplicating …")
     raw_with_ids = assign_stable_ids(raw)
 
     # Derive aliases from name_normalization.json at assembly time (D29)
     norm_path = ctx.intermediate_dir / "name_normalization.json"
     if norm_path.exists():
-        norm_data = json.loads(norm_path.read_text())
+        norm_data = json.loads(norm_path.read_text(encoding="utf-8"))
         norm_map = norm_data.get("mappings", {})
         if norm_map:
             alias_index = build_alias_index(norm_map)
@@ -59,7 +59,7 @@ def run_assemble(ctx: PipelineContext) -> None:
     synonym_events: list[dict] = []
     if merge_log_path.exists():
         try:
-            existing = json.loads(merge_log_path.read_text())
+            existing = json.loads(merge_log_path.read_text(encoding="utf-8"))
             synonym_events = [e for e in existing if e.get("event") == "synonym_collapse"]
         except (json.JSONDecodeError, ValueError):
             synonym_events = []

--- a/src/mykg/steps/step_ingest.py
+++ b/src/mykg/steps/step_ingest.py
@@ -66,7 +66,7 @@ def _run_parallel(
 
 
 def _load_manifest(manifest_path) -> dict[str, dict]:
-    raw: dict = json.loads(manifest_path.read_text())
+    raw: dict = json.loads(manifest_path.read_text(encoding="utf-8"))
     migrated = False
     result: dict[str, dict] = {}
     for filename, value in raw.items():
@@ -84,7 +84,7 @@ def _load_manifest(manifest_path) -> dict[str, dict]:
                 migrated = True
             result[filename] = value
     if migrated:
-        manifest_path.write_text(json.dumps(result, indent=_cfg.JSON_INDENT))
+        manifest_path.write_text(json.dumps(result, indent=_cfg.JSON_INDENT), encoding="utf-8")
         log.info("step_ingest — migrated file_manifest.json to dict format")
     return result
 
@@ -120,7 +120,7 @@ def run_ingest(ctx: PipelineContext) -> None:
     log.info("Step 1 — %d total chunk(s) ready for Pass 1", len(ctx.all_chunks))
 
     (ctx.intermediate_dir / "file_manifest.json").write_text(
-        json.dumps(manifest, indent=_cfg.JSON_INDENT)
+        json.dumps(manifest, indent=_cfg.JSON_INDENT), encoding="utf-8"
     )
     log.debug("Step 1 — file_manifest.json written (%d file(s))", len(ctx.file_contents))
 
@@ -164,7 +164,7 @@ def _run_append_ingest(ctx: PipelineContext) -> None:
                 "token_count": _token_count(content),
             }
 
-    manifest_path.write_text(json.dumps(manifest, indent=_cfg.JSON_INDENT))
+    manifest_path.write_text(json.dumps(manifest, indent=_cfg.JSON_INDENT), encoding="utf-8")
 
     # Also pick up any manifest files missing from raw_extractions.json — this
     # happens when a previous append run was interrupted after ingest but before
@@ -173,7 +173,7 @@ def _run_append_ingest(ctx: PipelineContext) -> None:
     unextracted: list[str] = []
     if raw_path.exists():
         try:
-            existing_raw: dict = json.loads(raw_path.read_text())
+            existing_raw: dict = json.loads(raw_path.read_text(encoding="utf-8"))
             for filename in manifest:
                 if filename not in existing_raw and filename not in changed:
                     unextracted.append(filename)
@@ -207,7 +207,7 @@ def _write_base_schema_parsed(ctx: PipelineContext) -> None:
         "locked_properties": ctx.base_schema.get("locked_properties", {}),
     }
     (ctx.intermediate_dir / "base_schema_parsed.json").write_text(
-        json.dumps(data, indent=_cfg.JSON_INDENT)
+        json.dumps(data, indent=_cfg.JSON_INDENT), encoding="utf-8"
     )
     n_classes = len(data["locked_classes"])
     n_props = len(data["locked_properties"])
@@ -240,6 +240,6 @@ def _write_thesaurus_parsed(ctx: PipelineContext) -> None:
         "relations_used": relations_used,
     }
     (ctx.intermediate_dir / "thesaurus_parsed.json").write_text(
-        json.dumps(data, indent=_cfg.JSON_INDENT)
+        json.dumps(data, indent=_cfg.JSON_INDENT), encoding="utf-8"
     )
     log.info("Step 1 — thesaurus_parsed.json written")

--- a/src/mykg/steps/step_normalize.py
+++ b/src/mykg/steps/step_normalize.py
@@ -22,16 +22,17 @@ def run_normalize_names(ctx: PipelineContext) -> None:
     if not _cfg.NORMALIZE_NAMES_ENABLED:
         log.info("Step 6b — normalize_names disabled; writing empty sentinel")
         norm_path.write_text(
-            json.dumps({"metadata": {"enabled": False}, "mappings": {}}, indent=_cfg.JSON_INDENT)
+            json.dumps({"metadata": {"enabled": False}, "mappings": {}}, indent=_cfg.JSON_INDENT),
+            encoding="utf-8",
         )
         return
 
-    raw = json.loads((ctx.intermediate_dir / "raw_extractions.json").read_text())
+    raw = json.loads((ctx.intermediate_dir / "raw_extractions.json").read_text(encoding="utf-8"))
     inventory = build_name_inventory(raw)
 
     if not inventory:
         log.info("Step 6b — no named nodes found; writing empty sentinel")
-        norm_path.write_text(json.dumps(build_normalization_file({}, {}), indent=_cfg.JSON_INDENT))
+        norm_path.write_text(json.dumps(build_normalization_file({}, {}), indent=_cfg.JSON_INDENT), encoding="utf-8")
         return
 
     log.info(
@@ -46,7 +47,7 @@ def run_normalize_names(ctx: PipelineContext) -> None:
         log.warning("Step 6b — normalization warning: %s", err)
 
     payload = build_normalization_file(norm_map, inventory, validation_warnings=errors or None)
-    norm_path.write_text(json.dumps(payload, indent=_cfg.JSON_INDENT))
+    norm_path.write_text(json.dumps(payload, indent=_cfg.JSON_INDENT), encoding="utf-8")
     log.info(
         "Step 6b — %d alias(es) mapped; name_normalization.json written",
         payload["metadata"]["aliases_mapped"],
@@ -55,7 +56,7 @@ def run_normalize_names(ctx: PipelineContext) -> None:
     if norm_map:
         normalized_raw = apply_normalization_map(raw, norm_map)
         (ctx.intermediate_dir / "raw_extractions.json").write_text(
-            json.dumps(normalized_raw, indent=_cfg.JSON_INDENT)
+            json.dumps(normalized_raw, indent=_cfg.JSON_INDENT), encoding="utf-8"
         )
         log.info("Step 6b — raw_extractions.json rewritten with canonical names")
 
@@ -68,7 +69,7 @@ def run_normalize_names(ctx: PipelineContext) -> None:
 
         chunk_idx_path = ctx.intermediate_dir / "chunk_node_index.json"
         if id_remap and chunk_idx_path.exists():
-            chunk_idx = json.loads(chunk_idx_path.read_text())
+            chunk_idx = json.loads(chunk_idx_path.read_text(encoding="utf-8"))
             updated = {
                 fname: {
                     chunk_key: [id_remap.get(nid, nid) for nid in ids]
@@ -76,7 +77,7 @@ def run_normalize_names(ctx: PipelineContext) -> None:
                 }
                 for fname, chunks in chunk_idx.items()
             }
-            chunk_idx_path.write_text(json.dumps(updated, indent=_cfg.JSON_INDENT))
+            chunk_idx_path.write_text(json.dumps(updated, indent=_cfg.JSON_INDENT), encoding="utf-8")
             log.info(
                 "Step 6b — chunk_node_index.json IDs remapped (%d ID(s) changed)", len(id_remap)
             )
@@ -84,10 +85,10 @@ def run_normalize_names(ctx: PipelineContext) -> None:
         shard_dir = ctx.intermediate_dir / "chunk_index_shards"
         if id_remap and shard_dir.exists():
             for shard_file in shard_dir.glob("*.json"):
-                shard = json.loads(shard_file.read_text())
+                shard = json.loads(shard_file.read_text(encoding="utf-8"))
                 shard["data"] = {
                     chunk_key: [id_remap.get(nid, nid) for nid in ids]
                     for chunk_key, ids in shard["data"].items()
                 }
-                shard_file.write_text(json.dumps(shard, indent=_cfg.JSON_INDENT))
+                shard_file.write_text(json.dumps(shard, indent=_cfg.JSON_INDENT), encoding="utf-8")
             log.debug("Step 6b — chunk_index_shards updated")

--- a/src/mykg/steps/step_orphan_connect.py
+++ b/src/mykg/steps/step_orphan_connect.py
@@ -32,21 +32,21 @@ def run_orphan_connect(ctx: PipelineContext) -> None:
         atomic_write_json(ctx.intermediate_dir / "orphan_log.json", [])
         return
 
-    raw_payload = json.loads((ctx.intermediate_dir / "orphan_candidates.json").read_text())
+    raw_payload = json.loads((ctx.intermediate_dir / "orphan_candidates.json").read_text(encoding="utf-8"))
     groups = [OrphanChunkGroup(**g) for g in raw_payload.get("groups", [])]
     schema_gap_orphans = [SchemaGapOrphan(**g) for g in raw_payload.get("schema_gap_orphans", [])]
 
     nodes = ctx.nodes
     if nodes is None:
-        nodes = json.loads((ctx.intermediate_dir / "nodes.json").read_text())
+        nodes = json.loads((ctx.intermediate_dir / "nodes.json").read_text(encoding="utf-8"))
 
-    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text())
+    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text(encoding="utf-8"))
 
     file_manifest = ctx.file_contents
     if file_manifest is None:
         manifest_path = ctx.intermediate_dir / "file_manifest.json"
         if manifest_path.exists():
-            file_manifest = json.loads(manifest_path.read_text())
+            file_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     chunk_texts: dict[str, str] = build_chunk_texts(file_manifest) if file_manifest else {}
     if not chunk_texts:
@@ -59,7 +59,7 @@ def run_orphan_connect(ctx: PipelineContext) -> None:
     prior_connections: dict[str, dict] = {}
     orphan_connections_path = ctx.intermediate_dir / "orphan_connections.json"
     if ctx.orphan_incremental and orphan_connections_path.exists():
-        prior_connections = json.loads(orphan_connections_path.read_text())
+        prior_connections = json.loads(orphan_connections_path.read_text(encoding="utf-8"))
 
     already_connected: set[str] = set()
     for edge in prior_connections.values():
@@ -141,7 +141,7 @@ def run_orphan_connect(ctx: PipelineContext) -> None:
             )
 
     edge_metadata_path = ctx.intermediate_dir / "edge_metadata.json"
-    edge_metadata = json.loads(edge_metadata_path.read_text())
+    edge_metadata = json.loads(edge_metadata_path.read_text(encoding="utf-8"))
     skipped = 0
     for eid, edge in orphan_connections.items():
         if eid in edge_metadata:

--- a/src/mykg/steps/step_orphan_score.py
+++ b/src/mykg/steps/step_orphan_score.py
@@ -14,17 +14,18 @@ def run_orphan_score(ctx: PipelineContext) -> None:
     if not _cfg.ORPHAN_PASS_ENABLED:
         log.info("Step orphan_score — skipped (orphan_pass.enabled: false)")
         (ctx.intermediate_dir / "orphan_candidates.json").write_text(
-            json.dumps({"groups": [], "schema_gap_orphans": []}, indent=_cfg.JSON_INDENT)
+            json.dumps({"groups": [], "schema_gap_orphans": []}, indent=_cfg.JSON_INDENT),
+            encoding="utf-8",
         )
         return
 
     nodes = ctx.nodes
     if nodes is None:
-        nodes = json.loads((ctx.intermediate_dir / "nodes.json").read_text())
+        nodes = json.loads((ctx.intermediate_dir / "nodes.json").read_text(encoding="utf-8"))
 
     edge_metadata = ctx.edge_metadata
     if edge_metadata is None:
-        edge_metadata = json.loads((ctx.intermediate_dir / "edge_metadata.json").read_text())
+        edge_metadata = json.loads((ctx.intermediate_dir / "edge_metadata.json").read_text(encoding="utf-8"))
 
     chunk_node_index = ctx.chunk_node_index
     if chunk_node_index is None:
@@ -34,20 +35,20 @@ def run_orphan_score(ctx: PipelineContext) -> None:
                 "intermediate/chunk_node_index.json not found. "
                 "Re-run from --from-step pass2 to regenerate it."
             )
-        chunk_node_index = json.loads(index_path.read_text())
+        chunk_node_index = json.loads(index_path.read_text(encoding="utf-8"))
 
-    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text())
+    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text(encoding="utf-8"))
 
     failed_chunks: list[dict] = []
     failed_path = ctx.intermediate_dir / "failed_chunks.json"
     if failed_path.exists() and _cfg.ORPHAN_BLANK_RECOVERY_ENABLED:
-        failed_chunks = json.loads(failed_path.read_text())
+        failed_chunks = json.loads(failed_path.read_text(encoding="utf-8"))
 
     file_manifest = ctx.file_contents
     if file_manifest is None:
         manifest_path = ctx.intermediate_dir / "file_manifest.json"
         if manifest_path.exists():
-            file_manifest = json.loads(manifest_path.read_text())
+            file_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     groups, unresolvable_orphans = score_orphan_candidates_v2(
         nodes,
@@ -58,7 +59,7 @@ def run_orphan_score(ctx: PipelineContext) -> None:
         file_manifest=file_manifest,
     )
 
-    (ctx.intermediate_dir / "nodes.json").write_text(json.dumps(nodes, indent=_cfg.JSON_INDENT))
+    (ctx.intermediate_dir / "nodes.json").write_text(json.dumps(nodes, indent=_cfg.JSON_INDENT), encoding="utf-8")
     ctx.nodes = nodes
 
     payload = {
@@ -66,7 +67,7 @@ def run_orphan_score(ctx: PipelineContext) -> None:
         "schema_gap_orphans": [],
     }
     (ctx.intermediate_dir / "orphan_candidates.json").write_text(
-        json.dumps(payload, indent=_cfg.JSON_INDENT)
+        json.dumps(payload, indent=_cfg.JSON_INDENT), encoding="utf-8"
     )
 
     # Write advisory events for orphans with no resolvable source chunk.
@@ -75,12 +76,12 @@ def run_orphan_score(ctx: PipelineContext) -> None:
         existing: list[dict] = []
         if orphan_log_path.exists():
             try:
-                existing = json.loads(orphan_log_path.read_text())
+                existing = json.loads(orphan_log_path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 existing = []
         for orphan_id in unresolvable_orphans:
             existing.append({"event": "orphan_unconnectable", "orphan_id": orphan_id})
-        orphan_log_path.write_text(json.dumps(existing, indent=_cfg.JSON_INDENT))
+        orphan_log_path.write_text(json.dumps(existing, indent=_cfg.JSON_INDENT), encoding="utf-8")
 
     total_orphans = sum(len(g.orphan_ids) for g in groups)
     blank_groups = sum(1 for g in groups if g.is_blank_response)

--- a/src/mykg/steps/step_pass1.py
+++ b/src/mykg/steps/step_pass1.py
@@ -35,9 +35,9 @@ def run_pass1_step(ctx: PipelineContext) -> None:
 
         write_schema(schema, ctx.intermediate_dir, TRIGGER_FREEZE_SCHEMA)
         ttl = export_ttl(schema, [], {})
-        (ctx.intermediate_dir / "schema.ttl").write_text(ttl)
+        (ctx.intermediate_dir / "schema.ttl").write_text(ttl, encoding="utf-8")
         merge_log_path = ctx.intermediate_dir / "merge_log.json"
-        merge_log_path.write_text(json.dumps([], indent=_cfg.JSON_INDENT))
+        merge_log_path.write_text(json.dumps([], indent=_cfg.JSON_INDENT), encoding="utf-8")
         return
 
     # --append-with-grow-schema (D52): run the locked re-induction over ONLY the changed
@@ -51,7 +51,7 @@ def run_pass1_step(ctx: PipelineContext) -> None:
             raise RuntimeError(
                 "grow_schema: file_manifest.json not found — re-run from the ingest step."
             )
-        file_contents: dict[str, str | dict] = json.loads(manifest_path.read_text())
+        file_contents: dict[str, str | dict] = json.loads(manifest_path.read_text(encoding="utf-8"))
         ctx.all_chunks = []
         changed = [f for f in ctx.append_new_files if f in file_contents]
         for fname in changed:
@@ -65,7 +65,7 @@ def run_pass1_step(ctx: PipelineContext) -> None:
     elif ctx.all_chunks is None:
         manifest_path = ctx.intermediate_dir / "file_manifest.json"
         if manifest_path.exists():
-            file_contents = json.loads(manifest_path.read_text())
+            file_contents = json.loads(manifest_path.read_text(encoding="utf-8"))
             ctx.all_chunks = []
             for fname, entry in file_contents.items():
                 ctx.all_chunks.extend(chunk_file(fname, _content_from_entry(entry)))
@@ -116,7 +116,7 @@ def run_pass1_step(ctx: PipelineContext) -> None:
     # Write synonym events. step_assemble reads these back and prepends them
     # to its own dedup events so the full audit trail is preserved on Re-entry C.
     merge_log_path = ctx.intermediate_dir / "merge_log.json"
-    merge_log_path.write_text(json.dumps(synonym_log, indent=_cfg.JSON_INDENT))
+    merge_log_path.write_text(json.dumps(synonym_log, indent=_cfg.JSON_INDENT), encoding="utf-8")
     if synonym_log:
         log.info("Step 3 — %d synonym collapse(s) logged to merge_log.json", len(synonym_log))
 
@@ -152,4 +152,4 @@ def run_pass1_step(ctx: PipelineContext) -> None:
     write_schema(schema, ctx.intermediate_dir, TRIGGER_SCHEMA_QUALITY)
 
     ttl = export_ttl(schema, [], {})
-    (ctx.intermediate_dir / "schema.ttl").write_text(ttl)
+    (ctx.intermediate_dir / "schema.ttl").write_text(ttl, encoding="utf-8")

--- a/src/mykg/steps/step_pass2.py
+++ b/src/mykg/steps/step_pass2.py
@@ -19,10 +19,10 @@ def _fname_slug(fname: str) -> str:
 
 
 def run_schema_flatten(ctx: PipelineContext) -> None:
-    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text())
+    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text(encoding="utf-8"))
     flat = flatten_schema(schema)
     (ctx.intermediate_dir / "flattened_schema.json").write_text(
-        json.dumps(flat, indent=_cfg.JSON_INDENT)
+        json.dumps(flat, indent=_cfg.JSON_INDENT), encoding="utf-8"
     )
     log.info("Step 5 — flattened %d concept(s)", len(flat))
 
@@ -32,7 +32,7 @@ def _load_manifest(ctx: PipelineContext) -> dict[str, str]:
         return ctx.file_contents
     manifest_path = ctx.intermediate_dir / "file_manifest.json"
     if manifest_path.exists():
-        raw = json.loads(manifest_path.read_text())
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
         ctx.file_contents = raw
         log.info("Step 6 — restored file_contents from file_manifest.json (%d file(s))", len(raw))
         return raw
@@ -48,8 +48,8 @@ def _content_from_entry(entry: str | dict) -> str:
 
 def run_pass2_step(ctx: PipelineContext) -> None:
     manifest = _load_manifest(ctx)
-    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text())
-    flat = json.loads((ctx.intermediate_dir / "flattened_schema.json").read_text())
+    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text(encoding="utf-8"))
+    flat = json.loads((ctx.intermediate_dir / "flattened_schema.json").read_text(encoding="utf-8"))
     _run(ctx, manifest, schema, flat)
 
 
@@ -88,15 +88,15 @@ def _run(
 
     if shard_dir.exists():
         for shard_file in shard_dir.glob("*.json"):
-            shard_content = json.loads(shard_file.read_text())
+            shard_content = json.loads(shard_file.read_text(encoding="utf-8"))
             existing_raw[shard_content["_fname"]] = shard_content["data"]
         for shard_file in chunk_shard_dir.glob("*.json") if chunk_shard_dir.exists() else []:
-            shard_content = json.loads(shard_file.read_text())
+            shard_content = json.loads(shard_file.read_text(encoding="utf-8"))
             existing_chunk[shard_content["_fname"]] = shard_content["data"]
         log.debug("Step 6 — loaded %d shard(s) from %s", len(existing_raw), shard_dir)
     elif raw_path.exists():
-        existing_raw = json.loads(raw_path.read_text())
-        existing_chunk = json.loads(chunk_path.read_text()) if chunk_path.exists() else {}
+        existing_raw = json.loads(raw_path.read_text(encoding="utf-8"))
+        existing_chunk = json.loads(chunk_path.read_text(encoding="utf-8")) if chunk_path.exists() else {}
 
     if ctx.append and ctx.append_new_files is not None:
         todo = {f: _content_from_entry(manifest[f]) for f in ctx.append_new_files if f in manifest}
@@ -144,10 +144,12 @@ def _run(
                 existing_chunk[fname] = file_idx
                 slug = _fname_slug(fname)
                 (shard_dir / f"{slug}.json").write_text(
-                    json.dumps({"_fname": fname, "data": result}, indent=_cfg.JSON_INDENT)
+                    json.dumps({"_fname": fname, "data": result}, indent=_cfg.JSON_INDENT),
+                    encoding="utf-8",
                 )
                 (chunk_shard_dir / f"{slug}.json").write_text(
-                    json.dumps({"_fname": fname, "data": file_idx}, indent=_cfg.JSON_INDENT)
+                    json.dumps({"_fname": fname, "data": file_idx}, indent=_cfg.JSON_INDENT),
+                    encoding="utf-8",
                 )
 
             new_raw, new_chunk, _failed = run_pass2(
@@ -186,10 +188,12 @@ def _run(
     def _write_shard(fname: str, result: dict, file_idx: dict) -> None:
         slug = _fname_slug(fname)
         (shard_dir / f"{slug}.json").write_text(
-            json.dumps({"_fname": fname, "data": result}, indent=_cfg.JSON_INDENT)
+            json.dumps({"_fname": fname, "data": result}, indent=_cfg.JSON_INDENT),
+            encoding="utf-8",
         )
         (chunk_shard_dir / f"{slug}.json").write_text(
-            json.dumps({"_fname": fname, "data": file_idx}, indent=_cfg.JSON_INDENT)
+            json.dumps({"_fname": fname, "data": file_idx}, indent=_cfg.JSON_INDENT),
+            encoding="utf-8",
         )
 
     def _on_file_done(fname: str, result: dict, file_idx: dict) -> None:
@@ -251,7 +255,7 @@ def _run(
             batch_retry_max=_cfg.PASS2_BATCH_RETRY_MAX,
         )
         (ctx.intermediate_dir / "pass2_batch_map.json").write_text(
-            json.dumps(batch_map, indent=_cfg.JSON_INDENT)
+            json.dumps(batch_map, indent=_cfg.JSON_INDENT), encoding="utf-8"
         )
         log.info(
             "Step 6 — batch map: %d batch(es) written to pass2_batch_map.json",
@@ -288,12 +292,12 @@ def _log_and_write(
     _log = log.warning if total_nodes == 0 and total_edges == 0 else log.info
     _log("Step 6 — extracted %d node(s), %d edge(s) (raw, total)", total_nodes, total_edges)
     (ctx.intermediate_dir / "raw_extractions.json").write_text(
-        json.dumps(raw, indent=_cfg.JSON_INDENT)
+        json.dumps(raw, indent=_cfg.JSON_INDENT), encoding="utf-8"
     )
     (ctx.intermediate_dir / "chunk_node_index.json").write_text(
-        json.dumps(chunk_node_index, indent=_cfg.JSON_INDENT)
+        json.dumps(chunk_node_index, indent=_cfg.JSON_INDENT), encoding="utf-8"
     )
-    (ctx.intermediate_dir / "raw_extractions.done").write_text("")
+    (ctx.intermediate_dir / "raw_extractions.done").write_text("", encoding="utf-8")
     ctx.raw_extractions = raw
     ctx.chunk_node_index = chunk_node_index
 
@@ -380,10 +384,12 @@ def _grow_schema_backfill(
         existing_chunk[fname] = file_idx
         slug = _fname_slug(fname)
         (shard_dir / f"{slug}.json").write_text(
-            json.dumps({"_fname": fname, "data": result}, indent=_cfg.JSON_INDENT)
+            json.dumps({"_fname": fname, "data": result}, indent=_cfg.JSON_INDENT),
+            encoding="utf-8",
         )
         (chunk_shard_dir / f"{slug}.json").write_text(
-            json.dumps({"_fname": fname, "data": file_idx}, indent=_cfg.JSON_INDENT)
+            json.dumps({"_fname": fname, "data": file_idx}, indent=_cfg.JSON_INDENT),
+            encoding="utf-8",
         )
 
     new_raw, new_chunk, _failed = run_pass2(

--- a/src/mykg/steps/step_preprocess.py
+++ b/src/mykg/steps/step_preprocess.py
@@ -27,7 +27,7 @@ _TXT_BACKEND_SUFFIXES: frozenset[str] = frozenset({".txt"})
 
 def _write_sentinel(intermediate_dir: Path, manifest: dict) -> None:
     intermediate_dir.mkdir(parents=True, exist_ok=True)
-    (intermediate_dir / "preprocess.done").write_text("done")
+    (intermediate_dir / "preprocess.done").write_text("done", encoding="utf-8")
     _atomic_write_json(intermediate_dir / "preprocess_manifest.json", manifest)
 
 
@@ -51,7 +51,7 @@ def _load_prior_manifest(intermediate_dir: Path) -> dict:
     if not p.exists():
         return {}
     try:
-        return json.loads(p.read_text())
+        return json.loads(p.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
 

--- a/src/mykg/steps/step_schema.py
+++ b/src/mykg/steps/step_schema.py
@@ -28,10 +28,10 @@ def run_schema_validate(ctx: PipelineContext) -> None:
                 "Neither schema.ttl nor schema.json found in intermediate dir "
                 "— cannot run schema validation"
             )
-        schema = json.loads(schema_json_path.read_text())
-        schema_ttl_path.write_text(export_ttl(schema, [], {}))
+        schema = json.loads(schema_json_path.read_text(encoding="utf-8"))
+        schema_ttl_path.write_text(export_ttl(schema, [], {}), encoding="utf-8")
         log.info("Step 3b — regenerated schema.ttl from schema.json")
-    schema_ttl = schema_ttl_path.read_text()
+    schema_ttl = schema_ttl_path.read_text(encoding="utf-8")
 
     # First attempt
     first = validate_schema_ttl(schema_ttl)
@@ -52,7 +52,7 @@ def run_schema_validate(ctx: PipelineContext) -> None:
             llm_attempted = False
 
         # Second attempt (re-read schema.ttl in case correction rewrote it)
-        schema_ttl2 = (ctx.intermediate_dir / "schema.ttl").read_text()
+        schema_ttl2 = (ctx.intermediate_dir / "schema.ttl").read_text(encoding="utf-8")
         second = validate_schema_ttl(schema_ttl2)
 
         record = {
@@ -61,7 +61,7 @@ def run_schema_validate(ctx: PipelineContext) -> None:
             "second_attempt": {"errors": second.errors, "passed": second.valid},
         }
         (ctx.intermediate_dir / "schema_validation_errors.json").write_text(
-            json.dumps(record, indent=_cfg.JSON_INDENT)
+            json.dumps(record, indent=_cfg.JSON_INDENT), encoding="utf-8"
         )
 
         if second.valid:
@@ -78,13 +78,13 @@ def run_schema_validate(ctx: PipelineContext) -> None:
     from datetime import datetime, timezone
 
     sentinel_content = datetime.now(timezone.utc).isoformat()
-    (ctx.intermediate_dir / "schema_validate.done").write_text(sentinel_content)
+    (ctx.intermediate_dir / "schema_validate.done").write_text(sentinel_content, encoding="utf-8")
 
 
 def run_human_review(ctx: PipelineContext) -> None:
     flag = ctx.intermediate_dir / "schema_approved.flag"
     if not ctx.review:
-        flag.write_text("auto-approved")
+        flag.write_text("auto-approved", encoding="utf-8")
         log.info("Step 4 — review gate skipped (--review not set)")
         return
     if flag.exists():

--- a/src/mykg/steps/step_validate_graph.py
+++ b/src/mykg/steps/step_validate_graph.py
@@ -12,13 +12,13 @@ log = get("mykg.steps.validate_graph")
 
 
 def run_validate_graph(ctx: PipelineContext) -> None:
-    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text())
+    schema = json.loads((ctx.intermediate_dir / "schema.json").read_text(encoding="utf-8"))
     nodes = ctx.nodes
     if nodes is None:
-        nodes = json.loads((ctx.intermediate_dir / "nodes.json").read_text())
+        nodes = json.loads((ctx.intermediate_dir / "nodes.json").read_text(encoding="utf-8"))
     edge_metadata = ctx.edge_metadata
     if edge_metadata is None:
-        edge_metadata = json.loads((ctx.intermediate_dir / "edge_metadata.json").read_text())
+        edge_metadata = json.loads((ctx.intermediate_dir / "edge_metadata.json").read_text(encoding="utf-8"))
     log.info("Steps 10–12 — validating and writing graph outputs …")
     declared_props = {p["name"] for p in schema.get("properties", [])}
     valid_edge_metadata = {
@@ -27,9 +27,9 @@ def run_validate_graph(ctx: PipelineContext) -> None:
     ttl = sanitize_abox_ttl(export_ttl(schema, nodes, valid_edge_metadata), schema)
     result = validate_knowledge_graph_ttl(ttl)
 
-    (ctx.output_dir / "nodes.jsonl").write_text(export_nodes_jsonl(nodes))
-    (ctx.output_dir / "edges.jsonl").write_text(export_edges_jsonl(valid_edge_metadata))
-    (ctx.output_dir / "knowledge_graph.ttl").write_text(ttl)
+    (ctx.output_dir / "nodes.jsonl").write_text(export_nodes_jsonl(nodes), encoding="utf-8")
+    (ctx.output_dir / "edges.jsonl").write_text(export_edges_jsonl(valid_edge_metadata), encoding="utf-8")
+    (ctx.output_dir / "knowledge_graph.ttl").write_text(ttl, encoding="utf-8")
 
     if _cfg.NETWORKX_ENABLED:
         written = export_networkx(nodes, valid_edge_metadata, ctx.output_dir)
@@ -48,7 +48,7 @@ def run_validate_graph(ctx: PipelineContext) -> None:
         log.info("Step 12e — Neo4j CSV export: %d file(s) written", len(n4j_written))
 
     (ctx.output_dir / "knowledge_graph_validation.json").write_text(
-        json.dumps(result, indent=_cfg.JSON_INDENT)
+        json.dumps(result, indent=_cfg.JSON_INDENT), encoding="utf-8"
     )
     if result["valid"]:
         log.info("Step 12b — knowledge_graph.ttl valid")

--- a/src/mykg/utility/context_calculator.py
+++ b/src/mykg/utility/context_calculator.py
@@ -66,7 +66,7 @@ def load_mykg_config() -> tuple[dict, Path]:
     for directory in [here, *here.parents]:
         config_path = directory / "mykg_config.yaml"
         if config_path.exists():
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 raw = yaml.safe_load(f)
             profile_name = raw.get("profile")
             if profile_name:
@@ -205,7 +205,7 @@ def write_candidate_config(config_path: "Path", profile_name: str, result: dict)
     """
     import re
 
-    text = config_path.read_text()
+    text = config_path.read_text(encoding="utf-8")
     lines = text.splitlines(keepends=True)
 
     # `batch_token_target` appears under both pass1 and pass2 with the same
@@ -250,7 +250,7 @@ def write_candidate_config(config_path: "Path", profile_name: str, result: dict)
     stem = config_path.stem  # "mykg_config"
     suffix = config_path.suffix  # ".yaml"
     out_path = config_path.with_name(f"{stem}_candidate{suffix}")
-    out_path.write_text("".join(new_lines))
+    out_path.write_text("".join(new_lines), encoding="utf-8")
     return out_path
 
 


### PR DESCRIPTION
## Summary

- Adds explicit `encoding="utf-8"` to all `.write_text()`, `.read_text()`, and text-mode `open()` calls across 23 files
- Fixes `UnicodeEncodeError` on Windows (cp1252) when graph content contains non-ASCII characters (μ, em-dash, etc.)
- No behavior change on macOS/Linux — `encoding="utf-8"` is a no-op where UTF-8 is already the platform default

## Files changed

Core, steps, CLI, and exporters: `config.py`, `feedback.py`, `merge_run.py`, `schema_history.py`, `orchestrator.py`, `pass2.py`, `cli.py`, `exporter.py`, `llm/agent_adapter.py`, `utility/context_calculator.py`, all `steps/` files, `exporters/neo4j/` files.

## Test plan

- [ ] `uv run pytest tests/ -x -q` — 1161 tests pass (1 pre-existing live-API flake in `test_llm_adapters.py` unrelated to this change)
- [ ] On Windows: extract a corpus with non-ASCII content (μ, —, →) and verify all output files write without `UnicodeEncodeError`

Closes #32 (Bug 4 — Windows charmap encoding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure all text file I/O across the pipeline, CLI, feedback utilities, and Neo4j exporters explicitly use UTF-8 encoding for consistent behavior across platforms, particularly Windows.

Bug Fixes:
- Resolve UnicodeEncodeError and related charset issues on Windows by forcing UTF-8 for all text-mode reads and writes of intermediate artifacts, configs, and exported graph files.

Enhancements:
- Standardize encoding handling by consistently specifying UTF-8 on Path.read_text/write_text and open() calls, improving portability and future-proofing text processing.