### PR TITLE
fix: cap harmonize_schema proposals via pass1.max_schema_proposals

### DIFF
--- a/mykg_config.yaml
+++ b/mykg_config.yaml
@@ -105,6 +105,7 @@ profiles:
         batch_token_target: 16000  # conservative; MUST stay ≤ context_window − max_output_tokens
         max_workers: 8
         per_file_batching: false  # set true for Option B: one batch per source file
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 8
@@ -278,6 +279,7 @@ profiles:
         batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
         max_workers: 8
         per_file_batching: false
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 8
@@ -450,6 +452,7 @@ profiles:
         batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
         max_workers: 1          # claude-cli is serial — 1 worker only
         per_file_batching: false  # set true for Option B: one batch per source file
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 1          # claude-cli is serial — 1 worker only
@@ -629,6 +632,7 @@ profiles:
         batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
         max_workers: 8
         per_file_batching: false
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 8
@@ -802,6 +806,7 @@ profiles:
         batch_token_target: 16000  # doubled; MUST stay ≤ context_window − max_output_tokens
         max_workers: 1              # local GPU can usually handle a small degree of parallelism
         per_file_batching: false
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 1
@@ -971,6 +976,7 @@ profiles:
         batch_token_target: 15000
         max_workers: 2                # the skill dispatches up to this many subagents per wave
         per_file_batching: false
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       pass2:
         max_workers: 2
         stateful_chunks: true

--- a/src/mykg/config.py
+++ b/src/mykg/config.py
@@ -100,6 +100,7 @@ CHUNK_TIKTOKEN_ENCODING: str = _get("chunking", "tiktoken_encoding")
 PASS1_BATCH_TOKEN_TARGET: int = _get("pass1", "batch_token_target")
 PASS1_MAX_WORKERS: int = _get("pass1", "max_workers")
 PASS1_PER_FILE_BATCHING: bool = _get_opt("pass1", "per_file_batching", False)
+PASS1_MAX_SCHEMA_PROPOSALS: int = _get_opt("pass1", "max_schema_proposals", 50)
 
 # ---------------------------------------------------------------------------
 # Pass 2

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -105,6 +105,7 @@ profiles:
         batch_token_target: 16000  # conservative; MUST stay ≤ context_window − max_output_tokens
         max_workers: 8
         per_file_batching: false  # set true for Option B: one batch per source file
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 8
@@ -278,6 +279,7 @@ profiles:
         batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
         max_workers: 8
         per_file_batching: false
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 8
@@ -450,6 +452,7 @@ profiles:
         batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
         max_workers: 1          # claude-cli is serial — 1 worker only
         per_file_batching: false  # set true for Option B: one batch per source file
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 1          # claude-cli is serial — 1 worker only
@@ -629,6 +632,7 @@ profiles:
         batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
         max_workers: 8
         per_file_batching: false
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 8
@@ -802,6 +806,7 @@ profiles:
         batch_token_target: 16000  # doubled; MUST stay ≤ context_window − max_output_tokens
         max_workers: 1              # local GPU can usually handle a small degree of parallelism
         per_file_batching: false
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
         max_workers: 1
@@ -971,6 +976,7 @@ profiles:
         batch_token_target: 15000
         max_workers: 2                # the skill dispatches up to this many subagents per wave
         per_file_batching: false
+        max_schema_proposals: 50  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
       pass2:
         max_workers: 2
         stateful_chunks: true

--- a/src/mykg/schema_merge.py
+++ b/src/mykg/schema_merge.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import json
 import logging
+import random as _random
 import re
 
+from mykg import config as _cfg
 from mykg.llm.adapter import LLMAdapter
 from mykg.llm.retry import llm_complete_with_retry
 from mykg.prompts import load_prompt
 from mykg.thesaurus import SynonymIndex
 
 _log = logging.getLogger("mykg.schema_merge")
+_PROPOSALS_RNG = _random.Random(0)
 
 _QUALITY_SYSTEM_PROMPT = load_prompt("schema_merge/quality_system")
 _HARMONIZE_SYSTEM_PROMPT = load_prompt("schema_merge/harmonize_system")
@@ -165,6 +168,14 @@ def harmonize_schema(
     remove, or duplicate — the same mechanism Pass 1 extraction uses. Empty by default,
     so behaviour is unchanged when no base schema is in play.
     """
+    cap = _cfg.PASS1_MAX_SCHEMA_PROPOSALS
+    if len(proposals) > cap:
+        _log.warning(
+            "harmonize_schema — %d proposals sampled down to %d (pass1.max_schema_proposals)",
+            len(proposals),
+            cap,
+        )
+        proposals = _PROPOSALS_RNG.sample(proposals, cap)
     proposals_block = json.dumps(proposals, indent=2)
     merged_block = json.dumps(schema, indent=2)
     user = "MERGED SCHEMA:\n" + merged_block + "\n\nRAW PROPOSALS:\n" + proposals_block
@@ -252,6 +263,14 @@ def harmonize_schema_for_merge(schema: dict, proposals: list[dict], adapter: LLM
     Sees both the merged schema and the two source session schemas as proposals.
     Returns the improved schema, or the original if the response is unparseable.
     """
+    cap = _cfg.PASS1_MAX_SCHEMA_PROPOSALS
+    if len(proposals) > cap:
+        _log.warning(
+            "harmonize_schema_for_merge — %d proposals sampled down to %d (pass1.max_schema_proposals)",
+            len(proposals),
+            cap,
+        )
+        proposals = _PROPOSALS_RNG.sample(proposals, cap)
     proposals_block = json.dumps(proposals, indent=2)
     merged_block = json.dumps(schema, indent=2)
     user = "MERGED SCHEMA:\n" + merged_block + "\n\nSESSION SCHEMAS:\n" + proposals_block

--- a/src/mykg/utility/context_calculator.py
+++ b/src/mykg/utility/context_calculator.py
@@ -26,7 +26,8 @@ In auto mode the script:
     mykg_config_candidate.yaml that patches: llm.context_window, llm.max_output_tokens,
     chunking.window_tokens, chunking.overlap_tokens, pass1.batch_token_target,
     pass2.batch_token_target, pass2.concat_batch_token_target, feedback.max_file_chars,
-    and normalize_names.batch_token_target
+    normalize_names.batch_token_target, and pass1.max_schema_proposals (shown as a
+    fixed reminder; not derived from context window)
 """
 
 import argparse
@@ -341,6 +342,7 @@ def print_report(
     print(f"        overlap_tokens: {ot}  # = window_tokens × {OVERLAP_RATIO:.0%}")
     print("      pass1:")
     print(f"        batch_token_target: {btt}  # = input_headroom × {1 - SAFETY_MARGIN_RATIO:.0%}")
+    print("        max_schema_proposals: 50  # fixed cap; lower on small-context models")
     print("      pass2:")
     print(f"        batch_token_target: {btt}        # used when prep_mode=batch_chunks")
     print(f"        concat_batch_token_target: {btt}  # used when prep_mode=concat")

--- a/tests/test_context_calculator.py
+++ b/tests/test_context_calculator.py
@@ -787,3 +787,10 @@ def test_print_report_includes_normalize_names_in_yaml_snippet(capsys):
     out = capsys.readouterr().out
     assert "normalize_names:" in out
     assert "batch_token_target: 20000" in out
+
+
+def test_print_report_includes_max_schema_proposals_in_yaml_snippet(capsys):
+    """print_report YAML snippet includes the pass1.max_schema_proposals line."""
+    print_report(PRINT_RESULT, model="test-model", chunk_divisor=12)
+    out = capsys.readouterr().out
+    assert "max_schema_proposals: 50" in out

--- a/tests/test_schema_merge.py
+++ b/tests/test_schema_merge.py
@@ -526,6 +526,24 @@ def test_harmonize_for_merge_falls_back_on_adapter_exception():
     assert result is _MERGED_SCHEMA_FOR_MERGE
 
 
+def test_harmonize_for_merge_samples_proposals_when_over_limit(monkeypatch):
+    """When session schemas exceed max_schema_proposals, only the cap reaches the LLM."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS1_MAX_SCHEMA_PROPOSALS", 1)
+    proposals = [
+        {"concepts": [{"type": f"Type{i}", "parent": None, "attributes": ["name"]}], "properties": []}
+        for i in range(3)
+    ]
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(_MERGED_SCHEMA_FOR_MERGE)
+    harmonize_schema_for_merge(_MERGED_SCHEMA_FOR_MERGE, proposals, adapter)
+
+    user_prompt = adapter.complete.call_args[0][1]
+    sent = json.loads(user_prompt.split("SESSION SCHEMAS:\n")[1])
+    assert len(sent) == 1
+
+
 # ---------------------------------------------------------------------------
 # review_schema_quality_for_merge tests
 # ---------------------------------------------------------------------------

--- a/tests/test_schema_merge.py
+++ b/tests/test_schema_merge.py
@@ -247,6 +247,42 @@ def test_harmonize_no_locked_block_unchanged():
     assert system_prompt == _HARMONIZE_SYSTEM_PROMPT
 
 
+def test_harmonize_samples_proposals_when_over_limit(monkeypatch):
+    """When proposals exceed max_schema_proposals, only the capped count reaches the LLM."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS1_MAX_SCHEMA_PROPOSALS", 2)
+    proposals = [
+        {"concepts": [{"type": f"Type{i}", "parent": None, "attributes": ["name"]}], "properties": []}
+        for i in range(5)
+    ]
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(_REDUCED_SCHEMA)
+    harmonize_schema(_SMALL_SCHEMA, proposals, adapter)
+
+    user_prompt = adapter.complete.call_args[0][1]
+    sent = json.loads(user_prompt.split("RAW PROPOSALS:\n")[1])
+    assert len(sent) == 2
+
+
+def test_harmonize_no_sample_when_under_limit(monkeypatch):
+    """When proposals are within the cap, all are sent to the LLM unchanged."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS1_MAX_SCHEMA_PROPOSALS", 100)
+    proposals = [
+        {"concepts": [{"type": f"Type{i}", "parent": None, "attributes": ["name"]}], "properties": []}
+        for i in range(3)
+    ]
+    adapter = MagicMock()
+    adapter.complete.return_value = json.dumps(_REDUCED_SCHEMA)
+    harmonize_schema(_SMALL_SCHEMA, proposals, adapter)
+
+    user_prompt = adapter.complete.call_args[0][1]
+    sent = json.loads(user_prompt.split("RAW PROPOSALS:\n")[1])
+    assert len(sent) == 3
+
+
 def test_review_quality_injects_locked_block():
     adapter = MagicMock()
     adapter.complete.return_value = json.dumps(_SMALL_SCHEMA)


### PR DESCRIPTION
Closes #40

## Summary

On large corpora (~14,900 files), Pass 1 produces ~750 batch proposals. `harmonize_schema()` was sending all of them in one LLM call — estimated ~375k tokens, exceeding every provider's context window.

- Add `pass1.max_schema_proposals` (default 50) to cap proposals sent to `harmonize_schema` and `harmonize_schema_for_merge`
- Fixed-seed sampling (`random.Random(0)`) for deterministic re-entry
- Warning logged when sampling fires
- `context_calculator.py` YAML snippet updated
- Both YAML files updated across all 6 profiles (Invariant 17)

## Test plan
- [x] `test_harmonize_samples_proposals_when_over_limit` — verifies cap applied in `harmonize_schema`
- [x] `test_harmonize_no_sample_when_under_limit` — verifies no sampling when under cap
- [x] `test_harmonize_for_merge_samples_proposals_when_over_limit` — verifies cap applied in `harmonize_schema_for_merge`
- [x] Full test suite passes (`1216 passed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)