### PR TITLE
fix: reconfigure stdout/stderr to UTF-8 on Windows (issue #32 Bug 2)

### DIFF
--- a/src/mykg/logging.py
+++ b/src/mykg/logging.py
@@ -44,6 +44,11 @@ def setup(log_file: Path | None = None, verbose: bool = False) -> None:
 
     from mykg import config
 
+    if sys.platform == "win32":
+        for _stream in (sys.stdout, sys.stderr):
+            if hasattr(_stream, "reconfigure"):
+                _stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+
     level = logging.DEBUG if verbose else logging.INFO
     root = logging.getLogger()
     root.setLevel(level)


### PR DESCRIPTION
## Summary

- On Windows (cp1252 console), log lines containing `—` (em-dash in `LOG_FORMAT`) and `→` (arrows in step log messages) trigger `UnicodeEncodeError`, producing `--- Logging error ---` stack traces interleaved with real output
- Adds `sys.stdout.reconfigure(encoding='utf-8', errors='backslashreplace')` at the start of `logging.setup()`, guarded by `sys.platform == 'win32'` and `hasattr(_stream, 'reconfigure')`
- Covers all 128 affected log strings globally with no per-message changes
- No-op on macOS/Linux; test-safe (StringIO has no `reconfigure`)

## Why not `h.encoding = 'utf-8'`

`StreamHandler.emit()` calls `stream.write(msg)` directly and never reads `self.encoding` — that approach does not work. `sys.stdout.reconfigure()` is the correct Python 3.7+ solution.

## Test plan

- [ ] `uv run pytest tests/ -x -q` — 1161 tests pass
- [ ] On Windows: run `mykg extract-graph` and verify no `--- Logging error ---` traces appear in the console output

Closes #32 (Bug 2 — console logging UTF-8 on Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent UnicodeEncodeError and noisy '--- Logging error ---' traces when logging Unicode characters on Windows consoles by reconfiguring stdout and stderr encoding to UTF-8.