### PR TITLE
Add LLM output-truncation and context-overflow detection (observability)

### DIFF
--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -323,7 +323,7 @@ def _claude_skills_dir() -> Path:
     """Return the user-level Claude Code skills folder.
 
     Resolution order:
-      1. ``$CLAUDE_CONFIG_DIR/skills`` — explicit override (graphify-style).
+      1. ``$CLAUDE_CONFIG_DIR/skills`` — explicit override.
       2. ``~/.claude/skills`` — macOS / Linux / Windows-Desktop default.
       3. ``%APPDATA%/Claude/skills`` — Windows fallback if it already exists
          on disk and ``~/.claude/skills`` does not (some Windows Claude Code
@@ -361,7 +361,7 @@ def _manual_copy_hint(source: Path, target: Path) -> str:
 def _install_agent_skill(*, force: bool = False) -> None:
     """Copy the bundled mykg skill into ~/.claude/skills/mykg.
 
-    Uses graphify v8's atomic install pattern: copy to ``<target>.tmp``, then
+    Uses an atomic install pattern: copy to ``<target>.tmp``, then
     ``os.replace`` over the final destination. A ``.mykg_skill_version`` stamp
     file is written next to the skill so a future ``mykg init`` invocation can
     detect a stale install (package upgraded but skill not refreshed).

--- a/src/mykg/llm/anthropic_adapter.py
+++ b/src/mykg/llm/anthropic_adapter.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import anthropic
 
 from mykg.llm.adapter import LLMAdapter
-from mykg.llm.retry import retry_on_rate_limit
+from mykg.llm.retry import looks_like_context_exceeded, retry_on_rate_limit
 from mykg.logging import record_llm_call
 
 if TYPE_CHECKING:
@@ -62,18 +62,37 @@ class AnthropicAdapter(LLMAdapter):
 
         def _call() -> str:
             t0 = time.monotonic()
-            message = self._client.messages.create(
-                model=self._model,
-                max_tokens=effective_max_tokens,
-                system=system,
-                messages=[{"role": "user", "content": user}],
-                timeout=effective_timeout,
-            )
+            try:
+                message = self._client.messages.create(
+                    model=self._model,
+                    max_tokens=effective_max_tokens,
+                    system=system,
+                    messages=[{"role": "user", "content": user}],
+                    timeout=effective_timeout,
+                )
+            except anthropic.APIStatusError as exc:
+                if looks_like_context_exceeded(exc):
+                    record_llm_call(
+                        provider="anthropic",
+                        model=self._model,
+                        context_label=context_label,
+                        input_tokens=0,
+                        output_tokens=0,
+                        duration_s=time.monotonic() - t0,
+                        system_prompt=system,
+                        user_prompt=user,
+                        error=f"context_length_exceeded: {exc}",
+                    )
+                raise
             raw = ""
             for block in message.content:
                 if hasattr(block, "text"):
                     raw = block.text
                     break
+            # Anthropic's stop_reason == "max_tokens" means output was truncated at
+            # the max_tokens cap — surfaced for diagnosability only (see Invariant 13:
+            # window/max_tokens sizing should prevent this in normal operation).
+            finish_reason = "max_tokens" if message.stop_reason == "max_tokens" else None
             record_llm_call(
                 provider="anthropic",
                 model=self._model,
@@ -84,6 +103,7 @@ class AnthropicAdapter(LLMAdapter):
                 raw_response=raw,
                 system_prompt=system,
                 user_prompt=user,
+                finish_reason=finish_reason,
             )
             return self.strip_code_fences(raw)
 

--- a/src/mykg/llm/ollama_adapter.py
+++ b/src/mykg/llm/ollama_adapter.py
@@ -7,7 +7,7 @@ import urllib.request
 from typing import TYPE_CHECKING
 
 from mykg.llm.adapter import LLMAdapter
-from mykg.llm.retry import retry_on_rate_limit
+from mykg.llm.retry import looks_like_context_exceeded, retry_on_rate_limit
 from mykg.logging import record_llm_call
 
 if TYPE_CHECKING:
@@ -78,6 +78,12 @@ class OllamaAdapter(LLMAdapter):
                 with urllib.request.urlopen(req, timeout=effective_timeout) as resp:
                     data = json.loads(resp.read())
                     raw = data.get("response", "")
+                    # done_reason == "length" means output was truncated at the
+                    # num_predict cap — surfaced for diagnosability only (see
+                    # Invariant 13: window/max_tokens sizing should prevent this in
+                    # normal operation).
+                    done_reason = data.get("done_reason")
+                    finish_reason = "length" if done_reason == "length" else None
                     record_llm_call(
                         provider="ollama",
                         model=self._model,
@@ -88,13 +94,38 @@ class OllamaAdapter(LLMAdapter):
                         raw_response=raw,
                         system_prompt=system,
                         user_prompt=user,
+                        finish_reason=finish_reason,
                     )
                     return self.strip_code_fences(raw)
             except urllib.error.HTTPError as exc:
                 if exc.code == 429:
                     raise
+                if looks_like_context_exceeded(exc):
+                    record_llm_call(
+                        provider="ollama",
+                        model=self._model,
+                        context_label=context_label,
+                        input_tokens=0,
+                        output_tokens=0,
+                        duration_s=time.monotonic() - t0,
+                        system_prompt=system,
+                        user_prompt=user,
+                        error=f"context_length_exceeded: {exc}",
+                    )
                 raise RuntimeError(f"Ollama request failed: {exc}") from exc
             except urllib.error.URLError as exc:
+                if looks_like_context_exceeded(exc):
+                    record_llm_call(
+                        provider="ollama",
+                        model=self._model,
+                        context_label=context_label,
+                        input_tokens=0,
+                        output_tokens=0,
+                        duration_s=time.monotonic() - t0,
+                        system_prompt=system,
+                        user_prompt=user,
+                        error=f"context_length_exceeded: {exc}",
+                    )
                 raise RuntimeError(f"Ollama request failed: {exc}") from exc
 
         return retry_on_rate_limit(  # type: ignore[return-value]

--- a/src/mykg/llm/openai_adapter.py
+++ b/src/mykg/llm/openai_adapter.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import openai
 
 from mykg.llm.adapter import LLMAdapter
-from mykg.llm.retry import retry_on_rate_limit
+from mykg.llm.retry import looks_like_context_exceeded, retry_on_rate_limit
 from mykg.logging import record_llm_call
 
 if TYPE_CHECKING:
@@ -129,9 +129,26 @@ class OpenAIAdapter(LLMAdapter):
                         use_completion_key=True,
                     )
                 else:
+                    if looks_like_context_exceeded(exc):
+                        record_llm_call(
+                            provider="openai",
+                            model=self._model,
+                            context_label=context_label,
+                            input_tokens=0,
+                            output_tokens=0,
+                            duration_s=time.monotonic() - t0,
+                            system_prompt=system,
+                            user_prompt=user,
+                            error=f"context_length_exceeded: {exc}",
+                        )
                     raise
             usage = resp.usage
             raw = resp.choices[0].message.content or "" if resp.choices else ""
+            # finish_reason == "length" means output was truncated at the token cap —
+            # surfaced for diagnosability only (see Invariant 13: window/max_tokens
+            # sizing should prevent this in normal operation).
+            choice_finish_reason = resp.choices[0].finish_reason if resp.choices else None
+            finish_reason = "length" if choice_finish_reason == "length" else None
             record_llm_call(
                 provider="openai",
                 model=self._model,
@@ -142,6 +159,7 @@ class OpenAIAdapter(LLMAdapter):
                 system_prompt=system,
                 user_prompt=user,
                 raw_response=raw,
+                finish_reason=finish_reason,
             )
             return self.strip_code_fences(raw)
 

--- a/src/mykg/llm/openrouter_adapter.py
+++ b/src/mykg/llm/openrouter_adapter.py
@@ -9,7 +9,7 @@ import httpx
 import openai
 
 from mykg.llm.adapter import LLMAdapter
-from mykg.llm.retry import retry_on_rate_limit
+from mykg.llm.retry import looks_like_context_exceeded, retry_on_rate_limit
 from mykg.logging import record_llm_call
 
 if TYPE_CHECKING:
@@ -72,7 +72,7 @@ class OpenRouterAdapter(LLMAdapter):
         def _call() -> str:
             t0 = time.monotonic()
 
-            def _do_request() -> tuple[str, object]:
+            def _do_request() -> tuple[str, object, str | None]:
                 resp = self._client.chat.completions.create(
                     model=self._model,
                     max_tokens=effective_max_tokens,
@@ -83,14 +83,16 @@ class OpenRouterAdapter(LLMAdapter):
                 )
                 usage = resp.usage
                 raw = resp.choices[0].message.content or "" if resp.choices else ""
-                return raw, usage
+                choice_finish_reason = resp.choices[0].finish_reason if resp.choices else None
+                finish_reason = "length" if choice_finish_reason == "length" else None
+                return raw, usage, finish_reason
 
             # Hard wall-clock deadline — prevents OpenRouter keep-alive bytes
             # from resetting the httpx read timeout indefinitely.
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
                 future = executor.submit(_do_request)
                 try:
-                    raw, usage = future.result(timeout=effective_timeout)
+                    raw, usage, finish_reason = future.result(timeout=effective_timeout)
                 except concurrent.futures.TimeoutError:
                     duration_s = time.monotonic() - t0
                     record_llm_call(
@@ -118,6 +120,7 @@ class OpenRouterAdapter(LLMAdapter):
                 raw_response=raw,
                 system_prompt=system,
                 user_prompt=user,
+                finish_reason=finish_reason,
             )
             return self.strip_code_fences(raw)
 
@@ -128,6 +131,9 @@ class OpenRouterAdapter(LLMAdapter):
                 raise  # handled by retry_on_rate_limit below
             except openai.APIStatusError as exc:
                 status = exc.status_code
+                error_msg = str(exc.message)
+                if looks_like_context_exceeded(exc):
+                    error_msg = f"context_length_exceeded: {error_msg}"
                 record_llm_call(
                     provider="openrouter",
                     model=self._model,
@@ -138,7 +144,7 @@ class OpenRouterAdapter(LLMAdapter):
                     system_prompt=system,
                     user_prompt=user,
                     status_code=status,
-                    error=str(exc.message),
+                    error=error_msg,
                 )
                 # Retry 5xx as transient; surface all others immediately.
                 if status >= 500:

--- a/src/mykg/llm/retry.py
+++ b/src/mykg/llm/retry.py
@@ -14,6 +14,37 @@ log = get("mykg.llm.retry")
 
 E = TypeVar("E", bound=BaseException)
 
+# Substrings seen across providers/SDKs when a prompt is rejected outright for not
+# fitting the model's context window (HTTP 400 from OpenAI, Ollama, vLLM, etc.).
+# There is no single exception type shared across SDKs for this, so detection is a
+# heuristic match on the stringified exception — observability only, this does not
+# drive a retry (see `looks_like_context_exceeded` callers).
+_CONTEXT_EXCEEDED_MARKERS = (
+    "context size",
+    "context length",
+    "context_length",
+    "context window",
+    "n_ctx",
+    "exceeds the available",
+    "maximum context",
+    "too many tokens",
+    "prompt is too long",
+    "context_length_exceeded",
+)
+
+
+def looks_like_context_exceeded(exc: BaseException) -> bool:
+    """Heuristically classify an exception as a context-window overflow.
+
+    Different backends raise different exception types/messages for the same
+    underlying problem (the prompt didn't fit the model's context window). This
+    matches on substrings of the stringified exception so callers can log a clear
+    diagnostic marker before re-raising, without depending on a specific SDK
+    exception class.
+    """
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _CONTEXT_EXCEEDED_MARKERS)
+
 
 def llm_complete_with_retry(
     adapter: LLMAdapter,

--- a/src/mykg/logging.py
+++ b/src/mykg/logging.py
@@ -132,6 +132,7 @@ def record_llm_call(
     user_prompt: str | None = None,
     status_code: int | None = None,
     error: str | None = None,
+    finish_reason: str | None = None,
 ) -> None:
     """Append one JSON line to llm.log. No-op if llm.log is not configured."""
     if _llm_handler is None:
@@ -166,6 +167,8 @@ def record_llm_call(
         entry["status_code"] = status_code
     if error is not None:
         entry["error"] = error
+    if finish_reason is not None:
+        entry["finish_reason"] = finish_reason
     line = json.dumps(entry) + "\n"
     record = logging.makeLogRecord({"msg": line, "levelno": logging.INFO})
     with _llm_log_lock:

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -1225,3 +1225,311 @@ def test_openrouter_live_call_respects_timeout():
     print(f"[live] tight timeout raised: {type(exc_info.value).__name__}: {exc_info.value}")
     # Accept any exception — the SDK raises openai.APITimeoutError or httpx.ReadTimeout
     assert exc_info.value is not None
+
+
+# ── finish_reason (truncation) detection ─────────────────────────────────────
+
+
+def test_anthropic_adapter_truncated_response_logs_finish_reason():
+    """stop_reason == 'max_tokens' is surfaced as finish_reason='max_tokens'."""
+    truncated_block = MagicMock()
+    truncated_block.text = "{ incomplete json"
+    truncated_response = MagicMock()
+    truncated_response.content = [truncated_block]
+    truncated_response.stop_reason = "max_tokens"
+
+    with (
+        patch("anthropic.Anthropic") as mock_cls,
+        patch("mykg.llm.anthropic_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.return_value = truncated_response
+
+        from mykg.llm.anthropic_adapter import AnthropicAdapter
+
+        adapter = AnthropicAdapter(
+            model="claude-sonnet-4-6", max_tokens=10, timeout=10, api_key="test-key"
+        )
+        adapter.complete("sys", "user")
+
+    assert mock_record.call_args.kwargs.get("finish_reason") == "max_tokens"
+
+
+def test_anthropic_adapter_normal_response_omits_finish_reason():
+    """stop_reason == 'end_turn' does not set finish_reason."""
+    ok_block = MagicMock()
+    ok_block.text = "{}"
+    ok_response = MagicMock()
+    ok_response.content = [ok_block]
+    ok_response.stop_reason = "end_turn"
+
+    with (
+        patch("anthropic.Anthropic") as mock_cls,
+        patch("mykg.llm.anthropic_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.return_value = ok_response
+
+        from mykg.llm.anthropic_adapter import AnthropicAdapter
+
+        adapter = AnthropicAdapter(
+            model="claude-sonnet-4-6", max_tokens=10, timeout=10, api_key="test-key"
+        )
+        adapter.complete("sys", "user")
+
+    assert mock_record.call_args.kwargs.get("finish_reason") is None
+
+
+def test_anthropic_adapter_context_exceeded_logs_and_reraises():
+    """A context-length-exceeded APIStatusError is logged with a marker and re-raised."""
+    import anthropic
+
+    api_err = anthropic.APIStatusError(
+        message="prompt is too long: 250000 tokens > 200000 maximum",
+        response=MagicMock(status_code=400, headers={}),
+        body={"error": {"message": "prompt is too long: 250000 tokens > 200000 maximum"}},
+    )
+
+    with (
+        patch("anthropic.Anthropic") as mock_cls,
+        patch("mykg.llm.anthropic_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.side_effect = api_err
+
+        from mykg.llm.anthropic_adapter import AnthropicAdapter
+
+        adapter = AnthropicAdapter(
+            model="claude-sonnet-4-6", max_tokens=10, timeout=10, api_key="test-key"
+        )
+        with pytest.raises(anthropic.APIStatusError):
+            adapter.complete("sys", "user")
+
+    call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
+    assert any(
+        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
+    )
+
+
+def test_openai_adapter_truncated_response_logs_finish_reason():
+    """finish_reason == 'length' is surfaced as finish_reason='length'."""
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = "{ incomplete"
+    mock_response.choices[0].finish_reason = "length"
+
+    with (
+        patch("openai.OpenAI") as mock_client_cls,
+        patch("mykg.llm.openai_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = mock_response
+
+        from mykg.llm.openai_adapter import OpenAIAdapter
+
+        adapter = OpenAIAdapter(model="gpt-4o", max_tokens=10, timeout=30, api_key="test-key")
+        adapter.complete("system prompt", "user prompt")
+
+    assert mock_record.call_args.kwargs.get("finish_reason") == "length"
+
+
+def test_openai_adapter_normal_response_omits_finish_reason():
+    """finish_reason == 'stop' does not set finish_reason."""
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = "hello"
+    mock_response.choices[0].finish_reason = "stop"
+
+    with (
+        patch("openai.OpenAI") as mock_client_cls,
+        patch("mykg.llm.openai_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = mock_response
+
+        from mykg.llm.openai_adapter import OpenAIAdapter
+
+        adapter = OpenAIAdapter(model="gpt-4o", max_tokens=10, timeout=30, api_key="test-key")
+        adapter.complete("system prompt", "user prompt")
+
+    assert mock_record.call_args.kwargs.get("finish_reason") is None
+
+
+def test_openai_adapter_context_exceeded_logs_and_reraises():
+    """A context-length-exceeded BadRequestError is logged with a marker and re-raised."""
+    import openai
+
+    api_err = openai.BadRequestError(
+        message="This model's maximum context length is 128000 tokens",
+        response=MagicMock(status_code=400, headers={}),
+        body={
+            "error": {
+                "message": "This model's maximum context length is 128000 tokens",
+            }
+        },
+    )
+
+    with (
+        patch("openai.OpenAI") as mock_cls,
+        patch("mykg.llm.openai_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = api_err
+
+        from mykg.llm.openai_adapter import OpenAIAdapter
+
+        adapter = OpenAIAdapter(model="gpt-4o", max_tokens=10, timeout=30, api_key="test-key")
+        with pytest.raises(openai.BadRequestError):
+            adapter.complete("sys", "user")
+
+    call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
+    assert any(
+        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
+    )
+
+
+def test_openrouter_adapter_truncated_response_logs_finish_reason():
+    """finish_reason == 'length' is surfaced as finish_reason='length'."""
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = "{ incomplete"
+    mock_response.choices[0].finish_reason = "length"
+
+    with (
+        patch("openai.OpenAI") as mock_client_cls,
+        patch("mykg.llm.openrouter_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = mock_response
+
+        from mykg.llm.openrouter_adapter import OpenRouterAdapter
+
+        adapter = OpenRouterAdapter(model="m", max_tokens=10, timeout=10, api_key="test-key")
+        adapter.complete("s", "u")
+
+    assert mock_record.call_args.kwargs.get("finish_reason") == "length"
+
+
+def test_openrouter_adapter_normal_response_omits_finish_reason():
+    """finish_reason == 'stop' does not set finish_reason."""
+    mock_response = MagicMock()
+    mock_response.choices[0].message.content = "hello"
+    mock_response.choices[0].finish_reason = "stop"
+
+    with (
+        patch("openai.OpenAI") as mock_client_cls,
+        patch("mykg.llm.openrouter_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = mock_response
+
+        from mykg.llm.openrouter_adapter import OpenRouterAdapter
+
+        adapter = OpenRouterAdapter(model="m", max_tokens=10, timeout=10, api_key="test-key")
+        adapter.complete("s", "u")
+
+    assert mock_record.call_args.kwargs.get("finish_reason") is None
+
+
+def test_openrouter_adapter_context_exceeded_marks_error():
+    """A context-length-exceeded 4xx APIStatusError gets the marker prefix on error."""
+    import openai
+
+    api_err = openai.APIStatusError(
+        message="maximum context length exceeded",
+        response=MagicMock(status_code=400, headers={}),
+        body={"error": {"message": "maximum context length exceeded"}},
+    )
+
+    with (
+        patch("openai.OpenAI") as mock_cls,
+        patch("mykg.llm.openrouter_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = api_err
+
+        from mykg.llm.openrouter_adapter import OpenRouterAdapter
+
+        adapter = OpenRouterAdapter(
+            model="m", max_tokens=10, timeout=10, api_key="test-key", retry_429_max=0
+        )
+        with pytest.raises(openai.APIStatusError):
+            adapter.complete("s", "u")
+
+    call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
+    assert any(
+        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
+    )
+
+
+def test_ollama_adapter_truncated_response_logs_finish_reason():
+    """done_reason == 'length' is surfaced as finish_reason='length'."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = json.dumps(
+        {"response": "trunc", "done_reason": "length"}
+    ).encode()
+
+    with (
+        patch("urllib.request.urlopen") as mock_urlopen,
+        patch("mykg.llm.ollama_adapter.record_llm_call") as mock_record,
+    ):
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        from mykg.llm.ollama_adapter import OllamaAdapter
+
+        adapter = OllamaAdapter(
+            model="gemma4:31b",
+            base_url="http://localhost:11434",
+            timeout=120,
+            stream=False,
+            max_tokens=10,
+            context_window=64000,
+        )
+        adapter.complete("system prompt", "user prompt")
+
+    assert mock_record.call_args.kwargs.get("finish_reason") == "length"
+
+
+def test_ollama_adapter_normal_response_omits_finish_reason():
+    """done_reason == 'stop' does not set finish_reason."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = json.dumps(
+        {"response": "hello", "done_reason": "stop"}
+    ).encode()
+
+    with (
+        patch("urllib.request.urlopen") as mock_urlopen,
+        patch("mykg.llm.ollama_adapter.record_llm_call") as mock_record,
+    ):
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        from mykg.llm.ollama_adapter import OllamaAdapter
+
+        adapter = OllamaAdapter(
+            model="gemma4:31b",
+            base_url="http://localhost:11434",
+            timeout=120,
+            stream=False,
+            max_tokens=10,
+            context_window=64000,
+        )
+        adapter.complete("system prompt", "user prompt")
+
+    assert mock_record.call_args.kwargs.get("finish_reason") is None
+
+
+def test_looks_like_context_exceeded_matches_known_markers():
+    """The shared heuristic matches common cross-provider context-overflow phrasing."""
+    from mykg.llm.retry import looks_like_context_exceeded
+
+    assert looks_like_context_exceeded(Exception("maximum context length is 128000 tokens"))
+    assert looks_like_context_exceeded(Exception("prompt is too long for this model"))
+    assert looks_like_context_exceeded(RuntimeError("n_ctx exceeded"))
+    assert not looks_like_context_exceeded(Exception("rate limit exceeded"))
+    assert not looks_like_context_exceeded(Exception("connection refused"))

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -1524,6 +1524,65 @@ def test_ollama_adapter_normal_response_omits_finish_reason():
     assert mock_record.call_args.kwargs.get("finish_reason") is None
 
 
+def test_ollama_adapter_context_exceeded_http_error_logs_and_reraises():
+    """A context-length-exceeded HTTPError is logged with a marker and re-raised."""
+    # looks_like_context_exceeded matches on str(exc), which for HTTPError is
+    # "HTTP Error <code>: <msg>" — the marker must be in msg, not the body.
+    exc = urllib.error.HTTPError(
+        url="http://localhost:11434/api/generate",
+        code=400,
+        msg="maximum context length exceeded",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=io.BytesIO(b""),
+    )
+
+    with (
+        patch("urllib.request.urlopen", side_effect=exc),
+        patch("mykg.llm.ollama_adapter.record_llm_call") as mock_record,
+    ):
+        adapter = _ollama_adapter(retry_max=0)
+        with pytest.raises(RuntimeError, match="Ollama request failed"):
+            adapter.complete("sys", "user")
+
+    call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
+    assert any(
+        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
+    )
+
+
+def test_ollama_adapter_context_exceeded_url_error_logs_and_reraises():
+    """A context-length-exceeded URLError is logged with a marker and re-raised."""
+    exc = urllib.error.URLError("maximum context length exceeded")
+
+    with (
+        patch("urllib.request.urlopen", side_effect=exc),
+        patch("mykg.llm.ollama_adapter.record_llm_call") as mock_record,
+    ):
+        adapter = _ollama_adapter(retry_max=0)
+        with pytest.raises(RuntimeError, match="Ollama request failed"):
+            adapter.complete("sys", "user")
+
+    call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
+    assert any(
+        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
+    )
+
+
+def test_ollama_adapter_non_context_url_error_not_logged():
+    """A plain URLError unrelated to context overflow does not get the marker."""
+    exc = urllib.error.URLError("connection refused")
+
+    with (
+        patch("urllib.request.urlopen", side_effect=exc),
+        patch("mykg.llm.ollama_adapter.record_llm_call") as mock_record,
+    ):
+        adapter = _ollama_adapter(retry_max=0)
+        with pytest.raises(RuntimeError, match="Ollama request failed"):
+            adapter.complete("sys", "user")
+
+    mock_record.assert_not_called()
+
+
 def test_looks_like_context_exceeded_matches_known_markers():
     """The shared heuristic matches common cross-provider context-overflow phrasing."""
     from mykg.llm.retry import looks_like_context_exceeded

--- a/tests/test_log_rotation.py
+++ b/tests/test_log_rotation.py
@@ -345,6 +345,39 @@ def test_record_llm_call_status_code_and_error_branches(tmp_path):
     assert '"error": "rate-limited"' in contents
 
 
+def test_record_llm_call_finish_reason_branch(tmp_path):
+    """record_llm_call adds finish_reason field only when provided."""
+    from unittest.mock import patch
+
+    import mykg.logging as mykg_logging
+
+    log_file = tmp_path / "run.log"
+    with patch("mykg.config.LOG_LLM_LOG", True):
+        mykg_logging.setup(log_file=log_file)
+
+    mykg_logging.record_llm_call(
+        provider="p",
+        model="m",
+        context_label="ctx-truncated",
+        input_tokens=0,
+        output_tokens=20,
+        duration_s=0.0,
+        finish_reason="max_tokens",
+    )
+    mykg_logging.record_llm_call(
+        provider="p",
+        model="m",
+        context_label="ctx-normal",
+        input_tokens=0,
+        output_tokens=5,
+        duration_s=0.0,
+    )
+    mykg_logging._llm_handler.flush()
+    lines = (tmp_path / "llm.log").read_text(encoding="utf-8").strip().splitlines()
+    assert '"finish_reason": "max_tokens"' in lines[0]
+    assert "finish_reason" not in lines[1]
+
+
 def test_record_llm_call_noop_when_handler_is_none(tmp_path):
     """record_llm_call short-circuits when LOG_LLM_LOG is False (no _llm_handler)."""
     from unittest.mock import patch


### PR DESCRIPTION
## Summary

- Adds `finish_reason` logging to `llm.log` for the Anthropic, OpenAI, OpenRouter, and Ollama adapters — surfaces `max_tokens`/`length` truncation (output hit the token cap) without changing any retry or chunking behavior.
- Adds a shared `looks_like_context_exceeded()` heuristic in `llm/retry.py` (ported from the `graphify` project's `_looks_like_context_exceeded`) and wires a catch-log-reraise wrapper into each adapter so a rejected over-long prompt (HTTP 400) is marked `context_length_exceeded:` in `llm.log` before the original exception propagates unchanged.
- Claude CLI adapter intentionally left untouched — no reliable native stop-reason field was found in its JSON envelope; documented as a known gap rather than guessed at.
- Drops two stale `graphify`-attribution comments in `cli.py` left over from an earlier reference implementation.

This is **observability only**: no change to `complete()`'s or `llm_complete_with_retry()`'s contracts, no new retry/bisection logic, `FailedChunkLog`/`failed_chunks.json` untouched. mykg's existing design (Invariant 13, config-sized windows) is meant to *prevent* overflow; this makes it possible to *confirm* that from the logs, or catch the rare case it isn't.

## Test plan

- [x] Full unit test suite passes (1223 passed, 6 deselected live-only tests)
- [x] 17 new unit tests covering: truncated response → `finish_reason` set, normal response → `finish_reason` absent, context-exceeded exception → logged + re-raised (all 4 adapters)
- [x] Live verification against real Anthropic/OpenAI/OpenRouter/Ollama backends:
  - Normal completions → `finish_reason` absent in all 4
  - Forced truncation (tiny `max_tokens`) → `finish_reason: "max_tokens"` (Anthropic) / `"length"` (OpenAI, OpenRouter, Ollama) in all 4
  - Forced context overflow (200k-token prompt) → hard-rejected + logged with marker on Anthropic and OpenAI; OpenRouter and Ollama don't hard-reject oversized prompts (silently truncate/accept instead) so signal 2 never fires there — expected provider behavior, not a gap in the detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)