### PR TITLE
Add GitHub Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pages/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: pages
+
+      - name: Build with Jekyll
+        working-directory: pages
+        run: bundle exec jekyll build --source . --destination ../_site
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          publish_branch: gh-pages

--- a/pages/Gemfile
+++ b/pages/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+# Swap for whatever theme was chosen in pages/_config.yml's `theme:` key.
+gem "jekyll-theme-minimal"
+
+gem "jekyll", "~> 4.3"
+
+# Needed for Ruby 3.3+ / newer Jekyll — webrick was removed from stdlib.
+gem "webrick", "~> 1.8"

--- a/pages/_config.yml
+++ b/pages/_config.yml
@@ -1,0 +1,4 @@
+title: myKG
+description: AI workflow that turns documents into a confidence-scored knowledge graph with an induced RDFS/OWL ontology
+theme: jekyll-theme-minimal
+show_downloads: false

--- a/pages/assets/mykg-logo-text.svg
+++ b/pages/assets/mykg-logo-text.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 120" width="400" height="120">
+  <defs>
+    <linearGradient id="nodeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#8b5cf6"/>
+    </linearGradient>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06b6d4"/>
+      <stop offset="100%" style="stop-color:#6366f1"/>
+    </linearGradient>
+  </defs>
+
+  <!-- ── Graph motif ── -->
+  <line x1="28" y1="55" x2="58" y2="26" stroke="#6366f1" stroke-width="1.8" stroke-opacity="0.7"/>
+  <line x1="28" y1="55" x2="58" y2="84" stroke="#6366f1" stroke-width="1.8" stroke-opacity="0.7"/>
+  <line x1="58" y1="26" x2="88" y2="55" stroke="#06b6d4" stroke-width="1.8" stroke-opacity="0.7"/>
+  <line x1="58" y1="84" x2="88" y2="55" stroke="#06b6d4" stroke-width="1.8" stroke-opacity="0.7"/>
+  <line x1="58" y1="26" x2="58" y2="84" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.4" stroke-dasharray="3,3"/>
+
+  <circle cx="28" cy="55" r="9" fill="url(#nodeGrad)"/>
+  <circle cx="58" cy="26" r="7" fill="url(#accentGrad)"/>
+  <circle cx="58" cy="84" r="7" fill="url(#accentGrad)"/>
+  <circle cx="88" cy="55" r="9" fill="url(#nodeGrad)"/>
+
+  <!-- ── Wordmark ── -->
+  <text x="108" y="70"
+        font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+        font-size="42"
+        font-weight="700"
+        letter-spacing="-1"
+        fill="#1e1b4b">my</text>
+  <text x="164" y="70"
+        font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+        font-size="42"
+        font-weight="700"
+        letter-spacing="-1"
+        fill="url(#nodeGrad)">KG</text>
+
+  <!-- ── Tagline — smaller spacing to fit ── -->
+  <text x="109" y="92"
+        font-family="'Segoe UI', system-ui, -apple-system, sans-serif"
+        font-size="10.5"
+        font-weight="400"
+        fill="#6366f1"
+        opacity="0.85"
+        letter-spacing="1">KNOWLEDGE GRAPH EXTRACTOR</text>
+</svg>

--- a/pages/blog.md
+++ b/pages/blog.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Blog
+---
+
+# Blog
+
+Coming soon — walkthroughs and case studies on building and using myKG.
+
+In the meantime, see [Articles & Tutorials in the README](https://github.com/SenolIsci/mykg#articles--tutorials) for existing write-ups on Medium.
+
+<ul>
+{% for post in site.posts %}
+  <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a> — {{ post.date | date: "%B %-d, %Y" }}</li>
+{% endfor %}
+</ul>

--- a/pages/index.md
+++ b/pages/index.md
@@ -13,7 +13,7 @@ title: Home
 
 It runs as a two-pass LLM pipeline: **Pass 1** induces a global schema (concept types and relationship properties) from your document corpus; **Pass 2** extracts typed entities and relationships per file against that schema. Every attribute, node, and edge carries a confidence score, so you always know how much to trust what was extracted.
 
-[View on GitHub](https://github.com/SenolIsci/mykg) · [PyPI](https://pypi.org/project/mykg/) · [Blog](blog.html)
+[View on GitHub](https://github.com/SenolIsci/mykg) · [PyPI](https://pypi.org/project/mykg/) · [Blog]({{ '/blog.html' | relative_url }})
 
 ## Why myKG
 
@@ -37,4 +37,4 @@ See the [README](https://github.com/SenolIsci/mykg#readme) for the full command 
 
 ## Learn more
 
-Read walkthroughs and case studies on the [blog](blog.html), or dig into the [source on GitHub](https://github.com/SenolIsci/mykg).
+Read walkthroughs and case studies on the [blog]({{ '/blog.html' | relative_url }}), or dig into the [source on GitHub](https://github.com/SenolIsci/mykg).

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: Home
+---
+
+<p align="center">
+  <img src="assets/mykg-logo-text.svg" width="360" alt="myKG">
+</p>
+
+# Turn your documents into a knowledge graph
+
+**myKG** automatically generates a confidence-scored knowledge graph from a set of mixed documents — Markdown, plain text, PDF, Word, PowerPoint, Excel, HTML, and images — grounded in an induced RDFS/OWL ontology.
+
+It runs as a two-pass LLM pipeline: **Pass 1** induces a global schema (concept types and relationship properties) from your document corpus; **Pass 2** extracts typed entities and relationships per file against that schema. Every attribute, node, and edge carries a confidence score, so you always know how much to trust what was extracted.
+
+[View on GitHub](https://github.com/SenolIsci/mykg) · [PyPI](https://pypi.org/project/mykg/) · [Blog](blog.html)
+
+## Why myKG
+
+- **Schema-guided extraction** — the graph is always grounded in a formal, inspectable RDFS/OWL schema before any entity is extracted, not a black box
+- **Bring your own ontology** — lock in classes and properties from an existing formal ontology and let the LLM extend it, or freeze it entirely
+- **Five output formats** — JSONL for Neo4j/NetworkX/RAG, Turtle RDF for OWL toolchains, NetworkX multi-format exports, an Obsidian vault of wikilinked notes, and a Neo4j LOAD CSV bundle
+- **Second brain for AI coding assistants** — point Claude Code, Cursor, or Copilot at the generated Obsidian vault (or the MCP server) and get answers grounded in your own documents
+- **Resumable, incremental, provider-agnostic** — every stage persists intermediate state; append new documents without re-processing everything; works with Anthropic, OpenAI, Ollama, OpenRouter, or the `claude` CLI
+
+## Quick start
+
+```bash
+pip install mykg
+mykg init
+mykg extract-graph my_notes/
+```
+
+Open `mykg_sessions/<timestamp>/output/knowledge_graph.html` in your browser to explore the result.
+
+See the [README](https://github.com/SenolIsci/mykg#readme) for the full command reference, configuration options, and pipeline internals.
+
+## Learn more
+
+Read walkthroughs and case studies on the [blog](blog.html), or dig into the [source on GitHub](https://github.com/SenolIsci/mykg).


### PR DESCRIPTION
## Summary
- New `pages/` folder: landing page (`index.md`, adapted from README), blog scaffold (`blog.md` + empty `_posts/`), Jekyll config/Gemfile (`jekyll-theme-minimal`), and the logo asset copied from `docs/`
- New `.github/workflows/pages.yml`: on push to `main` (when `pages/**` changes), builds the site with Jekyll and force-pushes the output to `gh-pages` via `peaceiris/actions-gh-pages@v4`

**Note:** this workflow requires `permissions: contents: write` so the Action can push to `gh-pages`.

## Test plan
- [ ] Merge to `main` and watch the `Pages` workflow run (`gh run watch`)
- [ ] Confirm `gh-pages` branch is created with built `_site/` output
- [ ] Enable Pages in repo settings (source = `gh-pages` branch) — will do via `gh api repos/SenolIsci/mykg/pages` after merge
- [ ] Visit https://senolisci.github.io/mykg/ once the first build completes

## Summary by Sourcery

Add a GitHub Pages Jekyll site and CI workflow for building and deploying it to the gh-pages branch.

New Features:
- Introduce a Jekyll-based landing page and blog scaffold under the new pages/ directory for the project website.

CI:
- Add a GitHub Actions workflow to build the Jekyll site and publish the generated _site output to the gh-pages branch on pushes to main.