### PR TITLE
docs: document mykg query terminal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ mykg extract-graph my_notes/
 | [`mykg parse-docs`](#standalone-document-conversion-mykg-parse-docs) | Standalone MinerU/markdownify document-to-Markdown conversion |
 | [`mykg fetch-web`](#website--repo-fetching-mykg-fetch-web) | Crawl a website or clone a GitHub repo into an `extract-graph`-ready folder |
 | [`mykg mcp-serve`](#mcp-model-context-protocol-server) | Start the MCP server exposing read-only graph query tools |
+| [`mykg query "<question>"`](#terminal-query-mykg-query) | Query the knowledge graph from the terminal — BFS/DFS traversal from seed nodes matching your question; mirrors the MCP query tool |
 
 ```
 mykg extract-graph my_notes/        # any directory: .md, .txt, .pdf, .docx, .html, images
@@ -980,6 +981,38 @@ The MCP server exposes 14 tools: `mykg_search_nodes`, `mykg_get_node`, `mykg_get
 ```
 
 To default to streamable HTTP, change `transport: streamable_http` in your active profile. CLI flags (`--transport`, `--host`, `--port`) override the config.
+
+### Terminal query (`mykg query`)
+
+```
+mykg query "<question>" [--session NAME] [--mode bfs|dfs] [--depth N] [--token-budget N]
+```
+
+Query the knowledge graph directly from the shell — no MCP server required. `mykg query` finds up to 3 seed nodes matching your question by name, alias, or attribute value, traverses outward through the graph to a bounded depth, and prints a text context window of the visited nodes and the relationships between them. It is the terminal-callable equivalent of the MCP `mykg_query_graph` tool, and it is read-only: it operates on the latest completed session unless `--session` is passed.
+
+- `question` (positional, required) — the free-text query.
+- `--session NAME` — session under `mykg_sessions/`; defaults to the latest completed session (newest dir with `output/nodes.jsonl`).
+- `--mode bfs|dfs` — traversal strategy (default `bfs`).
+- `--depth N` — traversal depth limit (default `2`).
+- `--token-budget N` — approximate token budget bounding the returned context (default `2000`).
+
+```bash
+mykg query "who is Alice" --depth 2
+```
+
+```
+# Knowledge Graph Context: who is Alice
+Seeds: <ids> | Mode: bfs | Depth: 2
+Nodes visited: N | Edges found: M
+
+## Nodes
+- [Type] Name (node-id) conf=0.95 (attr=val, ...)
+
+## Relationships
+- from-id --[edge_type]--> to-id (conf=0.90)
+```
+
+If nothing matches, it prints `No nodes found matching '<question>'. Try mykg_search_nodes for more flexible search.` and exits 0.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the new `mykg query "<question>"` terminal command — the read-only, terminal-callable equivalent of the MCP `mykg_query_graph` tool. Docs-only; no code changes.

## Changes to `README.md`

- **Command-reference table** — new `mykg query` row next to `mcp-serve`, linking to the new subsection anchor.
- **New subsection `### Terminal query (\`mykg query\`)`** — placed adjacent to the MCP Server section (its natural home as the CLI twin of the MCP query tool). Includes:
  - the synopsis line
  - a 2–3 sentence description (finds up to 3 seed nodes by name/alias/attribute, traverses to bounded depth, prints a text context window; read-only; latest completed session unless `--session`)
  - the four flags with defaults: `--session`, `--mode bfs|dfs` (default `bfs`), `--depth` (default `2`), `--token-budget` (default `2000`)
  - a worked example (`mykg query "who is Alice" --depth 2`)
  - the sample output-shape block
  - the no-match message

`docs/agent-mode.md` was checked but does not enumerate CLI subcommands as a list/table, so it was left untouched per the unit instructions. The "13/14 query tools" MCP count lines were intentionally not modified.

## Consistency check

- The four flag names and defaults match the specified command surface.
- The anchor `#terminal-query-mykg-query` resolves to the created `### Terminal query (\`mykg query\`)` heading (follows the repo's existing anchor convention, verified against the `parse-docs` row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the new `mykg query` terminal command as a read-only graph query interface callable from the shell.

Documentation:
- Add `mykg query "<question>"` to the CLI command reference table alongside existing subcommands.
- Introduce a dedicated "Terminal query (mykg query)" section describing usage, flags, example invocation, output format, and no-match behavior.

Relates to #53