### PR TITLE
fix: pin pdftext<0.7.0 to work around MinerU 3.4.0 PageChars TypeError

### DIFF
--- a/mykg_config.yaml
+++ b/mykg_config.yaml
@@ -57,7 +57,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -230,7 +230,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -402,7 +402,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -581,7 +581,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -754,7 +754,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -924,7 +924,7 @@ profiles:
         timeout_seconds: 1800
         uv_path: uv
         uv_python_version: "3.12"
-        mineru_spec: mineru[all]
+        mineru_spec: "mineru[all] pdftext<0.7.0"
         install_timeout_seconds: 1800
         extensions:
           - .pdf

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -57,7 +57,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -230,7 +230,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -402,7 +402,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -581,7 +581,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -754,7 +754,7 @@ profiles:
         timeout_seconds: 1800         # mineru run-phase timeout (30 min)
         uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
         uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
-        mineru_spec: mineru[all]      # package spec installed via `uv pip install -U <spec>`
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
         install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
         extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
           - .pdf
@@ -924,7 +924,7 @@ profiles:
         timeout_seconds: 1800
         uv_path: uv
         uv_python_version: "3.12"
-        mineru_spec: mineru[all]
+        mineru_spec: "mineru[all] pdftext<0.7.0"
         install_timeout_seconds: 1800
         extensions:
           - .pdf

--- a/src/mykg/uv_venv.py
+++ b/src/mykg/uv_venv.py
@@ -86,6 +86,9 @@ def ephemeral_venv(
             timeout=install_timeout,
             phase="uv venv",
         )
+        # Split spec on whitespace so multi-package specs like
+        # "mineru[all] pdftext<0.7.0" expand into separate arguments.
+        spec_args = spec.split()
         _run(
             [
                 resolved_uv,
@@ -94,7 +97,7 @@ def ephemeral_venv(
                 "--python",
                 str(_venv_bin(venv_dir, "python")),
                 "-U",
-                spec,
+                *spec_args,
             ],
             timeout=install_timeout,
             phase=f"uv pip install {spec}",


### PR DESCRIPTION
## Summary

- `pdftext 0.7.0` changed `PageChars` to non-iterable, breaking `MinerU 3.4.0`'s `_deduplicate_near_identical_chars` which loops over it as a list
- The fix is already in MinerU's GitHub HEAD (June 9 commit) but not yet in any PyPI release
- Temporary workaround: pin `pdftext<0.7.0` alongside `mineru[all]` until MinerU >3.4.0 ships

## Changes

- **`mykg_config.yaml`** + **`src/mykg/data/mykg_config.yaml`**: `mineru_spec` changed to `"mineru[all] pdftext<0.7.0"` in all 6 profiles
- **`src/mykg/uv_venv.py`**: split `spec` on whitespace before passing to `uv pip install` so multi-package specs expand into separate arguments (required since `uv pip install` does not accept space-separated packages as one string)

## Verified

Full `mykg extract-graph _input_files3/` run completed successfully — all 3 PDFs converted, 23 concepts / 22 properties, 6 nodes / 8 edges, all output formats written.

## Follow-up

Remove the `pdftext<0.7.0` pin once MinerU releases a version with the upstream fix (track: https://github.com/opendatalab/mineru/commit/c6e4b126).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)