### PR TITLE
feat(llm): enable Anthropic prompt caching on the API adapter

### DIFF
--- a/src/mykg/llm/anthropic_adapter.py
+++ b/src/mykg/llm/anthropic_adapter.py
@@ -74,6 +74,10 @@ class AnthropicAdapter(LLMAdapter):
                     system=system,
                     messages=[{"role": "user", "content": user}],
                     timeout=effective_timeout,
+                    # Top-level auto-caching: caches the last cacheable block (the
+                    # run-stable system prompt) so repeated Pass-2 chunk calls in a
+                    # run pay ~0.1x cache reads instead of full-price re-processing.
+                    cache_control={"type": "ephemeral"},
                 )
             except anthropic.APIStatusError as exc:
                 if looks_like_context_exceeded(exc):
@@ -101,13 +105,18 @@ class AnthropicAdapter(LLMAdapter):
             finish_reason = "max_tokens" if message.stop_reason == "max_tokens" else None
             if finish_reason is not None:
                 log_truncated_output("anthropic", self._model, context_label, finish_reason)
+            usage = message.usage
+            cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
+            cache_create = getattr(usage, "cache_creation_input_tokens", 0) or 0
             record_llm_call(
                 provider="anthropic",
                 model=self._model,
                 context_label=context_label,
-                input_tokens=message.usage.input_tokens,
-                output_tokens=message.usage.output_tokens,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
                 duration_s=time.monotonic() - t0,
+                cache_read_tokens=cache_read,
+                cache_creation_tokens=cache_create,
                 raw_response=raw,
                 system_prompt=system,
                 user_prompt=user,

--- a/src/mykg/llm/anthropic_adapter.py
+++ b/src/mykg/llm/anthropic_adapter.py
@@ -105,15 +105,20 @@ class AnthropicAdapter(LLMAdapter):
             finish_reason = "max_tokens" if message.stop_reason == "max_tokens" else None
             if finish_reason is not None:
                 log_truncated_output("anthropic", self._model, context_label, finish_reason)
-            usage = message.usage
+            # usage is present on every successful response, but guard against a
+            # None/missing usage so a malformed response can't turn into an
+            # AttributeError here (all four counts fall back to 0).
+            usage = getattr(message, "usage", None)
+            input_tokens = getattr(usage, "input_tokens", 0) or 0
+            output_tokens = getattr(usage, "output_tokens", 0) or 0
             cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
             cache_create = getattr(usage, "cache_creation_input_tokens", 0) or 0
             record_llm_call(
                 provider="anthropic",
                 model=self._model,
                 context_label=context_label,
-                input_tokens=usage.input_tokens,
-                output_tokens=usage.output_tokens,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
                 duration_s=time.monotonic() - t0,
                 cache_read_tokens=cache_read,
                 cache_creation_tokens=cache_create,

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -1910,3 +1910,107 @@ def test_ollama_context_overflow_url_error_warns_on_standard_logger(caplog):
             adapter.complete("sys", "user")
 
     assert any("context length exceeded" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# AnthropicAdapter — prompt caching
+# ---------------------------------------------------------------------------
+
+
+class _Usage:
+    """Minimal usage object with only the attributes the response carries.
+
+    Using a plain class (not MagicMock) lets a test omit the cache attributes
+    entirely so the adapter's getattr(..., 0) default path is exercised.
+    """
+
+    def __init__(self, input_tokens=10, output_tokens=5, **extra):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        for k, v in extra.items():
+            setattr(self, k, v)
+
+
+def _anthropic_response(text="{}", usage=None):
+    block = MagicMock()
+    block.text = text
+    resp = MagicMock()
+    resp.content = [block]
+    resp.stop_reason = "end_turn"
+    resp.usage = usage if usage is not None else _Usage()
+    return resp
+
+
+def test_anthropic_adapter_sends_cache_control():
+    """complete() passes top-level cache_control={'type': 'ephemeral'} to messages.create."""
+    with (
+        patch("anthropic.Anthropic") as mock_cls,
+        patch("mykg.llm.anthropic_adapter.record_llm_call"),
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _anthropic_response()
+
+        from mykg.llm.anthropic_adapter import AnthropicAdapter
+
+        adapter = AnthropicAdapter(
+            model="claude-sonnet-4-6", max_tokens=10, timeout=10, api_key="test-key"
+        )
+        adapter.complete("system prompt", "user prompt")
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs.get("cache_control") == {"type": "ephemeral"}
+    # system stays a plain string — top-level cache_control auto-caches it.
+    assert kwargs.get("system") == "system prompt"
+
+
+def test_anthropic_adapter_reports_cache_usage():
+    """Cache read/creation token counts from usage reach record_llm_call."""
+    usage = _Usage(
+        input_tokens=42,
+        output_tokens=7,
+        cache_read_input_tokens=1234,
+        cache_creation_input_tokens=56,
+    )
+
+    with (
+        patch("anthropic.Anthropic") as mock_cls,
+        patch("mykg.llm.anthropic_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _anthropic_response(usage=usage)
+
+        from mykg.llm.anthropic_adapter import AnthropicAdapter
+
+        adapter = AnthropicAdapter(
+            model="claude-sonnet-4-6", max_tokens=10, timeout=10, api_key="test-key"
+        )
+        adapter.complete("sys", "user")
+
+    kwargs = mock_record.call_args.kwargs
+    assert kwargs.get("cache_read_tokens") == 1234
+    assert kwargs.get("cache_creation_tokens") == 56
+
+
+def test_anthropic_adapter_cache_usage_defaults_to_zero():
+    """When usage lacks the cache attributes, record_llm_call gets 0 (no crash)."""
+    # _Usage() built without the cache attrs — the getattr default path.
+    with (
+        patch("anthropic.Anthropic") as mock_cls,
+        patch("mykg.llm.anthropic_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.return_value = _anthropic_response(usage=_Usage())
+
+        from mykg.llm.anthropic_adapter import AnthropicAdapter
+
+        adapter = AnthropicAdapter(
+            model="claude-sonnet-4-6", max_tokens=10, timeout=10, api_key="test-key"
+        )
+        adapter.complete("sys", "user")
+
+    kwargs = mock_record.call_args.kwargs
+    assert kwargs.get("cache_read_tokens") == 0
+    assert kwargs.get("cache_creation_tokens") == 0

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -2014,3 +2014,31 @@ def test_anthropic_adapter_cache_usage_defaults_to_zero():
     kwargs = mock_record.call_args.kwargs
     assert kwargs.get("cache_read_tokens") == 0
     assert kwargs.get("cache_creation_tokens") == 0
+
+
+def test_anthropic_adapter_missing_usage_defaults_all_to_zero():
+    """A response with usage=None does not raise; all four counts default to 0."""
+    resp = _anthropic_response()
+    resp.usage = None  # SDK omitted usage entirely
+
+    with (
+        patch("anthropic.Anthropic") as mock_cls,
+        patch("mykg.llm.anthropic_adapter.record_llm_call") as mock_record,
+    ):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.messages.create.return_value = resp
+
+        from mykg.llm.anthropic_adapter import AnthropicAdapter
+
+        adapter = AnthropicAdapter(
+            model="claude-sonnet-4-6", max_tokens=10, timeout=10, api_key="test-key"
+        )
+        # Must not raise AttributeError even though usage is None.
+        adapter.complete("sys", "user")
+
+    kwargs = mock_record.call_args.kwargs
+    assert kwargs.get("input_tokens") == 0
+    assert kwargs.get("output_tokens") == 0
+    assert kwargs.get("cache_read_tokens") == 0
+    assert kwargs.get("cache_creation_tokens") == 0


### PR DESCRIPTION
## What & why

`AnthropicAdapter.complete()` sent **no** `cache_control`, so Anthropic prompt caching was never activated. mykg's shared `complete(system, user, ...)` contract always puts the large, **per-run-stable** prompt (flattened schema + Pass-2 instructions) in `system` and the volatile per-chunk text in `user` — the ideal prefix-stable shape — yet the full system prompt was re-billed at full price on every Pass-2 chunk call.

The adapter also **dropped** the cache-usage stats the API already returns (`cache_read_input_tokens` / `cache_creation_input_tokens`), even though `record_llm_call` accepts them, the walkthrough renders cache columns, and the `claude-cli` adapter already wires them through.

## Change

- Add top-level `cache_control={"type": "ephemeral"}` to `messages.create(...)` — auto-caches the last cacheable block (the system prompt). No beta header, default 5m TTL. `system` stays a plain string.
- Forward `usage.cache_read_input_tokens` / `cache_creation_input_tokens` into `record_llm_call` (defensive `getattr(..., 0)`, mirroring the claude-cli adapter) so the walkthrough cache columns finally populate for the direct-API path.

## Tests

Three new unit tests in `tests/test_llm_adapters.py`: request carries the breakpoint, usage stats are reported, and stats default to `0` when the attributes are absent. Full adapter suites: **78 passed, 1 skipped** (the skip is the live OpenRouter test).

## Live verification (real Anthropic API)

Confirmed end-to-end against `api.anthropic.com` (model `claude-sonnet-4-5`) — two real calls with an identical large system prompt:

| Call | input | cache_creation | cache_read | output |
|---|---|---|---|---|
| 1 (cold) | 3 | **23,632** | 0 | 8 |
| 2 (warm) | 3 | 0 | **23,632** | 8 |

Call 1 wrote the 23,632-token system prefix to cache; call 2 read all 23,632 tokens **from cache** (paying ~0.1× instead of full price on the shared prefix). The `cache_control={"type": "ephemeral"}` kwarg is accepted by the live SDK/endpoint and caching genuinely engages — not just mock-verified.

## Scope

Anthropic adapter only — no config-file changes, no config knob/TTL (kept deliberately minimal), no other adapters touched.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable Anthropic LLM adapter prompt caching and surface cache usage metrics in call recording.

New Features:
- Activate Anthropic prompt caching for the system prompt via top-level cache_control on messages.create().

Enhancements:
- Record Anthropic cache read and creation token usage in record_llm_call for direct API calls.

Tests:
- Add unit tests verifying Anthropic adapter sends cache_control, forwards cache usage metrics, and safely defaults cache usage to zero when absent.