### PR TITLE
test: add tests for `mykg query` command and query_graph core

### DIFF
--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -1,0 +1,195 @@
+"""Tests for the `mykg query` terminal command and its core `query_graph`.
+
+Mirrors the synthetic-session fixture style of ``tests/test_mcp_server.py``.
+
+Independent-mergeability guard: this file may land before the sibling unit that
+adds ``src/mykg/query.py`` and the ``query`` CLI command. The query-dependent
+tests are skipped (not failed) until those exist, so this file is green either
+way.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from click.testing import CliRunner
+
+from mykg.cli import cli
+
+# ---------------------------------------------------------------------------
+# Independent-mergeability guard
+# ---------------------------------------------------------------------------
+
+try:
+    from mykg.query import build_query_graph, query_graph  # noqa: F401
+
+    _QUERY_AVAILABLE = True
+except Exception:  # pragma: no cover - exercised only pre-sibling-merge
+    build_query_graph = None  # type: ignore[assignment]
+    query_graph = None  # type: ignore[assignment]
+    _QUERY_AVAILABLE = False
+
+_QUERY_CMD_REGISTERED = "query" in cli.commands
+
+requires_query = pytest.mark.skipif(
+    not _QUERY_AVAILABLE, reason="mykg.query not present yet"
+)
+requires_query_cmd = pytest.mark.skipif(
+    not (_QUERY_AVAILABLE and _QUERY_CMD_REGISTERED),
+    reason="mykg query CLI command not registered yet",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic session data
+# ---------------------------------------------------------------------------
+
+SCHEMA = {
+    "concepts": [
+        {"type": "Person", "parent": None, "attributes": ["name", "email"]},
+        {"type": "Organization", "parent": None, "attributes": ["name", "industry"]},
+    ],
+    "properties": [
+        {
+            "name": "works_at",
+            "domain": "Person",
+            "range": "Organization",
+            "attributes": ["role"],
+        },
+    ],
+}
+
+NODES = [
+    {
+        "id": "person-alice",
+        "type": "Person",
+        "confidence": 0.95,
+        "attributes": {
+            "name": {"value": "Alice Smith", "confidence": 0.99},
+            "email": {"value": "alice@example.com", "confidence": 0.85},
+        },
+        "source_files": ["team.md"],
+        "aliases": ["A. Smith"],
+    },
+    {
+        "id": "org-acme",
+        "type": "Organization",
+        "confidence": 0.98,
+        "attributes": {
+            "name": {"value": "Acme Corp", "confidence": 1.0},
+            "industry": {"value": "Technology", "confidence": 0.9},
+        },
+        "source_files": ["partners.md"],
+        "aliases": ["ACME"],
+    },
+]
+
+EDGES = [
+    {
+        "id": "edge-001",
+        "type": "works_at",
+        "from": "person-alice",
+        "to": "org-acme",
+        "confidence": 0.92,
+        "attributes": {"role": {"value": "Engineer", "confidence": 0.88}},
+    },
+]
+
+
+def _write_session(sessions_root: Path, name: str) -> Path:
+    """Build a tmp session dir with nodes/edges/schema. Returns the session root."""
+    session_root = sessions_root / name
+    output = session_root / "output"
+    output.mkdir(parents=True)
+    intermediate = session_root / "intermediate"
+    intermediate.mkdir(parents=True)
+
+    (output / "nodes.jsonl").write_text(
+        "\n".join(json.dumps(n, ensure_ascii=False) for n in NODES),
+        encoding="utf-8",
+    )
+    (output / "edges.jsonl").write_text(
+        "\n".join(json.dumps(e, ensure_ascii=False) for e in EDGES),
+        encoding="utf-8",
+    )
+    (intermediate / "schema.json").write_text(
+        json.dumps(SCHEMA, ensure_ascii=False), encoding="utf-8"
+    )
+    return session_root
+
+
+@pytest.fixture
+def sessions_root(tmp_path: Path) -> Path:
+    return tmp_path / "mykg_sessions"
+
+
+@pytest.fixture
+def session_name() -> str:
+    return "test-session"
+
+
+@pytest.fixture
+def session_root(sessions_root: Path, session_name: str) -> Path:
+    return _write_session(sessions_root, session_name)
+
+
+# ---------------------------------------------------------------------------
+# 1. Core test — build_query_graph + query_graph
+# ---------------------------------------------------------------------------
+
+
+@requires_query
+def test_query_graph_core(session_root: Path):
+    qg = build_query_graph(session_root)
+    out = query_graph(qg, "Alice")
+    assert "# Knowledge Graph Context" in out
+    assert "Alice" in out
+    assert "## Nodes" in out
+    assert "## Relationships" in out
+
+
+# ---------------------------------------------------------------------------
+# 2. CLI parity test — byte-for-byte with the core function
+# ---------------------------------------------------------------------------
+
+
+@requires_query_cmd
+def test_query_cli_parity(
+    session_root: Path, sessions_root: Path, session_name: str, monkeypatch
+):
+    monkeypatch.setattr("mykg.cli._sessions_root", lambda: sessions_root)
+
+    qg = build_query_graph(session_root)
+    expected = query_graph(qg, "Alice")
+
+    result = CliRunner().invoke(
+        cli, ["query", "Alice", "--session", session_name]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.rstrip("\n") == expected.rstrip("\n")
+
+
+# ---------------------------------------------------------------------------
+# 3. No-match test — core + CLI
+# ---------------------------------------------------------------------------
+
+
+@requires_query
+def test_query_graph_no_match(session_root: Path):
+    out = query_graph(build_query_graph(session_root), "zzznotathing")
+    assert out.startswith("No nodes found matching")
+
+
+@requires_query_cmd
+def test_query_cli_no_match(
+    session_root: Path, sessions_root: Path, session_name: str, monkeypatch
+):
+    monkeypatch.setattr("mykg.cli._sessions_root", lambda: sessions_root)
+
+    result = CliRunner().invoke(
+        cli, ["query", "zzznotathing", "--session", session_name]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("No nodes found matching")


### PR DESCRIPTION
## Summary
Adds `tests/test_cli_query.py` for the new `mykg query "<question>"` terminal command (which replicates the MCP `mykg_query_graph` tool: BFS/DFS traversal → text context window).

Does **not** touch `src/mykg/mcp_server.py`, `src/mykg/query.py`, or `src/mykg/cli.py` — this unit only adds the test file.

## Tests added
- **Core** — `build_query_graph(session_root)` + `query_graph(qg, "Alice")` produce a block containing `# Knowledge Graph Context`, `Alice`, `## Nodes`, `## Relationships`.
- **CLI parity** — `mykg query Alice --session <name>` output is byte-for-byte identical to the core `query_graph(...)` call (session resolution monkeypatched via `mykg.cli._sessions_root`).
- **No-match** — both core and CLI return a string starting with `No nodes found matching` for a non-matching question.

## Fixture
Mirrors `tests/test_mcp_server.py`: writes `output/nodes.jsonl`, `output/edges.jsonl`, `intermediate/schema.json` (the exact layout `load_session` requires) into a tmp session — `person-alice` (Person, "Alice Smith"), `org-acme` (Organization, "Acme Corp"), and a `works_at` edge alice→acme. All writes use `encoding="utf-8"` and `json.dumps(..., ensure_ascii=False)` (Invariant 20).

## Independent mergeability
`src/mykg/query.py` and the `query` CLI command belong to a sibling unit not yet merged. The query-dependent tests are guarded by a `_QUERY_AVAILABLE` flag (+ command-registered check) and `@pytest.mark.skipif`, so `pytest tests/test_cli_query.py` is green as skips before the sibling lands and runs for real once it does.

## Verification
- Without sibling: `4 skipped`.
- Against a contract-conforming stub of `query.py` + `query` command: `4 passed`.
- `tests/test_mcp_server.py`: `50 passed`, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add tests for the `mykg query` core functions and CLI command using a synthetic knowledge graph session fixture, with skip guards to remain mergeable before the query feature lands.

Tests:
- Add core tests ensuring `build_query_graph` and `query_graph` produce the expected knowledge graph context output for a matching query.
- Add CLI tests verifying `mykg query` output matches the core `query_graph` result and handles no-match queries consistently.
- Introduce synthetic session fixtures that write schema, nodes, and edges files to a temporary session directory for query-related tests.
- Guard query-dependent tests with skip conditions so the suite passes as skips when the query module or CLI command are not yet available.

Relates to #53