### PR TITLE
Add terminal-callable `mykg query` mirroring the MCP query tool

### DIFF
--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -1909,6 +1909,46 @@ def _mcp_pid_path() -> Path:
     return d / "mcp-serve.pid"
 
 
+def _resolve_session_root(session: str | None) -> Path:
+    """Resolve a session root from --session (named dir) or the newest completed session.
+
+    Raises click.ClickException with a specific message when no sessions dir,
+    no completed sessions, or the chosen session lacks output/nodes.jsonl.
+    """
+    sessions_root = _sessions_root()
+
+    if session:
+        session_root = sessions_root / session
+    else:
+        if not sessions_root.exists():
+            raise click.ClickException(
+                f"No sessions directory at {sessions_root}. "
+                "Run 'mykg extract-graph <dir>' first."
+            )
+        entries = sorted(
+            [
+                d for d in sessions_root.iterdir()
+                if d.is_dir() and (d / "output" / "nodes.jsonl").exists()
+            ],
+            key=lambda d: d.name,
+        )
+        if not entries:
+            raise click.ClickException(
+                f"No completed sessions found under {sessions_root}. "
+                "Run 'mykg extract-graph <dir>' first."
+            )
+        session_root = entries[-1]
+
+    nodes_path = session_root / "output" / "nodes.jsonl"
+    if not nodes_path.exists():
+        raise click.ClickException(
+            f"Session '{session_root.name}' has no output/nodes.jsonl. "
+            "Is the extraction complete?"
+        )
+
+    return session_root
+
+
 @cli.command("mcp-serve")
 @click.option("--session", default=None, help="Session name under mykg_sessions/; defaults to latest.")
 @click.option(
@@ -1953,36 +1993,7 @@ def mcp_serve(session, transport, host, port, stop):
             "under your active profile, then re-run."
         )
 
-    sessions_root = _sessions_root()
-
-    if session:
-        session_root = sessions_root / session
-    else:
-        if not sessions_root.exists():
-            raise click.ClickException(
-                f"No sessions directory at {sessions_root}. "
-                "Run 'mykg extract-graph <dir>' first."
-            )
-        entries = sorted(
-            [
-                d for d in sessions_root.iterdir()
-                if d.is_dir() and (d / "output" / "nodes.jsonl").exists()
-            ],
-            key=lambda d: d.name,
-        )
-        if not entries:
-            raise click.ClickException(
-                f"No completed sessions found under {sessions_root}. "
-                "Run 'mykg extract-graph <dir>' first."
-            )
-        session_root = entries[-1]
-
-    nodes_path = session_root / "output" / "nodes.jsonl"
-    if not nodes_path.exists():
-        raise click.ClickException(
-            f"Session '{session_root.name}' has no output/nodes.jsonl. "
-            "Is the extraction complete?"
-        )
+    session_root = _resolve_session_root(session)
 
     transport = transport or getattr(cfg, "MCP_TRANSPORT", "stdio")
     host = host or getattr(cfg, "MCP_HOST", "localhost")
@@ -2002,6 +2013,20 @@ def mcp_serve(session, transport, host, port, stop):
         run_server(session_root, transport=transport, host=host, port=port)
     finally:
         pid_path.unlink(missing_ok=True)
+
+
+@cli.command("query")
+@click.argument("question")
+@click.option("--session", default=None, help="Session name under mykg_sessions/; defaults to latest.")
+@click.option("--mode", type=click.Choice(["bfs", "dfs"]), default="bfs", help="Traversal mode.")
+@click.option("--depth", default=2, type=int, help="Traversal depth limit.")
+@click.option("--token-budget", "token_budget", default=2000, type=int, help="Approx token budget for the returned context.")
+def query(question, session, mode, depth, token_budget):
+    """Query the knowledge graph from the terminal (mirrors the MCP query tool)."""
+    session_root = _resolve_session_root(session)
+    from mykg.query import build_query_graph, query_graph
+    qg = build_query_graph(session_root)
+    click.echo(query_graph(qg, question, mode=mode, depth=depth, token_budget=token_budget))
 
 
 def main():

--- a/src/mykg/query.py
+++ b/src/mykg/query.py
@@ -1,0 +1,167 @@
+"""Terminal-callable knowledge-graph query, mirroring the MCP query tool.
+
+This module replicates the algorithm of ``mykg_query_graph`` in
+``src/mykg/mcp_server.py`` (the MCP tool named "query") so it can be driven
+from the terminal via ``mykg query`` without importing or modifying the MCP
+server. The MCP file is left untouched per an explicit user constraint; the
+logic below is a byte-for-byte-compatible copy of the traversal, scoring, and
+text formatting, using only MCP-free primitives.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import networkx as nx
+
+from mykg.exporters.neo4j._common import load_session
+from mykg.exporter import _build_nx_graph
+
+
+def _node_name(node: dict) -> str:
+    attrs = node.get("attributes") or {}
+    name_attr = attrs.get("name")
+    if isinstance(name_attr, dict):
+        return name_attr.get("value") or ""
+    return str(name_attr) if name_attr else ""
+
+
+@dataclass
+class QueryGraph:
+    """In-memory index bundle for the terminal query path.
+
+    Holds only the parts of the MCP ``KnowledgeGraph`` that the query
+    traversal reads.
+    """
+
+    nodes: list[dict] = field(default_factory=list)
+    nodes_by_id: dict[str, dict] = field(default_factory=dict)
+    name_index: list[tuple[str, str, str]] = field(default_factory=list)
+    edges_by_node: dict[str, list[dict]] = field(default_factory=dict)
+    graph: nx.DiGraph = field(default_factory=nx.DiGraph)
+
+
+def build_query_graph(session_root: Path) -> QueryGraph:
+    """Load a session and build the indexes the query traversal needs."""
+    nodes, edges, _schema = load_session(session_root)
+    edge_metadata = {e["id"]: e for e in edges}
+    graph = _build_nx_graph(nodes, edge_metadata)
+
+    qg = QueryGraph(nodes=nodes, graph=graph)
+
+    for node in nodes:
+        nid = node["id"]
+        qg.nodes_by_id[nid] = node
+
+        name_val = _node_name(node)
+        if name_val:
+            qg.name_index.append((name_val.lower(), nid, name_val))
+
+        for alias in node.get("aliases") or []:
+            qg.name_index.append((alias.lower(), nid, alias))
+
+    for edge in edges:
+        qg.edges_by_node.setdefault(edge["from"], []).append(edge)
+        qg.edges_by_node.setdefault(edge["to"], []).append(edge)
+
+    return qg
+
+
+def query_graph(
+    qg: QueryGraph,
+    question: str,
+    mode: str = "bfs",
+    depth: int = 2,
+    token_budget: int = 2000,
+) -> str:
+    """Search the knowledge graph using BFS or DFS traversal from seed nodes.
+
+    Finds seed nodes matching the question, traverses outward, and returns a
+    text context window of relevant nodes and edges. This is a line-for-line
+    copy of ``mykg_query_graph``'s body (MCP tool), retargeted at ``qg``.
+    """
+    query_lower = question.lower()
+
+    scored: list[tuple[int, str]] = []
+    for name_lower, nid, _original in qg.name_index:
+        if name_lower == query_lower:
+            scored.append((100, nid))
+        elif query_lower in name_lower or name_lower in query_lower:
+            scored.append((60, nid))
+
+    for node in qg.nodes:
+        nid = node["id"]
+        if any(nid == s[1] for s in scored):
+            continue
+        for _attr_name, attr_val in (node.get("attributes") or {}).items():
+            val = attr_val.get("value") if isinstance(attr_val, dict) else attr_val
+            if val and isinstance(val, str) and query_lower in val.lower():
+                scored.append((40, nid))
+                break
+
+    scored.sort(key=lambda x: -x[0])
+    seeds = list(dict.fromkeys(s[1] for s in scored[:3]))
+
+    if not seeds:
+        return f"No nodes found matching '{question}'. Try mykg_search_nodes for more flexible search."
+
+    undirected = qg.graph.to_undirected()
+    visited: set[str] = set()
+    traversal_edges: list[tuple[str, str, dict]] = []
+
+    traverse = nx.dfs_edges if mode == "dfs" else nx.bfs_edges
+    for seed in seeds:
+        if seed not in undirected:
+            continue
+        for u, v in traverse(undirected, source=seed, depth_limit=depth):
+            visited.add(u)
+            visited.add(v)
+            for e in qg.edges_by_node.get(u, []):
+                if (e["from"] == u and e["to"] == v) or (e["from"] == v and e["to"] == u):
+                    traversal_edges.append((e["from"], e["to"], e))
+                    break
+    visited.update(seeds)
+
+    lines: list[str] = []
+    lines.append(f"# Knowledge Graph Context: {question}")
+    lines.append(f"Seeds: {', '.join(seeds)} | Mode: {mode} | Depth: {depth}")
+    lines.append(f"Nodes visited: {len(visited)} | Edges found: {len(traversal_edges)}")
+    lines.append("")
+
+    lines.append("## Nodes")
+    budget_chars = token_budget * 4
+    for nid in visited:
+        node = qg.nodes_by_id.get(nid)
+        if not node:
+            continue
+        name = _node_name(node)
+        ntype = node.get("type", "")
+        conf = node.get("confidence", 0.0)
+        attrs = []
+        for attr_name, attr_val in (node.get("attributes") or {}).items():
+            val = attr_val.get("value") if isinstance(attr_val, dict) else attr_val
+            if val and attr_name != "name":
+                attrs.append(f"{attr_name}={val}")
+        attr_str = f" ({', '.join(attrs)})" if attrs else ""
+        lines.append(f"- [{ntype}] {name} ({nid}) conf={conf:.2f}{attr_str}")
+        if sum(len(l) for l in lines) > budget_chars:
+            lines.append("... (truncated to fit token budget)")
+            break
+
+    if sum(len(l) for l in lines) < budget_chars:
+        lines.append("")
+        lines.append("## Relationships")
+        seen_edges: set[str] = set()
+        for src, dst, edge in traversal_edges:
+            eid = edge.get("id", f"{src}-{dst}")
+            if eid in seen_edges:
+                continue
+            seen_edges.add(eid)
+            etype = edge.get("type", "")
+            conf = edge.get("confidence", 0.0)
+            lines.append(f"- {src} --[{etype}]--> {dst} (conf={conf:.2f})")
+            if sum(len(l) for l in lines) > budget_chars:
+                lines.append("... (truncated to fit token budget)")
+                break
+
+    return "\n".join(lines)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,189 @@
+"""Tests for the terminal query path (src/mykg/query.py) and its parity with
+the MCP ``mykg_query_graph`` tool, plus the ``mykg query`` CLI command.
+
+The terminal query is a replication of the MCP tool (mcp_server.py is
+read-only). These tests lock in that the two produce byte-for-byte identical
+output for the same session data.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from mykg.query import QueryGraph, build_query_graph, query_graph
+
+
+SCHEMA = {
+    "concepts": [
+        {"type": "Person", "attributes": ["name", "email"], "parent": None},
+        {"type": "Organization", "attributes": ["name", "industry"], "parent": None},
+    ],
+    "properties": [
+        {"name": "works_at", "domain": "Person", "range": "Organization",
+         "attributes": ["role"]},
+    ],
+}
+
+NODES = [
+    {
+        "id": "person-alice",
+        "type": "Person",
+        "confidence": 0.95,
+        "attributes": {
+            "name": {"value": "Alice", "confidence": 1.0},
+            "email": {"value": "alice@acme.com", "confidence": 0.9},
+        },
+        "aliases": ["Ally"],
+        "source_files": ["team.md"],
+    },
+    {
+        "id": "organization-acme",
+        "type": "Organization",
+        "confidence": 0.9,
+        "attributes": {
+            "name": {"value": "Acme Corp", "confidence": 1.0},
+            "industry": {"value": "Tech", "confidence": 0.8},
+        },
+        "source_files": ["team.md"],
+    },
+]
+
+EDGES = [
+    {
+        "id": "edge-001",
+        "type": "works_at",
+        "from": "person-alice",
+        "to": "organization-acme",
+        "confidence": 0.96,
+        "attributes": {"role": {"value": "engineer", "confidence": 0.91}},
+        "source_files": ["team.md"],
+    },
+]
+
+
+@pytest.fixture
+def session_dir(tmp_path: Path) -> Path:
+    output = tmp_path / "output"
+    output.mkdir()
+    intermediate = tmp_path / "intermediate"
+    intermediate.mkdir()
+    (output / "nodes.jsonl").write_text(
+        "\n".join(json.dumps(n) for n in NODES), encoding="utf-8"
+    )
+    (output / "edges.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in EDGES), encoding="utf-8"
+    )
+    (intermediate / "schema.json").write_text(json.dumps(SCHEMA), encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def qg(session_dir: Path) -> QueryGraph:
+    return build_query_graph(session_dir)
+
+
+class TestBuildQueryGraph:
+    def test_indexes_built(self, qg: QueryGraph):
+        assert set(qg.nodes_by_id) == {"person-alice", "organization-acme"}
+        # name + alias both indexed
+        names = {entry[0] for entry in qg.name_index}
+        assert "alice" in names
+        assert "ally" in names  # alias, lowercased
+        assert "acme corp" in names
+        # edges_by_node indexed on both endpoints
+        assert any(e["id"] == "edge-001" for e in qg.edges_by_node["person-alice"])
+        assert any(e["id"] == "edge-001" for e in qg.edges_by_node["organization-acme"])
+
+
+class TestQueryGraph:
+    def test_exact_name_seed_and_format(self, qg: QueryGraph):
+        out = query_graph(qg, "Alice", mode="bfs", depth=2)
+        assert out.startswith("# Knowledge Graph Context: Alice")
+        assert "Seeds: person-alice | Mode: bfs | Depth: 2" in out
+        assert "## Nodes" in out
+        assert "## Relationships" in out
+        assert "- [Person] Alice (person-alice) conf=0.95 (email=alice@acme.com)" in out
+        assert "- person-alice --[works_at]--> organization-acme (conf=0.96)" in out
+
+    def test_alias_resolves(self, qg: QueryGraph):
+        out = query_graph(qg, "Ally")
+        assert "Seeds: person-alice" in out
+
+    def test_no_match(self, qg: QueryGraph):
+        out = query_graph(qg, "zzz-nomatch")
+        assert out == (
+            "No nodes found matching 'zzz-nomatch'. "
+            "Try mykg_search_nodes for more flexible search."
+        )
+
+    def test_dfs_mode(self, qg: QueryGraph):
+        out = query_graph(qg, "Alice", mode="dfs", depth=1)
+        assert "Mode: dfs | Depth: 1" in out
+
+
+def _invoke_mcp_tool(session_dir: Path, question: str, **kwargs) -> str:
+    """Invoke the real MCP mykg_query_graph tool via its underlying .fn."""
+    from mykg.mcp_server import KnowledgeGraph, mcp
+
+    kg = KnowledgeGraph(session_root=session_dir)
+    lifespan_ctx = SimpleNamespace(kg=kg)
+    request_ctx = SimpleNamespace(lifespan_context=lifespan_ctx)
+    ctx = SimpleNamespace(request_context=request_ctx)
+
+    tool = next(t for t in mcp._tool_manager.list_tools() if t.name == "mykg_query_graph")
+    return asyncio.run(tool.fn(question=question, ctx=ctx, **kwargs))
+
+
+class TestParityWithMCP:
+    @pytest.mark.parametrize(
+        "question,kwargs",
+        [
+            ("Alice", {}),
+            ("Alice", {"mode": "dfs", "depth": 1}),
+            ("Acme", {"depth": 2}),
+            ("Ally", {}),
+            ("zzz-nomatch", {}),
+            ("alice@acme.com", {}),  # attribute-value (score 40) match
+            ("Alice", {"token_budget": 1}),  # truncation path
+        ],
+    )
+    def test_terminal_matches_mcp(self, session_dir: Path, question: str, kwargs: dict):
+        qg = build_query_graph(session_dir)
+        terminal_out = query_graph(qg, question, **kwargs)
+        mcp_out = _invoke_mcp_tool(session_dir, question, **kwargs)
+        assert terminal_out == mcp_out
+
+
+class TestQueryCLI:
+    def test_query_command(self, session_dir: Path, monkeypatch, tmp_path: Path):
+        import mykg.cli as cli_mod
+        import mykg.config as cfg_mod
+
+        sessions_root = tmp_path / "sessions"
+        (sessions_root / "synth").mkdir(parents=True)
+        # move the synthetic session under sessions_root/synth
+        import shutil
+        shutil.copytree(session_dir / "output", sessions_root / "synth" / "output")
+        shutil.copytree(session_dir / "intermediate", sessions_root / "synth" / "intermediate")
+
+        monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(sessions_root))
+
+        runner = CliRunner()
+        result = runner.invoke(cli_mod.cli, ["query", "Alice", "--session", "synth"])
+        assert result.exit_code == 0, result.output
+        assert result.output.startswith("# Knowledge Graph Context: Alice")
+
+    def test_query_no_sessions(self, monkeypatch, tmp_path: Path):
+        import mykg.cli as cli_mod
+        import mykg.config as cfg_mod
+
+        monkeypatch.setattr(cfg_mod, "SESSIONS_DIR", str(tmp_path / "nope"))
+        runner = CliRunner()
+        result = runner.invoke(cli_mod.cli, ["query", "Alice"])
+        assert result.exit_code != 0
+        assert "No sessions directory" in result.output


### PR DESCRIPTION
## Summary
Adds a `mykg query` terminal command that does *exactly what the MCP `mykg_query_graph` tool does* — BFS/DFS graph traversal from seed nodes, returning a text context window. The MCP server (`src/mykg/mcp_server.py`) is **untouched** per the read-only constraint; the algorithm is replicated into a new MCP-free module.

## Changes
- **`src/mykg/query.py` (new)** — MCP-free replication of `mykg_query_graph`:
  - `QueryGraph` dataclass (in-memory index bundle: `nodes`, `nodes_by_id`, `name_index`, `edges_by_node`, `graph`).
  - `build_query_graph(session_root)` — loads via `load_session`, builds the nx graph via `_build_nx_graph`, and constructs the name/alias/edge indexes exactly as `KnowledgeGraph._build_indexes` does for the query path.
  - `query_graph(qg, question, mode, depth, token_budget)` — line-for-line copy of the MCP tool body: identical scoring (100 exact / 60 substring / 40 attribute-value), `seeds[:3]`, `nx.bfs_edges`/`nx.dfs_edges` traversal, text formatting, and `token_budget * 4` char truncation.
  - `_node_name` copied verbatim.
- **`src/mykg/cli.py`**:
  - Extracted the session-resolution block out of `mcp-serve` into a shared `_resolve_session_root(session)` helper (same ClickException messages) — **no behaviour change** to `mcp-serve`.
  - Added the `query` command (`--session`/`--mode`/`--depth`/`--token-budget`).

## Tests
`tests/test_query.py` (14 tests): index build, query paths (exact/alias/no-match/dfs), the CLI command + error path, and **7 parametrized parity cases** asserting terminal output is byte-for-byte identical to the real MCP tool over the same session data.

Full suite: 1303 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a terminal-accessible knowledge graph query that mirrors the MCP query tool while reusing shared session resolution in the CLI.

New Features:
- Add a `mykg query` CLI command to run BFS/DFS knowledge graph queries from the terminal with configurable depth and token budget.
- Provide a standalone `QueryGraph` module that loads session data and performs MCP-equivalent graph traversal and context generation without depending on the MCP server.

Enhancements:
- Refactor session root resolution in the CLI into a shared helper reused by both `mcp-serve` and `query` to keep session selection behaviour consistent.

Tests:
- Add tests for the new query module indexes and traversal behaviour, including edge cases and truncation paths.
- Add parity tests to ensure terminal queries produce byte-for-byte identical output to the MCP `mykg_query_graph` tool for the same session data.
- Add CLI tests for the `mykg query` command, covering successful queries and error handling when no sessions are available.

Closes #53