### PR TITLE
fix(append): re-extract modified files, not just new ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Controls how source files are packed into Pass 2 LLM calls (set per profile in `
 
 - **`batch_chunks`** *(default)* — packs chunks across files into token-bounded batches, ignoring file boundaries; best throughput and extraction density.
 - **`concat`** — merges whole small files into directory-grouped batches (one LLM call per window) for cross-file context.
-- **`per_file`** — one file per extraction unit; cleanest provenance (every entity traces to one source file).
+- **`per_file`** — one file per extraction unit; cleanest provenance (every entity traces to one source file). Also the only mode where `--append` fully updates a **modified** file — its old nodes are cleanly replaced on re-extraction (batch modes may retain stale copies; see [docs/architecture.md](docs/architecture.md#--append-change-detection-limits)).
 
 See [docs/architecture.md](docs/architecture.md#choosing-a-prep-mode) for the full comparison.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Controls how source files are packed into Pass 2 LLM calls (set per profile in `
 
 - **`batch_chunks`** *(default)* — packs chunks across files into token-bounded batches, ignoring file boundaries; best throughput and extraction density.
 - **`concat`** — merges whole small files into directory-grouped batches (one LLM call per window) for cross-file context.
-- **`per_file`** — one file per extraction unit; cleanest provenance (every entity traces to one source file). Also the only mode where `--append` fully updates a **modified** file — its old nodes are cleanly replaced on re-extraction (batch modes may retain stale copies; see [docs/architecture.md](docs/architecture.md#--append-change-detection-limits)).
+- **`per_file`** — one file per extraction unit; cleanest provenance (every entity traces to one source file). Fully updates a **modified** file on `--append` — its old nodes are cleanly replaced on re-extraction. (`batch_chunks` with `batch_per_file: true` gives the same guarantee; mixed-batch modes may retain stale copies — see [docs/architecture.md](docs/architecture.md#--append-change-detection-limits).)
 
 See [docs/architecture.md](docs/architecture.md#choosing-a-prep-mode) for the full comparison.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -369,7 +369,7 @@ After each LLM call, the pipeline validates the response: edges whose type is no
 
 **`concat`** merges small files into virtual batches up to `concat_batch_token_target`. Files below the target are concatenated together; a file that exceeds it stays its own batch. This cuts the number of LLM calls when you have many tiny files that would otherwise waste per-call overhead, and gives the model moderate cross-file context (related files, grouped by directory, in one prompt). Within each virtual batch, chunks still process sequentially when `stateful_chunks` is on. Because shards are real-file-keyed (post the de-virtualization fix), `--append` re-extracts only new/changed files like the other modes — the virtual batching is recomputed per run but unchanged files are skipped via their real-keyed shards.
 
-**`batch_chunks`** (the default) chunks every file first, then packs all chunks across the corpus into token-bounded batches sized to `batch_token_target`, ignoring file boundaries. Every batch is an independent LLM call, so workers stay saturated and a single large file never bottlenecks the run — its chunks simply distribute across batches alongside everyone else's. It also gives the densest extraction (the model sees a full token budget of material per call) and per-file incremental `--append` (only changed files re-extract). The trade-off is provenance: a mixed batch's result is attributed to every member file, so a node's `source_files` may over-list — the assembler's stable-ID/edge-hash dedup collapses the duplication at assembly time, but per-file citation is less precise than `per_file` or `concat`. Set `batch_per_file: true` to keep a file's chunks from sharing a batch with other files when precise provenance matters.
+**`batch_chunks`** (the default) chunks every file first, then packs all chunks across the corpus into token-bounded batches sized to `batch_token_target`, ignoring file boundaries. Every batch is an independent LLM call, so workers stay saturated and a single large file never bottlenecks the run — its chunks simply distribute across batches alongside everyone else's. It also gives the densest extraction (the model sees a full token budget of material per call) and per-file incremental `--append` (only changed files re-extract). The trade-off is provenance: a mixed batch's result is attributed to every member file, so a node's `source_files` may over-list — the assembler's stable-ID/edge-hash dedup collapses the duplication at assembly time, but per-file citation is less precise than `per_file` or `concat` (see *`--append` change-detection limits* below for how this over-attribution also affects re-extraction of modified files). Set `batch_per_file: true` to keep a file's chunks from sharing a batch with other files when precise provenance matters.
 
 As a rough sense of the call-count difference: a small test corpus of five files yields **5 calls** under `per_file`, **2 virtual batches** under `concat`, and **11 batches** under `batch_chunks` (more, smaller, evenly-sized calls that keep all workers busy).
 
@@ -413,6 +413,20 @@ This keeps the graph consistent — instances of a newly-added type appear in BO
 | **`--base-schema` compatible** | Yes | N/A | Yes | No (auto-loads session schema) | Yes |
 | **`--from-step` compatible** | Yes | Yes | Not in same command | Not in same command | N/A (automatic) |
 | **Empty delta behavior** | N/A | N/A | N/A | Collapses to plain `--append` | No restart if no new properties |
+
+### `--append` change-detection limits
+
+`--append` re-extracts new and content-modified files (detected by SHA-256 / content hash) against the frozen schema; unchanged files are skipped via their real-file-keyed shards. When a file's content changes, its own stale shard is evicted so it is re-extracted (rather than silently shadowed by the prior shard). But how completely re-extracting a *modified* file removes its previous nodes depends on the prep mode, because of Pass 2 over-attribution: a mixed batch's single LLM result is fanned out to **every** member file's shard, so a file's nodes also live in its batch siblings' shards.
+
+| Prep mode | Modified file re-extracted? | Old nodes fully removed on modify/blank? | Why |
+|---|---|---|---|
+| `per_file` | Yes — its own shard is evicted and re-run | Yes | Each file is its own LLM call and its own shard; no fan-out, so nothing is smeared into a sibling |
+| `batch_chunks` (default) | Yes — its own shard is evicted and re-run | **No (partial)** | The prior batch fanned the file's nodes into every batch sibling's shard; siblings are unchanged, so `--append` does not re-extract them and the node can survive via a sibling shard |
+| `concat` | Yes — its own shard is evicted and re-run | **No (partial)** | Same over-attribution as `batch_chunks`: a multi-file virtual batch fans its result to every member shard |
+
+**Deletion is clean in all modes:** removing a source file drops its nodes on the next `--append` — the file no longer contributes and no re-extraction is needed.
+
+To guarantee a modified file's old nodes are fully removed on `--append`, use `per_file` mode, or set `batch_per_file: true` under `batch_chunks` (which keeps a file's chunks from sharing a batch with others). Fully removing the smeared copies inside a mixed batch would require re-extracting the whole batch — deliberately out of scope for the shard-eviction fix. A subsequent full re-extract (`--from-step pass2`) also clears any survivals.
 
 ### Assembly and Deduplication
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -421,12 +421,13 @@ This keeps the graph consistent — instances of a newly-added type appear in BO
 | Prep mode | Modified file re-extracted? | Old nodes fully removed on modify/blank? | Why |
 |---|---|---|---|
 | `per_file` | Yes — its own shard is evicted and re-run | Yes | Each file is its own LLM call and its own shard; no fan-out, so nothing is smeared into a sibling |
-| `batch_chunks` (default) | Yes — its own shard is evicted and re-run | **No (partial)** | The prior batch fanned the file's nodes into every batch sibling's shard; siblings are unchanged, so `--append` does not re-extract them and the node can survive via a sibling shard |
+| `batch_chunks` + `batch_per_file: true` | Yes — its own shard is evicted and re-run | Yes | A batch never mixes files, so there is no fan-out — the file's own shard is the only one carrying its nodes |
+| `batch_chunks` (default, `batch_per_file: false`) | Yes — its own shard is evicted and re-run | **No (partial)** | The prior mixed batch fanned the file's nodes into every batch sibling's shard; siblings are unchanged, so `--append` does not re-extract them and the node can survive via a sibling shard |
 | `concat` | Yes — its own shard is evicted and re-run | **No (partial)** | Same over-attribution as `batch_chunks`: a multi-file virtual batch fans its result to every member shard |
 
 **Deletion is clean in all modes:** removing a source file drops its nodes on the next `--append` — the file no longer contributes and no re-extraction is needed.
 
-To guarantee a modified file's old nodes are fully removed on `--append`, use `per_file` mode, or set `batch_per_file: true` under `batch_chunks` (which keeps a file's chunks from sharing a batch with others). Fully removing the smeared copies inside a mixed batch would require re-extracting the whole batch — deliberately out of scope for the shard-eviction fix. A subsequent full re-extract (`--from-step pass2`) also clears any survivals.
+To guarantee a modified file's old nodes are fully removed on `--append`, use `per_file` mode **or** set `batch_per_file: true` under `batch_chunks` — both keep a file's chunks out of any other file's batch, so there is nothing to smear. Only the mixed-batch modes (`batch_chunks` with `batch_per_file: false`, and `concat`) leave partial survivals; there, a subsequent full re-extract (`--from-step pass2`) clears them. Fully removing the smeared copies *without* re-extracting the whole batch would require re-attributing a mixed batch's result per file — deliberately out of scope for the shard-eviction fix.
 
 ### Assembly and Deduplication
 

--- a/src/mykg/steps/step_pass2.py
+++ b/src/mykg/steps/step_pass2.py
@@ -98,6 +98,34 @@ def _run(
         existing_raw = json.loads(raw_path.read_text(encoding="utf-8"))
         existing_chunk = json.loads(chunk_path.read_text(encoding="utf-8")) if chunk_path.exists() else {}
 
+    # --append change-detection: a MODIFIED file (present in append_new_files
+    # because its content hash changed) still has its stale pre-change shard on
+    # disk. Left in existing_raw it would land in `skip` below and never be
+    # re-extracted, so the old content's nodes/edges survive as ghosts. Evict
+    # the per-file shard + in-memory entry for every changed file so modified
+    # files fall back into `todo`. New files have no shard, so eviction is a
+    # harmless no-op for them; unchanged files are never in append_new_files.
+    if ctx.append and ctx.append_new_files:
+        for fname in ctx.append_new_files:
+            existing_raw.pop(fname, None)
+            existing_chunk.pop(fname, None)
+            slug = _fname_slug(fname)
+            (shard_dir / f"{slug}.json").unlink(missing_ok=True)
+            (chunk_shard_dir / f"{slug}.json").unlink(missing_ok=True)
+        # D57: also drop batch-composition shards that touch a changed file, so
+        # _load_existing_raw_batches (batch_chunks mode) can't re-inject the
+        # pre-change extraction for a batch whose (chunk_count, source_files)
+        # fingerprint still matches after the edit.
+        raw_batch_shard_dir = ctx.intermediate_dir / "pass2_raw_batches"
+        if raw_batch_shard_dir.exists():
+            for shard_file in raw_batch_shard_dir.glob("*.json"):
+                try:
+                    entry = json.loads(shard_file.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    continue
+                if set(entry.get("source_files", [])) & ctx.append_new_files:
+                    shard_file.unlink(missing_ok=True)
+
     if ctx.append and ctx.append_new_files is not None:
         todo = {f: _content_from_entry(manifest[f]) for f in ctx.append_new_files if f in manifest}
     else:

--- a/tests/test_append_modified_e2e.py
+++ b/tests/test_append_modified_e2e.py
@@ -191,3 +191,41 @@ def test_append_reextracts_modified_file_shard_batch_chunks(tmp_path, monkeypatc
     assert "person-alice" not in {n["id"] for n in a_after["data"]["nodes"]}, (
         "modified file's own shard was not re-extracted"
     )
+
+
+def test_append_blanked_file_removes_ghost_batch_chunks_per_file(tmp_path, monkeypatch):
+    """batch_chunks + batch_per_file=true: a batch never mixes files, so there is
+    no over-attribution to smear a file's nodes into a sibling's shard. The
+    shard-eviction fix therefore removes a blanked file's nodes from the FINAL
+    graph, exactly like per_file mode — closing the batch_chunks limitation for
+    users who set batch_per_file: true."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_PREP_MODE", "batch_chunks")
+    monkeypatch.setattr(cfg, "PASS2_BATCH_PER_FILE", True)
+    monkeypatch.setattr(cfg, "ORPHAN_PASS_ENABLED", False)
+
+    inp = tmp_path / "input"
+    inp.mkdir(parents=True, exist_ok=True)
+    (inp / "a.md").write_text("Alice is a person. ALICE_MARKER", encoding="utf-8")
+    (inp / "b.md").write_text("Bob is a person. BOB_MARKER", encoding="utf-8")
+
+    adapter = ScriptedAdapter()
+    ctx = _make_full_ctx(tmp_path, adapter, append=False)
+    run(STEPS, ctx)
+    ids = _node_ids(ctx.output_dir)
+    assert "person-alice" in ids
+    assert "person-bob" in ids
+
+    (inp / "a.md").write_text("", encoding="utf-8")
+    adapter.a_nodes = []
+
+    ctx2 = _make_full_ctx(tmp_path, adapter, append=True)
+    run(STEPS, ctx2)
+
+    ids_after = _node_ids(ctx2.output_dir)
+    assert "person-alice" not in ids_after, (
+        "ghost: with batch_per_file=true there is no sibling smear, so Alice's "
+        "node must be fully removed after a.md is blanked"
+    )
+    assert "person-bob" in ids_after, "Bob (unchanged file) must remain"

--- a/tests/test_append_modified_e2e.py
+++ b/tests/test_append_modified_e2e.py
@@ -1,0 +1,193 @@
+"""End-to-end regression test for --append re-extracting MODIFIED files.
+
+Drives the real pipeline (``orchestrator.run(STEPS, ctx)``) twice with a
+step-routing scripted adapter:
+
+  1. Fresh run over two files — each contributes a unique node.
+  2. One file is blanked on disk, then re-run with ``append=True`` and an
+     adapter that now returns an empty extraction for that file.
+
+Before the fix, the blanked file's stale shard survived and its unique node
+persisted as a ghost in ``output/nodes.jsonl``. This test asserts the ghost is
+gone after the append run.
+
+Both prep modes are exercised: ``per_file`` and ``batch_chunks`` (the shipped
+default, which also exercises the pass2_raw_batches composition-cache eviction).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mykg.llm.adapter import LLMAdapter
+from mykg.orchestrator import PipelineContext, run
+from mykg.pipeline import STEPS
+
+
+# ``a.md`` contributes person-alice; ``b.md`` contributes person-bob. After
+# blanking a.md, person-alice must disappear from the final graph.
+_A_NODE = {
+    "id": "person-alice",
+    "type": "Person",
+    "attributes": {"name": {"value": "Alice", "confidence": 1.0}},
+}
+_B_NODE = {
+    "id": "person-bob",
+    "type": "Person",
+    "attributes": {"name": {"value": "Bob", "confidence": 1.0}},
+}
+
+_SCHEMA_JSON = json.dumps(
+    {
+        "concepts": [{"type": "Person", "parent": None, "attributes": ["name"]}],
+        "properties": [],
+    }
+)
+
+
+class ScriptedAdapter(LLMAdapter):
+    """Routes each pipeline LLM call by context_label to a canned response.
+
+    - pass1 / harmonize / quality review → the fixed one-concept schema
+    - normalize_names → empty mappings
+    - pass2 → whichever nodes the current phase should extract, keyed by which
+      source file's text the user prompt contains
+    """
+
+    def __init__(self) -> None:
+        # Mutated between the fresh run and the append run.
+        self.a_nodes: list[dict] = [_A_NODE]
+
+    def complete(self, system, user, context_label="", max_tokens=None, timeout=None):
+        label = context_label or ""
+        if label.startswith("pass1 batch") or label in (
+            "schema_harmonize",
+            "schema_quality_review",
+        ):
+            return _SCHEMA_JSON
+        if label.startswith("pass2 chunk"):
+            # Route by which file markers are in the prompt. A batch_chunks
+            # prompt may contain BOTH markers (both files packed into one
+            # batch) — return every matching file's nodes so the fresh run is
+            # complete regardless of prep mode.
+            nodes: list[dict] = []
+            if "ALICE_MARKER" in user:
+                nodes.extend(self.a_nodes)
+            if "BOB_MARKER" in user:
+                nodes.append(_B_NODE)
+            return json.dumps({"nodes": nodes, "edges": []})
+        # normalize_names and anything else: no-op mappings.
+        return "{}"
+
+    def endpoint_label(self) -> str:
+        return "scripted"
+
+
+def _make_full_ctx(tmp_path: Path, adapter: LLMAdapter, *, append: bool) -> PipelineContext:
+    out = tmp_path / "output"
+    inter = tmp_path / "intermediate"
+    inp = tmp_path / "input"
+    for p in (out, inter, inp):
+        p.mkdir(parents=True, exist_ok=True)
+    return PipelineContext(
+        input_dir=inp,
+        output_dir=out,
+        intermediate_dir=inter,
+        adapter=adapter,
+        base_schema=None,
+        thesaurus=None,
+        review=False,
+        append=append,
+    )
+
+
+def _node_ids(output_dir: Path) -> set[str]:
+    path = output_dir / "nodes.jsonl"
+    ids: set[str] = set()
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                ids.add(json.loads(line)["id"])
+    return ids
+
+
+def test_append_blanked_file_removes_ghost_nodes_per_file(tmp_path, monkeypatch):
+    """per_file mode: blanking a file and re-appending removes its nodes from the
+    final graph. Each file gets its own LLM call and its own shard, so no
+    over-attribution smears its nodes into a sibling's shard."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_PREP_MODE", "per_file")
+    monkeypatch.setattr(cfg, "ORPHAN_PASS_ENABLED", False)
+
+    inp = tmp_path / "input"
+    inp.mkdir(parents=True, exist_ok=True)
+    (inp / "a.md").write_text("Alice is a person. ALICE_MARKER", encoding="utf-8")
+    (inp / "b.md").write_text("Bob is a person. BOB_MARKER", encoding="utf-8")
+
+    adapter = ScriptedAdapter()
+
+    ctx = _make_full_ctx(tmp_path, adapter, append=False)
+    run(STEPS, ctx)
+    ids = _node_ids(ctx.output_dir)
+    assert "person-alice" in ids, "fresh run should extract Alice from a.md"
+    assert "person-bob" in ids
+
+    (inp / "a.md").write_text("", encoding="utf-8")
+    adapter.a_nodes = []  # blanked file now yields no nodes
+
+    ctx2 = _make_full_ctx(tmp_path, adapter, append=True)
+    run(STEPS, ctx2)
+
+    ids_after = _node_ids(ctx2.output_dir)
+    assert "person-alice" not in ids_after, (
+        "ghost: Alice's node survived after a.md was blanked and re-appended"
+    )
+    assert "person-bob" in ids_after, "Bob (unchanged file) must remain"
+
+
+def test_append_reextracts_modified_file_shard_batch_chunks(tmp_path, monkeypatch):
+    """batch_chunks mode: the minimal shard-eviction fix guarantees the MODIFIED
+    file's OWN shard is re-extracted (here, to empty after blanking).
+
+    Known limitation (D53 over-attribution): when files share a batch, the single
+    LLM result is fanned out to every member's shard, so a blanked file's nodes
+    also live in its batch siblings' shards. Those siblings are unchanged and are
+    not re-extracted on append, so the node can still reach the final graph via a
+    sibling shard. Fully removing that requires re-extracting the whole batch — a
+    larger change deliberately out of scope for this fix. This test therefore
+    asserts the guarantee the fix actually makes: the changed file's own shard is
+    refreshed, not that every trace is gone from the merged graph."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_PREP_MODE", "batch_chunks")
+    monkeypatch.setattr(cfg, "ORPHAN_PASS_ENABLED", False)
+
+    inp = tmp_path / "input"
+    inp.mkdir(parents=True, exist_ok=True)
+    (inp / "a.md").write_text("Alice is a person. ALICE_MARKER", encoding="utf-8")
+    (inp / "b.md").write_text("Bob is a person. BOB_MARKER", encoding="utf-8")
+
+    adapter = ScriptedAdapter()
+    ctx = _make_full_ctx(tmp_path, adapter, append=False)
+    run(STEPS, ctx)
+
+    shard_dir = ctx.intermediate_dir / "raw_extractions_shards"
+    a_before = json.loads((shard_dir / "a.md.json").read_text())
+    assert "person-alice" in {n["id"] for n in a_before["data"]["nodes"]}
+
+    (inp / "a.md").write_text("", encoding="utf-8")
+    adapter.a_nodes = []
+
+    ctx2 = _make_full_ctx(tmp_path, adapter, append=True)
+    run(STEPS, ctx2)
+
+    # The blanked file's OWN shard was re-extracted and no longer carries Alice.
+    a_after = json.loads((shard_dir / "a.md.json").read_text())
+    assert "person-alice" not in {n["id"] for n in a_after["data"]["nodes"]}, (
+        "modified file's own shard was not re-extracted"
+    )

--- a/tests/test_step_pass2.py
+++ b/tests/test_step_pass2.py
@@ -352,14 +352,17 @@ def test_concat_append_detects_only_changed_file(tmp_path, monkeypatch):
 
 class TrackingAdapter(LLMAdapter):
     """MockAdapter that records every completion call so a test can assert
-    whether re-extraction actually happened."""
+    whether re-extraction actually happened, and — via the recorded user
+    prompt / context_label — which file's content was sent."""
 
     def __init__(self, response: str = '{"nodes": [], "edges": []}'):
         self._response = response
-        self.calls: list[str] = []
+        # Each call records both the user prompt (carries the source file's
+        # text in per_file mode) and the context_label (chunk-scoped in pass2).
+        self.calls: list[dict[str, str]] = []
 
     def complete(self, system, user, context_label="", max_tokens=None, timeout=None):
-        self.calls.append(user)
+        self.calls.append({"user": user, "context_label": context_label})
         return self._response
 
     def endpoint_label(self) -> str:
@@ -421,6 +424,15 @@ def test_append_reextracts_modified_file_per_file(tmp_path, monkeypatch):
 
     # The adapter WAS invoked (re-extraction happened) — pre-fix this list is empty.
     assert adapter.calls, "modified file a.md was never re-extracted"
+
+    # Call routing: only the modified file's content (a.md → "Alice.") was sent
+    # to the LLM; the unchanged file's content (b.md → "Bob.") never was — so no
+    # needless LLM cost was incurred for b.md (Invariant 16). context_label in
+    # pass2 is chunk-scoped ("pass2 chunk N"), not filename-scoped, so we route
+    # on the file text carried in the user prompt.
+    prompts = " ".join(c["user"] for c in adapter.calls)
+    assert "Alice." in prompts, "a.md's content was not sent for re-extraction"
+    assert "Bob." not in prompts, "b.md (unchanged) was needlessly re-extracted"
 
     shard_dir = ctx.intermediate_dir / "raw_extractions_shards"
     a_shard = json.loads((shard_dir / "a.md.json").read_text())
@@ -510,6 +522,40 @@ def test_append_evicts_stale_batch_shard_for_changed_file(tmp_path, monkeypatch)
     a_ids = {n["id"] for n in a_shard["data"]["nodes"]}
     assert "fresh-a" in a_ids
     assert "stale-a" not in a_ids
+
+
+def test_append_batch_shard_eviction_tolerates_corrupt_shard(tmp_path, monkeypatch):
+    """A malformed pass2_raw_batches shard must not crash the eviction scan — it
+    is skipped (the except-branch guard) and the run proceeds normally."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_PREP_MODE", "batch_chunks")
+
+    ctx = _make_ctx(tmp_path)
+    _seed_two_file_session(ctx, a_node_id="stale-a", b_node_id="keep-b")
+
+    raw_batch_dir = ctx.intermediate_dir / "pass2_raw_batches"
+    raw_batch_dir.mkdir()
+    # Corrupt (non-JSON) shard — the eviction scan must swallow the parse error.
+    (raw_batch_dir / "0000.json").write_text("}{ not json at all")
+
+    fresh_node = {
+        "id": "fresh-a",
+        "type": "Person",
+        "attributes": {"name": {"value": "Fresh", "confidence": 1.0}},
+    }
+    ctx.adapter = TrackingAdapter(response=json.dumps({"nodes": [fresh_node], "edges": []}))
+    ctx.append = True
+    ctx.append_new_files = {"a.md"}
+
+    # Must not raise despite the unreadable shard.
+    run_pass2_step(ctx)
+
+    # a.md was still re-extracted (the corrupt shard didn't block the run).
+    a_shard = json.loads(
+        (ctx.intermediate_dir / "raw_extractions_shards" / "a.md.json").read_text()
+    )
+    assert "fresh-a" in {n["id"] for n in a_shard["data"]["nodes"]}
 
 
 def test_concat_legacy_virtual_shards_migrated(tmp_path, monkeypatch):

--- a/tests/test_step_pass2.py
+++ b/tests/test_step_pass2.py
@@ -350,6 +350,168 @@ def test_concat_append_detects_only_changed_file(tmp_path, monkeypatch):
     assert not any(k.startswith("concat_batch_") for k in raw)
 
 
+class TrackingAdapter(LLMAdapter):
+    """MockAdapter that records every completion call so a test can assert
+    whether re-extraction actually happened."""
+
+    def __init__(self, response: str = '{"nodes": [], "edges": []}'):
+        self._response = response
+        self.calls: list[str] = []
+
+    def complete(self, system, user, context_label="", max_tokens=None, timeout=None):
+        self.calls.append(user)
+        return self._response
+
+    def endpoint_label(self) -> str:
+        return "tracking"
+
+
+def _seed_two_file_session(ctx: PipelineContext, *, a_node_id: str, b_node_id: str) -> None:
+    """Write schema/flattened schema + two per-file shards (a.md, b.md) each
+    carrying a known node, plus a matching manifest. Models a completed prior run."""
+    _write_schema(ctx)
+    (ctx.intermediate_dir / "flattened_schema.json").write_text(
+        json.dumps({"Person": ["name"], "Organization": ["name"]})
+    )
+    (ctx.intermediate_dir / "file_manifest.json").write_text(
+        json.dumps({"a.md": "Alice.", "b.md": "Bob."})
+    )
+    shard_dir = ctx.intermediate_dir / "raw_extractions_shards"
+    chunk_shard_dir = ctx.intermediate_dir / "chunk_index_shards"
+    shard_dir.mkdir()
+    chunk_shard_dir.mkdir()
+    for fname, nid in (("a.md", a_node_id), ("b.md", b_node_id)):
+        (shard_dir / f"{fname}.json").write_text(
+            json.dumps(
+                {
+                    "_fname": fname,
+                    "data": {"nodes": [{"id": nid, "type": "Person"}], "edges": []},
+                }
+            )
+        )
+        (chunk_shard_dir / f"{fname}.json").write_text(
+            json.dumps({"_fname": fname, "data": {"1": [nid]}})
+        )
+
+
+def test_append_reextracts_modified_file_per_file(tmp_path, monkeypatch):
+    """A MODIFIED file (in append_new_files) must be re-extracted, not skipped.
+
+    Regression test: before the fix, the modified file's stale shard survived,
+    landed in `skip`, and the file was never re-sent to the LLM — its old
+    nodes/edges persisted as ghosts."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_PREP_MODE", "per_file")
+
+    ctx = _make_ctx(tmp_path)
+    _seed_two_file_session(ctx, a_node_id="stale-a", b_node_id="keep-b")
+    # a.md was modified (blanked); the adapter now returns a DIFFERENT node set.
+    fresh_node = {
+        "id": "fresh-a",
+        "type": "Person",
+        "attributes": {"name": {"value": "Fresh", "confidence": 1.0}},
+    }
+    adapter = TrackingAdapter(response=json.dumps({"nodes": [fresh_node], "edges": []}))
+    ctx.adapter = adapter
+    ctx.append = True
+    ctx.append_new_files = {"a.md"}
+
+    run_pass2_step(ctx)
+
+    # The adapter WAS invoked (re-extraction happened) — pre-fix this list is empty.
+    assert adapter.calls, "modified file a.md was never re-extracted"
+
+    shard_dir = ctx.intermediate_dir / "raw_extractions_shards"
+    a_shard = json.loads((shard_dir / "a.md.json").read_text())
+    a_ids = {n["id"] for n in a_shard["data"]["nodes"]}
+    # a.md's shard now reflects the fresh extraction, and the ghost is gone.
+    assert "fresh-a" in a_ids
+    assert "stale-a" not in a_ids
+
+    # b.md (unchanged, not in append_new_files) is untouched.
+    b_shard = json.loads((shard_dir / "b.md.json").read_text())
+    assert {n["id"] for n in b_shard["data"]["nodes"]} == {"keep-b"}
+
+
+def test_append_leaves_unchanged_file_shard_intact_per_file(tmp_path, monkeypatch):
+    """Only the changed file is re-extracted; an unchanged file's shard is
+    byte-for-byte preserved (no needless LLM cost, Invariant 16)."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_PREP_MODE", "per_file")
+
+    ctx = _make_ctx(tmp_path)
+    _seed_two_file_session(ctx, a_node_id="stale-a", b_node_id="keep-b")
+    shard_dir = ctx.intermediate_dir / "raw_extractions_shards"
+    b_before = (shard_dir / "b.md.json").read_bytes()
+
+    ctx.adapter = TrackingAdapter(
+        response=json.dumps({"nodes": [{"id": "fresh-a", "type": "Person"}], "edges": []})
+    )
+    ctx.append = True
+    ctx.append_new_files = {"a.md"}
+
+    run_pass2_step(ctx)
+
+    assert (shard_dir / "b.md.json").read_bytes() == b_before
+
+
+def test_append_evicts_stale_batch_shard_for_changed_file(tmp_path, monkeypatch):
+    """batch_chunks mode: a pass2_raw_batches shard whose source_files includes a
+    changed file must be evicted so _load_existing_raw_batches can't re-inject the
+    pre-change extraction (D57)."""
+    import mykg.config as cfg
+
+    monkeypatch.setattr(cfg, "PASS2_PREP_MODE", "batch_chunks")
+
+    ctx = _make_ctx(tmp_path)
+    _seed_two_file_session(ctx, a_node_id="stale-a", b_node_id="keep-b")
+
+    # Seed a stale batch-composition shard that references a.md.
+    raw_batch_dir = ctx.intermediate_dir / "pass2_raw_batches"
+    raw_batch_dir.mkdir()
+    stale_batch = raw_batch_dir / "0000.json"
+    stale_batch.write_text(
+        json.dumps(
+            {
+                "batch_index": 0,
+                "status": "ok",
+                "chunk_count": 1,
+                "source_files": ["a.md"],
+                "extraction": {"nodes": [{"id": "stale-a", "type": "Person"}], "edges": []},
+            }
+        )
+    )
+
+    fresh_node = {
+        "id": "fresh-a",
+        "type": "Person",
+        "attributes": {"name": {"value": "Fresh", "confidence": 1.0}},
+    }
+    ctx.adapter = TrackingAdapter(response=json.dumps({"nodes": [fresh_node], "edges": []}))
+    ctx.append = True
+    ctx.append_new_files = {"a.md"}
+
+    run_pass2_step(ctx)
+
+    # The pre-change batch shard must not have been reused to re-inject the stale
+    # extraction. (The batch is re-dispatched, so a fresh 0000.json may be written
+    # — the invariant is that its content is NOT the pre-change extraction.)
+    if stale_batch.exists():
+        rewritten = json.loads(stale_batch.read_text())
+        ids = {n.get("id") for n in rewritten.get("extraction", {}).get("nodes", [])}
+        assert "stale-a" not in ids, "pre-change batch extraction was re-injected"
+
+    # a.md was re-extracted afresh; its shard carries the new node, not the ghost.
+    a_shard = json.loads(
+        (ctx.intermediate_dir / "raw_extractions_shards" / "a.md.json").read_text()
+    )
+    a_ids = {n["id"] for n in a_shard["data"]["nodes"]}
+    assert "fresh-a" in a_ids
+    assert "stale-a" not in a_ids
+
+
 def test_concat_legacy_virtual_shards_migrated(tmp_path, monkeypatch):
     """A pre-existing concat_batch_* shard is cleared and the session rebuilds real-keyed."""
     ctx = _concat_ctx(tmp_path, monkeypatch, response='{"nodes": [], "edges": []}')


### PR DESCRIPTION
## Problem

`mykg extract-graph --append` **detected** a content-modified (or blanked) `.md` file but **never re-extracted it**. The file's old nodes/edges persisted in the graph as ghosts, and zero LLM calls fired for it.

Confirmed at runtime: blanking a file and running `--append` left its shard byte-for-byte identical and its unique-content nodes still in `output/nodes.jsonl`.

### Root cause
`_invalidate_append_downstream` deletes pass2's *declared outputs*, but the shard directories (`raw_extractions_shards/`, `chunk_index_shards/`) aren't in that list, and `raw_extractions.json` is explicitly preserved for append. So a modified file's stale shard survived, landed in `skip = set(existing_raw.keys())` in `step_pass2._run`, and was stripped from `todo` — even though it was in `ctx.append_new_files`. New files worked; modified files didn't.

## Fix

In `step_pass2._run`, before computing `skip`, evict the per-file shard (+ in-memory entry) for every file in `ctx.append_new_files`, so modified files fall back into `todo`. Also drop `pass2_raw_batches/` composition shards whose `source_files` touch a changed file, so the D57 batch cache can't re-inject the pre-change extraction.

**Minimal & guarded:** both blocks are gated by `ctx.append and ctx.append_new_files`. Non-append runs, resume, `--from-step`, grow-schema back-fill, and unchanged files are provably untouched. New files (no shard) are a no-op.

## Known limitation (documented, not fixed)

Fully resolves **`per_file`** mode. In **`batch_chunks`** (default) / **`concat`**, the pre-existing D53 over-attribution fans a file's nodes into batch siblings' shards; those siblings are unchanged so `--append` can't clear them, and a node can survive via a sibling shard. Documented as a table in `docs/architecture.md` and a short note in `README.md`. Workarounds: `per_file`, `batch_per_file: true`, or `--from-step pass2`.

## Tests

- Unit: per_file re-extraction, unchanged-shard preservation, batch-shard eviction (`tests/test_step_pass2.py`).
- E2E: full pipeline extract → blank a file → `--append`, asserting the ghost is gone in `per_file` and the modified file's own shard is refreshed in `batch_chunks` (`tests/test_append_modified_e2e.py`).
- Full suite: **1287 passed**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure append runs re-extract content-modified files and evict stale shards so their outdated nodes do not persist in the graph.

Bug Fixes:
- Evict per-file and batch composition shards for content-modified files during append so they are re-extracted instead of being silently skipped.

Documentation:
- Document the limitations of append change-detection across prep modes and clarify that only per_file mode fully updates modified files on append.

Tests:
- Add unit tests for append re-extraction behavior in per_file and batch_chunks modes and an end-to-end regression test that blanking a file removes its ghost nodes.