### PR TITLE
Flush pass2 batch_chunks shards incrementally, enabling cancel/resume

### DIFF
--- a/src/mykg/pass2.py
+++ b/src/mykg/pass2.py
@@ -600,6 +600,15 @@ def run_pass2_batched(
     for fname, content in files.items():
         all_chunks.extend(chunk_file(fname, content))
 
+    # Exact target for "every chunk of this file has now appeared in a
+    # completed batch" — lets us finalize+flush a file's shard as soon as its
+    # last chunk resolves, rather than waiting for the entire corpus (#see
+    # incremental-shard-flush fix: a file's chunks can be scattered across
+    # many non-adjacent batches, so this is the only reliable completion signal).
+    total_chunks_per_file: dict[str, int] = {}
+    for c in all_chunks:
+        total_chunks_per_file[c.source_file] = total_chunks_per_file.get(c.source_file, 0) + 1
+
     batches = build_pass2_batches(all_chunks, batch_token_target, per_file=per_file)
     batch_map = make_batch_map(batches)
 
@@ -780,10 +789,42 @@ def run_pass2_batched(
             completed = [retry_by_idx.get(orig[0], orig) for orig in completed]
             completed.sort(key=lambda t: t[0])
 
+        # Tracks how many of each file's chunks have been merged so far, so a
+        # file can be finalized and flushed the moment its last chunk resolves
+        # — without waiting for every other file/batch in the corpus.
+        chunks_seen_per_file: dict[str, int] = {}
+        results: dict[str, dict] = {}
+
+        def _finalize_file(fname: str) -> None:
+            nodes = _dedup_within_file(file_nodes[fname])
+            surviving_ids = {n["id"] for n in nodes}
+            edges = [
+                e
+                for e in file_edges[fname]
+                if e.get("from") in surviving_ids and e.get("to") in surviving_ids
+            ]
+            log.info("  %s — total: %d node(s), %d edge(s)", fname, len(nodes), len(edges))
+            results[fname] = {"nodes": nodes, "edges": edges}
+            if on_file_done is not None:
+                on_file_done(fname, results[fname], chunk_node_index[fname])
+            # Drop the accumulator so the trailing fallback loop below doesn't
+            # re-finalize (and re-call on_file_done for) an already-flushed file.
+            del file_nodes[fname]
+            del file_edges[fname]
+
         for batch_idx, extraction, batch in completed:
             if extraction is None:
                 for chunk in batch:
                     failed_log.record(chunk.source_file, chunk.chunk_index + 1, "blank_response")
+                    chunks_seen_per_file[chunk.source_file] = (
+                        chunks_seen_per_file.get(chunk.source_file, 0) + 1
+                    )
+                for fname in {c.source_file for c in batch}:
+                    if (
+                        fname in file_nodes
+                        and chunks_seen_per_file.get(fname, 0) >= total_chunks_per_file[fname]
+                    ):
+                        _finalize_file(fname)
                 continue
 
             clean = _strip_nulls(extraction)
@@ -801,6 +842,7 @@ def run_pass2_batched(
                 chunk_node_index[fname][str(chunk_idx_1based)] = [
                     _name_slug(n) for n in batch_nodes
                 ]
+                chunks_seen_per_file[fname] = chunks_seen_per_file.get(fname, 0) + 1
 
             for fname in {c.source_file for c in batch}:
                 file_nodes[fname].extend(batch_nodes)
@@ -809,20 +851,24 @@ def run_pass2_batched(
                 if stateful:
                     prior_nodes_by_file[fname] = _dedup_within_file(file_nodes[fname])
 
-    # Finalize per-file results: dedup nodes and drop dangling edges.
-    results: dict[str, dict] = {}
-    for fname in files:
-        nodes = _dedup_within_file(file_nodes[fname])
-        surviving_ids = {n["id"] for n in nodes}
-        edges = [
-            e
-            for e in file_edges[fname]
-            if e.get("from") in surviving_ids and e.get("to") in surviving_ids
-        ]
-        log.info("  %s — total: %d node(s), %d edge(s)", fname, len(nodes), len(edges))
-        results[fname] = {"nodes": nodes, "edges": edges}
-        if on_file_done is not None:
-            on_file_done(fname, results[fname], chunk_node_index[fname])
+            # Every chunk this file has has now been accounted for — finalize
+            # and flush its shard immediately rather than waiting for the rest
+            # of the corpus (this is what makes cancel/resume possible: a
+            # crash after this point only loses batches still in flight).
+            for fname in {c.source_file for c in batch}:
+                if chunks_seen_per_file.get(fname, 0) >= total_chunks_per_file[fname]:
+                    _finalize_file(fname)
+
+    # Defensive fallback: finalize any file the incremental path above somehow
+    # missed (e.g. a file with zero chunks). Should never fire in practice —
+    # every file's chunk count is exact and every chunk is accounted for in
+    # the loop above, success or exhausted-retry-failure alike.
+    for fname in list(file_nodes):
+        log.warning(
+            "Pass 2 batched — %s was not finalized incrementally; finalizing as fallback",
+            fname,
+        )
+        _finalize_file(fname)
 
     failed_entries = failed_log.entries()
     return results, chunk_node_index, failed_entries, batch_map

--- a/tests/test_pass2_batch_incremental_shards.py
+++ b/tests/test_pass2_batch_incremental_shards.py
@@ -1,0 +1,205 @@
+"""Tests for incremental on_file_done flushing in run_pass2_batched.
+
+A file's chunks can land in many non-adjacent batches (build_pass2_batches does
+cross-file bin-packing by default), so on_file_done must fire as soon as every
+chunk belonging to a file has appeared in a completed (post-retry) batch —
+not only once, at the very end, after every batch in the whole corpus finishes.
+This is what makes cancel/resume for `pass2.prep_mode: batch_chunks` possible:
+a crash mid-run only loses batches still in flight, not everything computed
+so far.
+"""
+
+import unittest.mock as mock
+from unittest.mock import MagicMock
+
+import mykg.pass2 as p2_mod
+from mykg.pass2 import run_pass2_batched
+
+
+def test_on_file_done_fires_before_all_batches_complete():
+    """A file whose chunks all land in early batches gets on_file_done called
+    before the last batch (for a different, later file) has even resolved."""
+    files = {
+        "early.md": "# Early\nshort content about Alice",
+        "late.md": "# Late\nshort content about Bob",
+    }
+    schema = {"concepts": [], "properties": []}
+    flat = {}
+
+    # batch_token_target=1 with per_file=True forces one chunk per batch and
+    # file boundaries as hard split points, so "early.md" fully resolves in
+    # its own batch(es) before "late.md"'s batch is even dispatched in order —
+    # per_file=True also guarantees batches never mix files.
+    call_order: list[str] = []
+
+    def fake_extract(batch, *args, **kwargs):
+        call_order.append(batch[0].source_file)
+        return {"nodes": [], "edges": []}
+
+    on_file_done_calls: list[str] = []
+
+    def on_file_done(fname, result, file_idx):
+        on_file_done_calls.append(fname)
+
+    with mock.patch.object(p2_mod, "_extract_batch", side_effect=fake_extract):
+        run_pass2_batched(
+            files,
+            schema,
+            flat,
+            MagicMock(),
+            batch_token_target=1,
+            per_file=True,
+            max_workers=1,
+            on_file_done=on_file_done,
+        )
+
+    # Both files must have been finalized exactly once.
+    assert sorted(on_file_done_calls) == ["early.md", "late.md"]
+    assert len(on_file_done_calls) == 2
+    # "early.md" is finalized strictly before "late.md" — the incremental path
+    # does not wait for the whole corpus before flushing the first file.
+    assert on_file_done_calls.index("early.md") < on_file_done_calls.index("late.md")
+
+
+def test_on_file_done_not_called_twice_per_file():
+    """The trailing defensive fallback loop must not re-finalize an
+    already-flushed file (which would double-call on_file_done)."""
+    files = {"a.md": "# A\nsome content", "b.md": "# B\nmore content"}
+    schema = {"concepts": [], "properties": []}
+    flat = {}
+
+    def fake_extract(batch, *args, **kwargs):
+        return {"nodes": [], "edges": []}
+
+    on_file_done_calls: list[str] = []
+
+    def on_file_done(fname, result, file_idx):
+        on_file_done_calls.append(fname)
+
+    with mock.patch.object(p2_mod, "_extract_batch", side_effect=fake_extract):
+        run_pass2_batched(
+            files,
+            schema,
+            flat,
+            MagicMock(),
+            batch_token_target=100_000,  # everything packs into one batch
+            max_workers=1,
+            on_file_done=on_file_done,
+        )
+
+    assert on_file_done_calls.count("a.md") == 1
+    assert on_file_done_calls.count("b.md") == 1
+
+
+def test_on_file_done_waits_for_retry_to_resolve():
+    """A file's on_file_done must not fire after the first (failed) attempt —
+    only after the retry round resolves it, success or exhausted-failure."""
+    files = {"a.md": "# A\nsome content"}
+    schema = {"concepts": [], "properties": []}
+    flat = {}
+
+    extract_calls = []
+
+    def fail_once_then_succeed(batch, *args, **kwargs):
+        extract_calls.append(1)
+        if len(extract_calls) == 1:
+            raise RuntimeError("simulated transient failure")
+        return {"nodes": [], "edges": []}
+
+    on_file_done_calls: list[str] = []
+
+    def on_file_done(fname, result, file_idx):
+        on_file_done_calls.append(fname)
+
+    with mock.patch.object(p2_mod, "_extract_batch", side_effect=fail_once_then_succeed):
+        run_pass2_batched(
+            files,
+            schema,
+            flat,
+            MagicMock(),
+            batch_token_target=100_000,
+            batch_retry_max=1,
+            max_workers=1,
+            on_file_done=on_file_done,
+        )
+
+    # 1 initial failed attempt + 1 retry that succeeds.
+    assert len(extract_calls) == 2
+    # on_file_done fires exactly once, after the retry resolved it — not once
+    # per attempt.
+    assert on_file_done_calls == ["a.md"]
+
+
+def test_on_file_done_fires_after_exhausted_retries_too():
+    """A file whose batch never succeeds still gets finalized (with whatever
+    partial results exist) once retries are exhausted — not silently dropped."""
+    files = {"a.md": "# A\nsome content"}
+    schema = {"concepts": [], "properties": []}
+    flat = {}
+
+    def always_fail(batch, *args, **kwargs):
+        raise RuntimeError("always fails")
+
+    on_file_done_calls: list[str] = []
+
+    def on_file_done(fname, result, file_idx):
+        on_file_done_calls.append(fname)
+
+    with mock.patch.object(p2_mod, "_extract_batch", side_effect=always_fail):
+        run_pass2_batched(
+            files,
+            schema,
+            flat,
+            MagicMock(),
+            batch_token_target=100_000,
+            batch_retry_max=1,
+            max_workers=1,
+            on_file_done=on_file_done,
+        )
+
+    assert on_file_done_calls == ["a.md"]
+
+
+def test_shard_files_written_incrementally(tmp_path):
+    """End-to-end: intermediate_dir shard files (via a step_pass2-style
+    on_file_done) exist for a completed file even while other files in the
+    same corpus haven't finished yet."""
+    files = {
+        "early.md": "# Early\nshort content",
+        "late.md": "# Late\nshort content",
+    }
+    schema = {"concepts": [], "properties": []}
+    flat = {}
+
+    shard_dir = tmp_path / "raw_extractions_shards"
+    shard_dir.mkdir()
+
+    def fake_extract(batch, *args, **kwargs):
+        return {"nodes": [], "edges": []}
+
+    written_before_second_file_done: list[str] = []
+
+    def on_file_done(fname, result, file_idx):
+        (shard_dir / f"{fname.replace('.md', '')}.json").write_text("{}")
+        # Snapshot what's on disk at the moment THIS file is finalized.
+        written_before_second_file_done.append(
+            sorted(p.name for p in shard_dir.glob("*.json"))
+        )
+
+    with mock.patch.object(p2_mod, "_extract_batch", side_effect=fake_extract):
+        run_pass2_batched(
+            files,
+            schema,
+            flat,
+            MagicMock(),
+            batch_token_target=1,
+            per_file=True,
+            max_workers=1,
+            on_file_done=on_file_done,
+        )
+
+    # When "early.json" was finalized, "late.json" must not yet exist —
+    # proof that shards are written one file at a time, not all at once
+    # at the very end.
+    assert written_before_second_file_done[0] == ["early.json"]
+    assert written_before_second_file_done[1] == ["early.json", "late.json"]


### PR DESCRIPTION
## Summary

- `run_pass2_batched()` (`pass2.prep_mode: batch_chunks`) dispatched every batch in the corpus up front and only called `on_file_done` once, per file, in a single loop after every batch (including retries) had resolved. Because a file's chunks can be scattered across many non-adjacent batches (`build_pass2_batches` does cross-file bin-packing by default), no shard was ever written until 100% of the corpus finished.
- Confirmed on a real 3002-batch, ~40-hour extraction run: `raw_extractions_shards/`/`chunk_index_shards/` stayed completely empty at 5.9% progress. A crash/`Ctrl-C` mid-run lost every batch computed so far.
- `step_pass2.py` already resumes correctly from whatever shards exist (`existing_raw`/`skip`/`todo` filtering) — this logic is shared across all three prep modes and already worked for `per_file`/`concat`, which write shards incrementally. `batch_chunks` was the only mode missing this.
- Fix: a file is now finalized and its shard flushed the moment every one of its chunks has appeared in a completed (post-retry) batch, instead of waiting for the entire corpus. No changes to `step_pass2.py`, `pass2_batch.py`, retry-round mechanics, or any other prep mode.

**Confirmed CLI semantics (no code change needed, already correct):**
- Plain `mykg extract-graph <dir> --session <name>` (no `--from-step`) resumes from whatever shards survived a crash — now meaningfully possible for `batch_chunks` too.
- `mykg extract-graph <dir> --from-step pass2 --session <name>` still wipes `raw_extractions_shards/`/`chunk_index_shards/` and forces a full fresh re-extraction, exactly as before.

## Test plan

- [x] 5 new unit tests (`test_pass2_batch_incremental_shards.py`): `on_file_done` fires before all batches complete, not called twice per file, waits for retry to resolve (not on first failed attempt), fires after exhausted retries too, and an end-to-end shard-file proof that one file's shard exists on disk before a later file's does.
- [x] Full existing pass2 test suite (85 tests across `test_pass2*.py`/`test_step_pass2.py`) passes unchanged.
- [x] Full project suite: 1248 passed, 90% coverage, no regressions.
- [x] Live smoke test: real `extract-graph` run against `_input_files/` with `batch_chunks` mode and a small `batch_token_target` forcing 3 batches — completed cleanly, correct final node/edge counts, all shard files written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)