### PR TITLE
fix: guard node/edge confidence against non-numeric LLM values (issue #32 Bug 1)

### DIFF
--- a/src/mykg/assembler.py
+++ b/src/mykg/assembler.py
@@ -50,6 +50,31 @@ def _coerce_attr(val) -> dict:
     return {"value": val, "confidence": _cfg.CONFIDENCE_FALLBACK}
 
 
+def _coerce_conf(val) -> float:
+    """Safely convert a top-level node/edge confidence value to float.
+
+    Mirrors _coerce_attr's try/except+clamp logic for the scalar confidence
+    field that sits at the node/edge level (not inside an attribute dict).
+    """
+    try:
+        conf = float(val)
+    except (TypeError, ValueError):
+        log.warning(
+            "_coerce_conf: confidence value %r is not numeric; using fallback %s",
+            val,
+            _cfg.CONFIDENCE_FALLBACK,
+        )
+        return float(_cfg.CONFIDENCE_FALLBACK)
+    clamped = max(0.0, min(1.0, conf))
+    if clamped != conf:
+        log.warning(
+            "_coerce_conf: confidence value %s out of range [0.0, 1.0]; clamped to %s",
+            conf,
+            clamped,
+        )
+    return clamped
+
+
 def _stable_id(node_type: str, name_value: str) -> str:
     """Thin wrapper kept for backwards-compatibility; delegates to ids.stable_id."""
     return _ids_stable_id(node_type, name_value)
@@ -130,7 +155,7 @@ def deduplicate_nodes(
 
         for source_file, node in occurrences:
             merged["source_files"].append(source_file)
-            confs.append(float(node.get("confidence", _cfg.CONFIDENCE_FALLBACK)))
+            confs.append(_coerce_conf(node.get("confidence", _cfg.CONFIDENCE_FALLBACK)))
             node_attrs = node.get("attributes", {})
             if not isinstance(node_attrs, dict):
                 node_attrs = {}
@@ -232,7 +257,7 @@ def deduplicate_edges(
 
         for source_file, edge in occurrences:
             merged["source_files"].append(source_file)
-            confs.append(float(edge.get("confidence", _cfg.CONFIDENCE_FALLBACK)))
+            confs.append(_coerce_conf(edge.get("confidence", _cfg.CONFIDENCE_FALLBACK)))
             attrs = edge.get("attributes", {})
             if not isinstance(attrs, dict):
                 attrs = {}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -575,3 +575,64 @@ def test_dedup_nodes_with_non_dict_attrs():
     nodes, _ = deduplicate_nodes(raw)
     assert len(nodes) == 1
     assert nodes[0]["attributes"]["name"]["value"] == "Alice"
+
+
+def test_deduplicate_nodes_malformed_confidence_does_not_raise():
+    """Nodes with non-numeric confidence (e.g. '#') must not crash deduplicate_nodes (issue #32 Bug 1)."""
+    from mykg.assembler import assign_stable_ids, deduplicate_nodes
+
+    raw = {
+        "file_a.md": {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "confidence": "#",
+                    "attributes": {"name": {"value": "Alice", "confidence": 0.9}},
+                }
+            ],
+            "edges": [],
+        }
+    }
+    updated = assign_stable_ids(raw)
+    nodes, _ = deduplicate_nodes(updated)
+    assert len(nodes) == 1
+    assert 0.0 <= nodes[0]["confidence"] <= 1.0
+
+
+def test_deduplicate_edges_malformed_confidence_does_not_raise():
+    """Edges with non-numeric confidence (e.g. 'N/A') must not crash deduplicate_edges (issue #32 Bug 1)."""
+    from mykg.assembler import assign_stable_ids, deduplicate_edges
+
+    raw = {
+        "file_a.md": {
+            "nodes": [
+                {
+                    "id": "person-alice",
+                    "type": "Person",
+                    "confidence": 1.0,
+                    "attributes": {"name": {"value": "Alice", "confidence": 1.0}},
+                },
+                {
+                    "id": "org-acme",
+                    "type": "Organization",
+                    "confidence": 1.0,
+                    "attributes": {"name": {"value": "Acme", "confidence": 1.0}},
+                },
+            ],
+            "edges": [
+                {
+                    "type": "works_at",
+                    "from": "person-alice",
+                    "to": "org-acme",
+                    "confidence": "N/A",
+                    "attributes": {},
+                }
+            ],
+        }
+    }
+    updated = assign_stable_ids(raw)
+    edge_metadata, _ = deduplicate_edges(updated)
+    assert len(edge_metadata) == 1
+    edge = next(iter(edge_metadata.values()))
+    assert 0.0 <= edge["confidence"] <= 1.0


### PR DESCRIPTION
## Summary

- Two unguarded `float()` calls in `deduplicate_nodes` and `deduplicate_edges` crashed the assembler when the LLM emitted a non-numeric confidence value such as `'#'` or `'N/A'`
- Adds `_coerce_conf(val) -> float` helper that mirrors `_coerce_attr`'s try/except + fallback to `CONFIDENCE_FALLBACK` + clamp to `[0.0, 1.0]`
- Replaces both raw `float()` call sites in `assembler.py` with `_coerce_conf()`
- Adds two regression tests covering node and edge paths with malformed confidence values

## Example failure

```python
node = {"confidence": "#", "type": "Person", "attributes": {...}}
float(node.get("confidence", 0.5))
# → ValueError: could not convert string to float: '#'
```

## Files changed

- `src/mykg/assembler.py` — new `_coerce_conf()` helper + 2 call-site fixes
- `tests/test_assembler.py` — 2 new regression tests

## Test plan

- [ ] `uv run pytest tests/ -x -q` — 1163 tests pass (1161 existing + 2 new)

Closes #32 (Bug 1 — assembler unguarded float())

🤖 Generated with [Claude Code](https://claude.com/claude-code)