### PR TITLE
fix: skip retry+LLM feedback for precondition/usage errors

### DIFF
--- a/src/mykg/merge_run.py
+++ b/src/mykg/merge_run.py
@@ -125,7 +125,7 @@ def run_merge(ctx: MergeContext) -> None:
             state.save(ctx.intermediate_dir)
 
             try:
-                error = _try_run(step, ctx)
+                error, non_retryable = _try_run(step, ctx)
             except (KeyboardInterrupt, SystemExit) as exc:
                 state.mark_failed(step.name, repr(exc), attempts=1, llm_correction=False)
                 state.save(ctx.intermediate_dir)
@@ -205,21 +205,34 @@ def run_merge(ctx: MergeContext) -> None:
                 schema_restart_triggered = True
                 break  # restart the for-loop via the outer while
 
-            if error:
+            if error and non_retryable:
+                log.warning(
+                    "PRECONDITION FAILED %s — %s (skipping retry and LLM feedback; "
+                    "this is a usage/precondition error, not a transient or content error)",
+                    step.name,
+                    error,
+                )
+
+            if error and not non_retryable:
                 log.warning("RETRY %s — attempt 1 failed: %s", step.name, error)
-                error = _try_run(step, ctx)
+                error, non_retryable = _try_run(step, ctx)
 
             llm_correction = False
-            if error and step.is_llm_step:
+            if error and not non_retryable and step.is_llm_step:
                 log.warning("FEEDBACK %s — requesting LLM correction", step.name)
                 try:
                     llm_correction = feedback.apply(step.name, error, ctx)
                 except Exception as fb_exc:
                     log.warning("Feedback handler failed: %s", fb_exc)
-                error = _try_run(step, ctx)
+                error, non_retryable = _try_run(step, ctx)
 
             if error:
-                attempts = 3 if (step.is_llm_step and llm_correction) else 2
+                if non_retryable:
+                    attempts = 1
+                elif step.is_llm_step and llm_correction:
+                    attempts = 3
+                else:
+                    attempts = 2
                 state.mark_failed(
                     step.name, error, attempts=attempts, llm_correction=llm_correction
                 )

--- a/src/mykg/orchestrator.py
+++ b/src/mykg/orchestrator.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
+import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 if TYPE_CHECKING:
@@ -175,14 +176,26 @@ class PipelineState(BaseModel):
         return state
 
 
-def _try_run(step: Step, ctx: PipelineContext) -> str | None:
+def _try_run(step: Step, ctx: PipelineContext) -> tuple[str | None, bool]:
+    """Run one step, returning (error_message, non_retryable).
+
+    non_retryable is True when the failure is a click.ClickException — a
+    precondition/usage error raised deliberately by step code (e.g. "no
+    batch proposals found for --from-step merge_proposals"). These are not
+    LLM content errors, so retrying the step or asking the LLM feedback
+    handler to "fix" schema.json cannot resolve them and only wastes time
+    (or, if the feedback handler misfires on an unrelated error, can crash
+    with a masking exception of its own).
+    """
     try:
         step.fn(ctx)
-        return None
+        return None, False
     except SchemaUpdatedError:
         raise  # propagate; orchestrator handles restart
+    except click.ClickException as exc:
+        return str(exc.message if hasattr(exc, "message") else exc), True
     except Exception as exc:
-        return str(exc)
+        return str(exc), False
 
 
 def _log_advisory(step: Step, error: str, ctx: PipelineContext) -> None:
@@ -364,7 +377,7 @@ def run(steps: list[Step], ctx: PipelineContext) -> None:
             state.save(ctx.intermediate_dir)
 
             try:
-                error = _try_run(step, ctx)
+                error, non_retryable = _try_run(step, ctx)
             except (KeyboardInterrupt, SystemExit) as exc:
                 # Signal or Ctrl-C — save failure before the process exits so
                 # pipeline_state.json doesn't stay stuck as "running".
@@ -456,21 +469,34 @@ def run(steps: list[Step], ctx: PipelineContext) -> None:
                 schema_restart_triggered = True
                 break  # restart the for-loop via the outer while
 
-            if error:
+            if error and non_retryable:
+                log.warning(
+                    "PRECONDITION FAILED %s — %s (skipping retry and LLM feedback; "
+                    "this is a usage/precondition error, not a transient or content error)",
+                    step.name,
+                    error,
+                )
+
+            if error and not non_retryable:
                 log.warning("RETRY %s — attempt 1 failed: %s", step.name, error)
-                error = _try_run(step, ctx)
+                error, non_retryable = _try_run(step, ctx)
 
             llm_correction = False
-            if error and step.is_llm_step:
+            if error and not non_retryable and step.is_llm_step:
                 log.warning("FEEDBACK %s — requesting LLM correction", step.name)
                 try:
                     llm_correction = feedback.apply(step.name, error, ctx)
                 except Exception as fb_exc:
                     log.warning("Feedback handler failed: %s", fb_exc)
-                error = _try_run(step, ctx)
+                error, non_retryable = _try_run(step, ctx)
 
             if error:
-                attempts = 3 if (step.is_llm_step and llm_correction) else 2
+                if non_retryable:
+                    attempts = 1
+                elif step.is_llm_step and llm_correction:
+                    attempts = 3
+                else:
+                    attempts = 2
                 state.mark_failed(
                     step.name, error, attempts=attempts, llm_correction=llm_correction
                 )

--- a/src/mykg/schema_history.py
+++ b/src/mykg/schema_history.py
@@ -68,10 +68,10 @@ def write_schema(
         except (json.JSONDecodeError, OSError):
             pass
 
-    prev_concepts = {c["type"] for c in prev.get("concepts", [])}
-    prev_props = {p["name"] for p in prev.get("properties", [])}
-    curr_concepts = {c["type"] for c in schema.get("concepts", [])}
-    curr_props = {p["name"] for p in schema.get("properties", [])}
+    prev_concepts = {c["type"] for c in prev.get("concepts", []) if "type" in c}
+    prev_props = {p["name"] for p in prev.get("properties", []) if "name" in p}
+    curr_concepts = {c["type"] for c in schema.get("concepts", []) if "type" in c}
+    curr_props = {p["name"] for p in schema.get("properties", []) if "name" in p}
 
     concepts_added = sorted(curr_concepts - prev_concepts)
     concepts_removed = sorted(prev_concepts - curr_concepts)

--- a/tests/test_merge_run.py
+++ b/tests/test_merge_run.py
@@ -92,7 +92,7 @@ def test_run_merge_schema_restart_invalidates_outputs(tmp_path):
         call_count[0] += 1
         if call_count[0] == 1:
             raise _schema_updated_error()
-        return None
+        return None, False
 
     with (
         patch("mykg.merge_run._try_run", side_effect=side_effect),
@@ -123,7 +123,7 @@ def test_run_merge_schema_restart_regenerates_schema_ttl(tmp_path):
         call_count[0] += 1
         if call_count[0] == 1:
             raise _schema_updated_error(["new_prop"])
-        return None
+        return None, False
 
     fake_ttl = "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
 
@@ -151,7 +151,7 @@ def test_run_merge_schema_restart_removes_approval_flag(tmp_path):
         call_count[0] += 1
         if call_count[0] == 1:
             raise _schema_updated_error()
-        return None
+        return None, False
 
     with (
         patch("mykg.merge_run._try_run", side_effect=side_effect),
@@ -175,7 +175,7 @@ def test_run_merge_schema_restart_clears_runtime_fields(tmp_path):
         call_count[0] += 1
         if call_count[0] == 1:
             raise _schema_updated_error()
-        return None
+        return None, False
 
     captured = {}
 
@@ -217,7 +217,7 @@ def test_run_merge_schema_restart_resets_step_states_to_pending(tmp_path):
             state_path = ctx_arg.intermediate_dir / "pipeline_state.json"
             if state_path.exists():
                 state_at_restart.update(json.loads(state_path.read_text()).get("steps", {}))
-        return None
+        return None, False
 
     with (
         patch("mykg.merge_run._try_run", side_effect=side_effect),
@@ -247,7 +247,7 @@ def test_run_merge_schema_restart_increments_restart_count(tmp_path):
         if call_count[0] == 1:
             raise _schema_updated_error()
         restart_counts_seen.append(ctx_arg.schema_restart_count)
-        return None
+        return None, False
 
     with (
         patch("mykg.merge_run._try_run", side_effect=side_effect),
@@ -290,7 +290,7 @@ def test_run_merge_sets_schema_hints_on_restart(tmp_path):
             raise schema_exc
         if not captured_hints and ctx_arg.schema_hints:
             captured_hints.extend(ctx_arg.schema_hints)
-        return None
+        return None, False
 
     with (
         patch("mykg.merge_run._try_run", side_effect=side_effect),
@@ -325,7 +325,7 @@ def test_run_merge_schema_restart_limit_reached_continues(tmp_path):
         call_count[0] += 1
         if call_count[0] == 1:
             raise _schema_updated_error()
-        return None
+        return None, False
 
     # Should not raise; the limit-exceeded branch logs a warning and continues
     with (
@@ -371,7 +371,7 @@ def test_run_merge_halt_error_raised_on_blocking_step_failure(tmp_path):
 
     # Always return an error string (simulates step failure on every attempt)
     with (
-        patch("mykg.merge_run._try_run", return_value="simulated failure"),
+        patch("mykg.merge_run._try_run", return_value=("simulated failure", False)),
         patch("mykg.merge_run._is_done", return_value=False),
         patch("mykg.merge_run.log"),
     ):
@@ -391,7 +391,7 @@ def test_run_merge_log_advisory_called_on_step_failure(tmp_path):
     ctx = _make_ctx(tmp_path)
 
     with (
-        patch("mykg.merge_run._try_run", return_value="oops"),
+        patch("mykg.merge_run._try_run", return_value=("oops", False)),
         patch("mykg.merge_run._is_done", return_value=False),
         patch("mykg.merge_run._log_merge_advisory") as mock_advisory,
         patch("mykg.merge_run.log"),
@@ -420,8 +420,8 @@ def test_run_merge_non_blocking_step_continues_after_failure(tmp_path):
 
     def try_run_side_effect(step, ctx_arg):
         if step.name == target_step_name:
-            return "non-blocking failure"
-        return None
+            return "non-blocking failure", False
+        return None, False
 
     with (
         patch("mykg.merge_run._try_run", side_effect=try_run_side_effect),
@@ -448,7 +448,7 @@ def test_run_merge_waits_at_human_review_when_review_enabled(tmp_path):
 
     def try_run_side_effect(step, ctx_arg):
         seen_steps.append(step.name)
-        return None
+        return None, False
 
     # human_review step is the only one with requires_review_flag=True
     with (
@@ -480,8 +480,8 @@ def test_run_merge_feedback_path_triggered_on_llm_step_failure(tmp_path):
 
     def try_run_side_effect(step, ctx_arg):
         if step.name == llm_step_name:
-            return f"simulated {step.name} error"
-        return None
+            return f"simulated {step.name} error", False
+        return None, False
 
     with (
         patch("mykg.merge_run._try_run", side_effect=try_run_side_effect),
@@ -510,8 +510,8 @@ def test_run_merge_feedback_handler_exception_logged_not_raised(tmp_path):
 
     def try_run_side_effect(step, ctx_arg):
         if step.name == llm_step_name:
-            return f"simulated {step.name} error"
-        return None
+            return f"simulated {step.name} error", False
+        return None, False
 
     with (
         patch("mykg.merge_run._try_run", side_effect=try_run_side_effect),

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -169,6 +169,57 @@ def test_run_retries_on_failure(tmp_path):
     assert call_counts["n"] == 2
 
 
+def test_run_does_not_retry_click_exception(tmp_path):
+    """A click.ClickException (precondition/usage error) fails immediately —
+    no second attempt, since retrying cannot fix a missing-precondition error."""
+    import click
+
+    call_counts = {"n": 0}
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True, exist_ok=True)
+
+    def bad_precondition(c):
+        call_counts["n"] += 1
+        raise click.ClickException("no batch proposals found")
+
+    steps = [Step(name="bad", fn=bad_precondition, outputs=["x.json"], blocking=True)]
+    with pytest.raises(PipelineHaltError) as exc_info:
+        run(steps, ctx)
+    assert call_counts["n"] == 1
+    assert "no batch proposals found" in str(exc_info.value)
+
+
+def test_run_skips_feedback_on_click_exception(tmp_path, monkeypatch):
+    """A click.ClickException on an is_llm_step=True step must not invoke
+    feedback.apply — the error is a usage/precondition failure, not
+    LLM-fixable schema content, and asking the LLM to "correct" it wastes
+    time or can produce a nonsensical schema edit."""
+    import click
+
+    import mykg.feedback as feedback
+
+    feedback_called = {"called": False}
+
+    def fake_apply(step_name, error, ctx):
+        feedback_called["called"] = True
+        return False
+
+    monkeypatch.setattr(feedback, "apply", fake_apply)
+
+    ctx = _make_ctx(tmp_path)
+    ctx.intermediate_dir.mkdir(parents=True, exist_ok=True)
+
+    def bad_precondition(c):
+        raise click.ClickException("no batch proposals found")
+
+    steps = [
+        Step(name="pass1", fn=bad_precondition, outputs=["x.json"], is_llm_step=True, blocking=True)
+    ]
+    with pytest.raises(PipelineHaltError):
+        run(steps, ctx)
+    assert feedback_called["called"] is False
+
+
 def test_run_halts_on_blocking_failure(tmp_path):
     ctx = _make_ctx(tmp_path)
     ctx.intermediate_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_schema_history.py
+++ b/tests/test_schema_history.py
@@ -55,6 +55,30 @@ def test_write_schema_no_diff_still_writes_delta(tmp_path: Path) -> None:
     assert second["properties_total"] == 0
 
 
+def test_write_schema_handles_concept_missing_type_key(tmp_path: Path) -> None:
+    """A malformed concept/property dict missing 'type'/'name' (e.g. from a bad
+    LLM feedback correction) must not raise KeyError — it is skipped from the
+    delta diff rather than crashing the write."""
+    schema = {
+        "concepts": [
+            {"type": "Person", "parent": None, "attributes": ["name"]},
+            {"parent": None, "attributes": ["bad"]},  # missing "type"
+        ],
+        "properties": [
+            {"name": "works_at", "domain": "Person", "range": "Organization"},
+            {"domain": "Person", "range": "Organization"},  # missing "name"
+        ],
+    }
+    write_schema(schema, tmp_path, TRIGGER_PASS1_MERGE)
+
+    schema_path = tmp_path / "schema.json"
+    assert schema_path.exists()
+    deltas = sorted((tmp_path / "schema_history").glob("*.json"))
+    delta = json.loads(deltas[0].read_text())
+    assert "Person" in delta["concepts_added"]
+    assert "works_at" in delta["properties_added"]
+
+
 def test_write_schema_handles_corrupt_previous_schema(tmp_path: Path) -> None:
     """If the existing schema.json is invalid JSON, write_schema still proceeds (lines 67-68)."""
     # Pre-create a corrupt schema.json


### PR DESCRIPTION
## Summary
- The orchestrator's per-step retry + LLM feedback loop (D31 Two-Tier Correction Model) was treating `click.ClickException` precondition/usage errors identically to real transient/content extraction errors — e.g. running `--from-step merge_proposals` on a session that predates the Pass 1 batch-persistence feature (no `pass1_batch_proposals/`) triggered a wasted second attempt and an LLM "schema fix" call for an error that has nothing to do with schema content.
- In one observed run this even crashed with a masking `KeyError: 'type'` inside `schema_history.write_schema` when the feedback LLM's unrelated "correction" returned malformed schema JSON.
- `_try_run()` in both `orchestrator.py` and `merge_run.py` (which share this retry pattern) now returns `(error, non_retryable)`; a `click.ClickException` sets `non_retryable=True` and the main loop skips straight to `PipelineHaltError`, bypassing the second attempt and `feedback.apply()` entirely.
- Hardened `schema_history.write_schema()` to skip (not crash on) concept/property dicts missing `type`/`name` keys, as defense-in-depth.

## Test plan
- [x] Added `test_run_does_not_retry_click_exception` and `test_run_skips_feedback_on_click_exception` to `tests/test_orchestrator.py`
- [x] Added `test_write_schema_handles_concept_missing_type_key` to `tests/test_schema_history.py`
- [x] Updated all `_try_run` mocks in `tests/test_merge_run.py` to the new tuple contract
- [x] Full suite: `1266 passed` (`pytest tests/ -m "not live"`)
- [x] `ruff check` clean on all modified files
- [x] Live smoke test: real `extract-graph` run to completion, then simulated a pre-v0.3.20 session by deleting `pass1_batch_proposals/`/`pass1_batch_selection.json`, then ran `--from-step merge_proposals` — confirmed immediate `PRECONDITION FAILED` log with no retry/feedback lines and no wasted LLM call (previously took ~30s and risked a masking crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)