### PR TITLE
feat(llm): add Gemini adapter via native google-genai SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The wizard walks you through three prompts:
 |---|---|---|---|
 | Anthropic (Claude) | `anthropic-claude` | `ANTHROPIC_API_KEY` | Recommended for quality |
 | OpenAI | `openai` | `OPENAI_API_KEY` | |
+| Google Gemini | `gemini` | `GEMINI_API_KEY` | 1M-token context; implicit prompt caching is automatic |
 | Ollama | `ollama-local` | — | Local inference, no key needed |
 | OpenRouter | `openrouter-free` | `OPENROUTER_API_KEY` | Access many models via one key |
 | Claude CLI | `claude-cli` | — | Uses `claude -p` subprocess; serial only |

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The wizard walks you through three prompts:
 |---|---|---|---|
 | Anthropic (Claude) | `anthropic-claude` | `ANTHROPIC_API_KEY` | Recommended for quality |
 | OpenAI | `openai` | `OPENAI_API_KEY` | |
-| Google Gemini | `gemini` | `GEMINI_API_KEY` | 1M-token context; implicit prompt caching is automatic |
+| Google Gemini | `gemini` | `GEMINI_API_KEY` | Implicit prompt caching is automatic. Profile ships the same token budgets as `openai`; raise `llm.context_window` to use Gemini's full 1M window |
 | Ollama | `ollama-local` | — | Local inference, no key needed |
 | OpenRouter | `openrouter-free` | `OPENROUTER_API_KEY` | Access many models via one key |
 | Claude CLI | `claude-cli` | — | Uses `claude -p` subprocess; serial only |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -680,7 +680,7 @@ The pipeline is fully decoupled from any specific LLM provider. A single abstrac
 |---|---|
 | Anthropic (Claude) | Recommended for quality; supports prompt caching |
 | OpenAI (GPT-4o) | Also works with Azure OpenAI and any OpenAI-compatible endpoint |
-| Google Gemini | Native `google-genai` SDK. The shipped profile mirrors the `openai` token budgets (128K window); the models themselves support up to 1M, so raise `llm.context_window` and rerun the context-calculator to exploit it. Implicit context caching is automatic and server-side — the adapter implements no caching, it only reports `cache_read_tokens`. `llm.thinking_level` bounds the reasoning budget, which is drawn from the same `max_output_tokens` allowance as the answer |
+| Google Gemini | Native `google-genai` SDK. The shipped profile mirrors the `openai` token budgets (128K window); the models themselves support up to 1M, so raise `llm.context_window` and rerun the context-calculator to exploit it. Implicit context caching is automatic and server-side — the adapter implements no caching, it only reports `cache_read_tokens`. The reasoning budget is drawn from the same `max_output_tokens` allowance as the answer and defaults to `low`; add an optional `llm.thinking_level` key to the profile to change it |
 | Ollama | Local inference; no API key required |
 | OpenRouter | Access many models via a single API key |
 | Claude CLI | Uses the `claude -p` subprocess; no API key; billing via Claude Pro/Max plan; serial only |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -680,7 +680,7 @@ The pipeline is fully decoupled from any specific LLM provider. A single abstrac
 |---|---|
 | Anthropic (Claude) | Recommended for quality; supports prompt caching |
 | OpenAI (GPT-4o) | Also works with Azure OpenAI and any OpenAI-compatible endpoint |
-| Google Gemini | Native `google-genai` SDK; 1M-token context. Implicit context caching is automatic and server-side — the adapter implements no caching, it only reports `cache_read_tokens`. `llm.thinking_level` bounds the reasoning budget, which is drawn from the same `max_output_tokens` allowance as the answer |
+| Google Gemini | Native `google-genai` SDK. The shipped profile mirrors the `openai` token budgets (128K window); the models themselves support up to 1M, so raise `llm.context_window` and rerun the context-calculator to exploit it. Implicit context caching is automatic and server-side — the adapter implements no caching, it only reports `cache_read_tokens`. `llm.thinking_level` bounds the reasoning budget, which is drawn from the same `max_output_tokens` allowance as the answer |
 | Ollama | Local inference; no API key required |
 | OpenRouter | Access many models via a single API key |
 | Claude CLI | Uses the `claude -p` subprocess; no API key; billing via Claude Pro/Max plan; serial only |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,7 @@ This document explains how **myKG** works at a conceptual level: the pipelines, 
 
 Both pipelines run as a sequence of named steps. All intermediate state is written to disk after every step, so any step can be re-entered without repeating upstream work.
 
-The LLM layer is provider-pluggable: six adapters ship out of the box (Anthropic, OpenAI, Ollama, OpenRouter, Claude CLI, and **Agent**). The Agent provider is unusual — instead of calling an HTTP API or a subprocess, it writes LLM tasks to a session-local inbox folder and polls an outbox for answers supplied by a Claude Code skill running on the user's side. The 12 pipeline steps and the orchestrator do not know which adapter is active.
+The LLM layer is provider-pluggable: seven adapters ship out of the box (Anthropic, OpenAI, Gemini, Ollama, OpenRouter, Claude CLI, and **Agent**). The Agent provider is unusual — instead of calling an HTTP API or a subprocess, it writes LLM tasks to a session-local inbox folder and polls an outbox for answers supplied by a Claude Code skill running on the user's side. The 12 pipeline steps and the orchestrator do not know which adapter is active.
 
 <p align="center">
   <img src="diagrams/system-overview.png" width="80%" style="vertical-align:middle;">
@@ -674,12 +674,13 @@ The pipeline applies two tiers of automatic correction before asking for human i
 
 ## LLM Provider Support
 
-The pipeline is fully decoupled from any specific LLM provider. A single abstract adapter interface — accepting a system prompt and a user prompt, returning a string — is all that pipeline logic depends on. Six provider implementations ship out of the box:
+The pipeline is fully decoupled from any specific LLM provider. A single abstract adapter interface — accepting a system prompt and a user prompt, returning a string — is all that pipeline logic depends on. Seven provider implementations ship out of the box:
 
 | Provider | Notes |
 |---|---|
 | Anthropic (Claude) | Recommended for quality; supports prompt caching |
 | OpenAI (GPT-4o) | Also works with Azure OpenAI and any OpenAI-compatible endpoint |
+| Google Gemini | Native `google-genai` SDK; 1M-token context. Implicit context caching is automatic and server-side — the adapter implements no caching, it only reports `cache_read_tokens`. `llm.thinking_level` bounds the reasoning budget, which is drawn from the same `max_output_tokens` allowance as the answer |
 | Ollama | Local inference; no API key required |
 | OpenRouter | Access many models via a single API key |
 | Claude CLI | Uses the `claude -p` subprocess; no API key; billing via Claude Pro/Max plan; serial only |
@@ -689,7 +690,7 @@ All provider parameters — model, context window, token limits, timeout, base U
 
 ### Agent provider — adapter that polls a filesystem
 
-The Agent provider is the sixth `LLMAdapter` subclass, not a fork of the orchestrator. The 12 pipeline steps, all 14 LLM call sites, every `prompts/*.txt` template, and the `ThreadPoolExecutor` parallelism in `pass1` / `pass2` / `orphan_connect` are unchanged. Only the implementation of `LLMAdapter.complete(system, user) → str` differs: instead of making an HTTP request, it writes a JSON task envelope to disk and polls for the response. This keeps the entire correctness story of mykg's deterministic pipeline — re-entry, sentinel-based completion checks, retry-once + LLM feedback — applicable verbatim to agent mode.
+The Agent provider is the seventh `LLMAdapter` subclass, not a fork of the orchestrator. The 12 pipeline steps, all 14 LLM call sites, every `prompts/*.txt` template, and the `ThreadPoolExecutor` parallelism in `pass1` / `pass2` / `orphan_connect` are unchanged. Only the implementation of `LLMAdapter.complete(system, user) → str` differs: instead of making an HTTP request, it writes a JSON task envelope to disk and polls for the response. This keeps the entire correctness story of mykg's deterministic pipeline — re-entry, sentinel-based completion checks, retry-once + LLM feedback — applicable verbatim to agent mode.
 
 The request/response contract lives entirely on the filesystem under each session's `intermediate/` directory. The adapter writes `agent_inbox/<task_id>.task.json` (containing the system prompt, user prompt, step name, and a context label) atomically via the `.tmp` + `rename` pattern. The skill on the other side reads the task, dispatches a subagent, and writes the answer envelope to `agent_outbox/<task_id>.answer.json` — again atomically. After the answer file is fully renamed, the skill creates a zero-byte sentinel at `agent_outbox/<task_id>.done`. The adapter polls only for the sentinel, never for the answer file, so it can never observe a half-written response.
 
@@ -713,7 +714,7 @@ The Claude Code skill in `src/mykg/data/skills/mykg/SKILL.md` exposes a single s
 | **Session isolation** | Each run lives in a timestamped folder containing its own inputs, intermediate state, outputs, and logs | Runs never interfere; any run can be resumed or re-entered independently without touching other sessions |
 | **Single config file** | `mykg_config.yaml` is the sole source of truth for all parameters | No hardcoded literals in pipeline or adapter code; switching provider, model, or tuning parameters requires only a config change |
 | **Pydantic for all data models** | All structured data between pipeline stages uses Pydantic BaseModel | Free JSON serialization, field validation, and type coercion at every pipeline boundary |
-| **Filesystem-backed agent provider** | Sixth `LLMAdapter` subclass that writes JSON tasks to a session-local inbox and polls a `.done` sentinel | Lets a Claude Code skill — or any other host with file access — supply LLM answers without modifying the 12-step pipeline, the orchestrator, or any of the 14 LLM call sites. The contract is JSON files on disk; testable with a mock drainer in `tmp_path` |
+| **Filesystem-backed agent provider** | Seventh `LLMAdapter` subclass that writes JSON tasks to a session-local inbox and polls a `.done` sentinel | Lets a Claude Code skill — or any other host with file access — supply LLM answers without modifying the 12-step pipeline, the orchestrator, or any of the 14 LLM call sites. The contract is JSON files on disk; testable with a mock drainer in `tmp_path` |
 | **Fetch-web as a standalone acquisition command** | `mykg fetch-web` has no session, no LLM calls, and no pipeline step of its own — it just writes a folder shaped like an `extract-graph` input | Acquisition and provenance are decoupled from extraction; the output folder can be inspected, edited, or reused independently before any LLM cost is incurred |
 | **MCP server as a query-only layer** | `mykg mcp-serve` loads a completed session into memory and serves 13 read-only tools via MCP; no extraction, no writes, no LLM calls | Clean separation between the extraction pipeline (expensive, long-running, write-heavy) and the query layer (fast, in-memory, read-only); any MCP client can query without understanding the pipeline |
 | **GitHub URL → shallow clone, not crawl** | `is_github_repo_url()` routes `github.com/<owner>/<repo>` to `git clone --depth N`, skipping Crawlee and the venv entirely | A repo's source files are better obtained via git than by crawling rendered HTML pages; avoids paying the Crawlee venv cost when it adds no value |

--- a/mykg_config.yaml
+++ b/mykg_config.yaml
@@ -739,11 +739,14 @@ profiles:
   # only *reports* the saving via cache_read_tokens in llm.log — it implements no
   # caching of its own.
   #
-  # thinking_level controls the reasoning budget. Gemini 3.x draws thinking
-  # tokens from the SAME max_output_tokens allowance as the visible answer, so a
-  # budget that is too small returns an EMPTY response with finish_reason=
-  # MAX_TOKENS. Keep max_output_tokens generous. Use thinking_level (not
-  # thinking_budget) — thinking_budget=0 is rejected by gemini-3.6-flash.
+  # Gemini 3.x draws thinking tokens from the SAME max_output_tokens allowance as
+  # the visible answer, so a budget that is too small returns an EMPTY response
+  # with finish_reason=MAX_TOKENS. Keep max_output_tokens generous.
+  #
+  # The reasoning budget defaults to "low" in the adapter. To change it, add an
+  # `llm.thinking_level` key here (low | medium | high, or null to let the model
+  # decide). Use thinking_level, not thinking_budget — thinking_budget=0 is
+  # rejected outright by gemini-3.6-flash.
   #
   # NOTE ON RATE LIMITS (Invariant 13): max_workers below matches the openai
   # profile. The Gemini FREE tier allows only 5 requests/minute/model and will
@@ -766,11 +769,6 @@ profiles:
       context_window: 128000      # ① model's total context limit
       max_output_tokens: 32000    # ② output cap — shared by thinking + answer
       model: gemini-3.7-flash
-      thinking_level: low         # low | medium | high, or null to omit and let the
-                                  # model decide. Thinking tokens are billed as output
-                                  # AND drawn from max_output_tokens. Measured on an
-                                  # extraction prompt: low = 442 thinking tokens / 2.9s
-                                  # vs omitted = 942 / 4.4s, same parsed result.
       timeout: 1800                # seconds per LLM call before raising a timeout error
       retry_429_max: 5            # max retries on HTTP 429 rate-limit before giving up
       retry_429_base_delay: 2.0   # initial backoff seconds; doubles on each retry (exponential)

--- a/mykg_config.yaml
+++ b/mykg_config.yaml
@@ -2,7 +2,8 @@
 # myKG — Knowledge Graph Extractor
 # =============================================================================
 # ACTIVE PROFILE — change this one line to switch provider and all settings.
-# Available: ollama-local | anthropic-claude | openai | openrouter-free | claude-cli | agent-claude-code
+# Available: ollama-local | anthropic-claude | openai | gemini | openrouter-free |
+#            claude-cli | agent-claude-code
 # =============================================================================
 profile: openai
 
@@ -728,6 +729,203 @@ profiles:
       transport: stdio             # default transport: stdio | streamable_http
 
   # ---------------------------------------------------------------------------
+  gemini:
+  # Google Gemini — native google-genai SDK, requires GEMINI_API_KEY (or
+  # GOOGLE_API_KEY) in env / .env.mykg.
+  #
+  # Implicit context caching is automatic and server-side on Gemini 2.5+ models:
+  # a stable prompt prefix (the flattened schema in system_instruction) is cached
+  # by Google with no cache object to create and no storage cost. The adapter
+  # only *reports* the saving via cache_read_tokens in llm.log — it implements no
+  # caching of its own.
+  #
+  # thinking_level controls the reasoning budget. Gemini 3.x draws thinking
+  # tokens from the SAME max_output_tokens allowance as the visible answer, so a
+  # budget that is too small returns an EMPTY response with finish_reason=
+  # MAX_TOKENS. Keep max_output_tokens generous. Use thinking_level (not
+  # thinking_budget) — thinking_budget=0 is rejected by gemini-3.6-flash.
+  #
+  # NOTE ON RATE LIMITS (Invariant 13): the Gemini free tier allows only
+  # 5 requests/minute/model, so max_workers below is deliberately 2, not 8.
+  # On a paid tier, raise the max_workers values to match your quota.
+  #
+  # Token budget chain (use context-calculator to recompute when switching models):
+  #   ① context_window    = 1000000
+  #   ② max_output_tokens = 32000
+  #   ③ input_headroom    = ① − ② = 968000
+  #      batch_token_target = 32000  (conservative for reliable JSON output)
+  #      window_tokens      = batch_token_target / 4 = 8000
+  #      overlap_tokens     = window_tokens × 0.10 = 800
+  # ---------------------------------------------------------------------------
+    provider: gemini
+    llm_retry:
+      max_retries: 2        # retries on empty/blank response; set to 0 to disable
+    llm:
+      context_window: 1000000     # ① model's total context limit
+      max_output_tokens: 32000    # ② output cap — shared by thinking + answer
+      model: gemini-3.7-flash
+      thinking_level: low         # low | medium | high, or null to omit and let the
+                                  # model decide. Thinking tokens are billed as output
+                                  # AND drawn from max_output_tokens. Measured on an
+                                  # extraction prompt: low = 442 thinking tokens / 2.9s
+                                  # vs omitted = 942 / 4.4s, same parsed result.
+      timeout: 1800                # seconds per LLM call before raising a timeout error
+      retry_429_max: 5            # max retries on HTTP 429 rate-limit before giving up
+      retry_429_base_delay: 2.0   # initial backoff seconds; doubles on each retry (exponential)
+      # api_key:                  # optional: override GEMINI_API_KEY env var
+    pipeline:
+      # --- Ingestion & chunking -----------------------------------------------
+      ingest:
+        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+      # --- Preprocess (optional non-md document conversion via MinerU) ----------
+      # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
+      # call and deleted on exit; nothing is installed into mykg's interpreter.
+      preprocess:
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
+        keep_artifacts: false        # when false (default) keep only the final <stem>.md; drop MinerU's nested subtree, images/, and .mineru.json sidecar. Set true to retain everything MinerU wrote (debugging).
+        extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
+        timeout_seconds: 1800         # mineru run-phase timeout (30 min)
+        uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
+        uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
+        install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
+        extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
+          - .pdf
+          - .docx
+          - .doc
+          - .pptx
+          - .xlsx
+          - .png
+          - .jpg
+          - .jpeg
+          - .html
+          - .htm
+          - .txt
+      # --- Fetch (optional web crawl via fetch-web command) --------------------
+      # The crawler runs inside an ephemeral uv-managed venv created per fetch-web
+      # call and deleted on exit; nothing is installed into mykg's interpreter.
+      fetch:
+        enabled: true                 # master toggle for the fetch-web command
+        output_dir: mykg_web_fetch    # default base folder for fetch-web output (./<output_dir>/<domain>/); overridden by --output
+        strategy: same-domain         # link-following scope, passed to Crawlee's enqueue_links(strategy=...):
+                                       #   same-domain — follow links to the same registrable domain, across subdomains (e.g. docs.example.com + www.example.com)
+                                       #   same-origin — follow links matching scheme+host+port exactly (stricter than same-domain; subdomains excluded)
+                                       #   all         — follow any link found, including off-site domains (use with care: max_pages/max_depth become the only guardrails)
+        max_pages: 1000                # hard cap on total fetched pages (bounds runtime)
+        max_depth: 1                   # max crawl depth from the seed URL
+        respect_robots: true          # honor robots.txt disallow + crawl-delay
+        request_delay_seconds: 0.5    # politeness delay between requests
+        concurrency: 4                # max concurrent requests
+        download_assets: true         # download linked binaries whose suffix is in preprocess.extensions
+        timeout_seconds: 1800         # crawl run-phase timeout (30 min)
+        uv_path: uv                   # uv CLI path (uv is a core mykg dependency)
+        uv_python_version: "3.12"    # interpreter pinned for the ephemeral crawl venv
+        crawlee_spec: "crawlee[beautifulsoup]"   # spec installed via `uv pip install -U`
+        install_timeout_seconds: 1800 # install-phase timeout (30 min)
+        github_clone_enabled: true    # master toggle for the GitHub-repo git-clone path (vs Crawlee)
+        github_clone_depth: 1          # `git clone --depth N` — shallow clone (history depth only; full working tree is always cloned). 1 = latest commit's files only, no history. Increase (or set higher) only if you want .git/ history in _repo/ for provenance.
+        github_clone_timeout_seconds: 1800  # git clone timeout (30 min)
+        max_workers: 2                 # max concurrent seed crawls inside one shared venv for --url-list
+      chunking:
+        window_tokens: 8000     # = batch_token_target / 4
+        overlap_tokens: 800     # = window_tokens × 0.10
+        tiktoken_encoding: cl100k_base
+      # --- Pass 1: schema induction -------------------------------------------
+      pass1:
+        batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
+        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        per_file_batching: false
+        max_schema_proposals: 25  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
+        random_seed: 0  # fixed seed for deterministic batch sampling when batches exceed max_schema_proposals; scoped per-call, not shared across repeated Pass 1 invocations
+      # --- Pass 2: instance extraction ----------------------------------------
+      pass2:
+        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        stateful_chunks: true
+        prep_mode: batch_chunks             # per_file | concat | batch_chunks — controls how files are prepared before Pass 2
+        per_file_token_target: 32000   # token cap per file; used when prep_mode=per_file. Files over this are truncated to the first N tokens. 0 = no cap
+        concat_batch_token_target: 32000  # target token budget per virtual batch; used when prep_mode=concat
+        batch_token_target: 32000         # token budget per chunk batch; used when prep_mode=batch_chunks
+        batch_per_file: false              # when true, never mix chunks from different files in one batch; used when prep_mode=batch_chunks
+        batch_retry_max: 1                 # max in-run retry rounds for failed batches (0 = disabled)
+      normalize_names:
+        enabled: true
+        max_names_per_type: 50000 # safety-net cap per type; primary batch sizing is controlled by batch_token_target
+        batch_token_target: 32000 # max tokens per LLM normalization call; types are bin-packed greedily up to this limit
+      # --- Orphan recovery -----------------------------------------------------
+      orphan_pass:
+        enabled: false
+        min_cooccurrence: 1
+        top_k_per_orphan: 5
+        confidence_base: 0.5
+        confidence_weight: 0.5
+        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        schema_max_restarts: 0
+        excerpt_window: 4000
+        excerpt_context: 1500
+        excerpt_max_total: 16000
+        blank_recovery_enabled: true
+        connected_sample_size: 200
+      # --- Assembly & deduplication -------------------------------------------
+      assembly:
+        confidence_agg: mean
+        edge_id_prefix: "edge-"
+        edge_id_hex_length: 6
+        edge_dedup_separator: "|"
+        confidence_fallback: 0.0
+        confidence_scalar_omitted: 0.5
+      # --- Export --------------------------------------------------------------
+      export:
+        schema_namespace: "http://mykg.local/schema/"
+        data_namespace: "http://mykg.local/data/"
+        rdf_namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        rdfs_namespace: "http://www.w3.org/2000/01/rdf-schema#"
+        schema_prefix_label: ex
+        data_prefix_label: data
+        comment_width: 42
+        skos_namespace: "http://www.w3.org/2004/02/skos/core#"
+        networkx_enabled: true
+        obsidian_enabled: true
+        obsidian_vault_dir: obsidian_vault
+        neo4j_csv_enabled: false
+        neo4j_csv_dir: neo4j_csv
+      # --- Pipeline infrastructure --------------------------------------------
+      error_gate:
+        enabled: false
+        threshold: 3
+      feedback:
+        max_file_chars: 224640
+      paths:
+        output_dir: output
+        intermediate_dir: intermediate
+        sessions_dir: mykg_sessions
+      output:
+        json_indent: 2
+      logging:
+        max_bytes: 10485760
+        backup_count: 3
+        llm_log: false
+        capture_prompts: false
+        error_output_max_chars: 500
+      report:
+        enabled: true           # generate walkthrough.md after each extract run; set false to skip
+      merge_graphs:
+        reextraction_strategy: surgical  # none | surgical | full — controls re-extraction when merged schema has new properties absent from a source session
+        surgical_top_k_chunks_per_property: 0  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
+        human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
+        orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
+    # --- MCP server — mykg mcp-serve settings --------------------------------
+    mcp:
+      enabled: true                # master toggle for the MCP server (mykg mcp-serve) (mykg mcp-serve)
+      host: localhost              # bind address for streamable HTTP (ignored for stdio)
+      port: 3100                   # port for streamable HTTP (ignored for stdio)
+      transport: stdio             # default transport: stdio | streamable_http
+
+  # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
   ollama-local:
   # Ollama — local inference, no API key required.
   # Requires Ollama running at base_url (default: http://localhost:11434).

--- a/mykg_config.yaml
+++ b/mykg_config.yaml
@@ -745,14 +745,16 @@ profiles:
   # MAX_TOKENS. Keep max_output_tokens generous. Use thinking_level (not
   # thinking_budget) — thinking_budget=0 is rejected by gemini-3.6-flash.
   #
-  # NOTE ON RATE LIMITS (Invariant 13): the Gemini free tier allows only
-  # 5 requests/minute/model, so max_workers below is deliberately 2, not 8.
-  # On a paid tier, raise the max_workers values to match your quota.
+  # NOTE ON RATE LIMITS (Invariant 13): max_workers below matches the openai
+  # profile. The Gemini FREE tier allows only 5 requests/minute/model and will
+  # return 429 RESOURCE_EXHAUSTED at these settings — drop pass1/pass2/
+  # orphan_pass max_workers to 1–2 if you are on it. Paid tiers handle these
+  # values fine.
   #
   # Token budget chain (use context-calculator to recompute when switching models):
-  #   ① context_window    = 1000000
+  #   ① context_window    = 128000
   #   ② max_output_tokens = 32000
-  #   ③ input_headroom    = ① − ② = 968000
+  #   ③ input_headroom    = ① − ② = 96000
   #      batch_token_target = 32000  (conservative for reliable JSON output)
   #      window_tokens      = batch_token_target / 4 = 8000
   #      overlap_tokens     = window_tokens × 0.10 = 800
@@ -761,7 +763,7 @@ profiles:
     llm_retry:
       max_retries: 2        # retries on empty/blank response; set to 0 to disable
     llm:
-      context_window: 1000000     # ① model's total context limit
+      context_window: 128000      # ① model's total context limit
       max_output_tokens: 32000    # ② output cap — shared by thinking + answer
       model: gemini-3.7-flash
       thinking_level: low         # low | medium | high, or null to omit and let the
@@ -776,7 +778,7 @@ profiles:
     pipeline:
       # --- Ingestion & chunking -----------------------------------------------
       ingest:
-        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        max_workers: 8
       # --- Preprocess (optional non-md document conversion via MinerU) ----------
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
@@ -834,13 +836,13 @@ profiles:
       # --- Pass 1: schema induction -------------------------------------------
       pass1:
         batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
-        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        max_workers: 4
         per_file_batching: false
         max_schema_proposals: 25  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
         random_seed: 0  # fixed seed for deterministic batch sampling when batches exceed max_schema_proposals; scoped per-call, not shared across repeated Pass 1 invocations
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
-        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        max_workers: 4
         stateful_chunks: true
         prep_mode: batch_chunks             # per_file | concat | batch_chunks — controls how files are prepared before Pass 2
         per_file_token_target: 32000   # token cap per file; used when prep_mode=per_file. Files over this are truncated to the first N tokens. 0 = no cap
@@ -859,7 +861,7 @@ profiles:
         top_k_per_orphan: 5
         confidence_base: 0.5
         confidence_weight: 0.5
-        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        max_workers: 4
         schema_max_restarts: 0
         excerpt_window: 4000
         excerpt_context: 1500

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "tiktoken>=0.6",
     "anthropic>=0.28",
     "openai>=1.30",
+    "google-genai>=2.18",
     "click>=8.1",
     "pyyaml>=6.0",
     "python-dotenv>=1.0",

--- a/sample.env.mykg
+++ b/sample.env.mykg
@@ -6,3 +6,6 @@ OPENROUTER_API_KEY=
 
 # OpenAI
 OPENAI_API_KEY=
+
+# Google Gemini (GOOGLE_API_KEY also accepted)
+GEMINI_API_KEY=

--- a/src/mykg/cli.py
+++ b/src/mykg/cli.py
@@ -103,6 +103,13 @@ _PROFILE_META = {
         "key_url": "https://platform.openai.com/api-keys",
         "default_model": "gpt-4o",
     },
+    "gemini": {
+        "label": "Google Gemini",
+        "key_var": "GEMINI_API_KEY",
+        "key_hint": "AIza...",
+        "key_url": "https://aistudio.google.com/apikey",
+        "default_model": "gemini-3.7-flash",
+    },
     "ollama-local": {
         "label": "Ollama (local inference, no API key needed)",
         "key_var": None,

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -739,11 +739,14 @@ profiles:
   # only *reports* the saving via cache_read_tokens in llm.log — it implements no
   # caching of its own.
   #
-  # thinking_level controls the reasoning budget. Gemini 3.x draws thinking
-  # tokens from the SAME max_output_tokens allowance as the visible answer, so a
-  # budget that is too small returns an EMPTY response with finish_reason=
-  # MAX_TOKENS. Keep max_output_tokens generous. Use thinking_level (not
-  # thinking_budget) — thinking_budget=0 is rejected by gemini-3.6-flash.
+  # Gemini 3.x draws thinking tokens from the SAME max_output_tokens allowance as
+  # the visible answer, so a budget that is too small returns an EMPTY response
+  # with finish_reason=MAX_TOKENS. Keep max_output_tokens generous.
+  #
+  # The reasoning budget defaults to "low" in the adapter. To change it, add an
+  # `llm.thinking_level` key here (low | medium | high, or null to let the model
+  # decide). Use thinking_level, not thinking_budget — thinking_budget=0 is
+  # rejected outright by gemini-3.6-flash.
   #
   # NOTE ON RATE LIMITS (Invariant 13): max_workers below matches the openai
   # profile. The Gemini FREE tier allows only 5 requests/minute/model and will
@@ -766,11 +769,6 @@ profiles:
       context_window: 128000      # ① model's total context limit
       max_output_tokens: 32000    # ② output cap — shared by thinking + answer
       model: gemini-3.7-flash
-      thinking_level: low         # low | medium | high, or null to omit and let the
-                                  # model decide. Thinking tokens are billed as output
-                                  # AND drawn from max_output_tokens. Measured on an
-                                  # extraction prompt: low = 442 thinking tokens / 2.9s
-                                  # vs omitted = 942 / 4.4s, same parsed result.
       timeout: 1800                # seconds per LLM call before raising a timeout error
       retry_429_max: 5            # max retries on HTTP 429 rate-limit before giving up
       retry_429_base_delay: 2.0   # initial backoff seconds; doubles on each retry (exponential)

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -2,7 +2,8 @@
 # myKG — Knowledge Graph Extractor
 # =============================================================================
 # ACTIVE PROFILE — change this one line to switch provider and all settings.
-# Available: ollama-local | anthropic-claude | openai | openrouter-free | claude-cli | agent-claude-code
+# Available: ollama-local | anthropic-claude | openai | gemini | openrouter-free |
+#            claude-cli | agent-claude-code
 # =============================================================================
 profile: openai
 
@@ -728,6 +729,203 @@ profiles:
       transport: stdio             # default transport: stdio | streamable_http
 
   # ---------------------------------------------------------------------------
+  gemini:
+  # Google Gemini — native google-genai SDK, requires GEMINI_API_KEY (or
+  # GOOGLE_API_KEY) in env / .env.mykg.
+  #
+  # Implicit context caching is automatic and server-side on Gemini 2.5+ models:
+  # a stable prompt prefix (the flattened schema in system_instruction) is cached
+  # by Google with no cache object to create and no storage cost. The adapter
+  # only *reports* the saving via cache_read_tokens in llm.log — it implements no
+  # caching of its own.
+  #
+  # thinking_level controls the reasoning budget. Gemini 3.x draws thinking
+  # tokens from the SAME max_output_tokens allowance as the visible answer, so a
+  # budget that is too small returns an EMPTY response with finish_reason=
+  # MAX_TOKENS. Keep max_output_tokens generous. Use thinking_level (not
+  # thinking_budget) — thinking_budget=0 is rejected by gemini-3.6-flash.
+  #
+  # NOTE ON RATE LIMITS (Invariant 13): the Gemini free tier allows only
+  # 5 requests/minute/model, so max_workers below is deliberately 2, not 8.
+  # On a paid tier, raise the max_workers values to match your quota.
+  #
+  # Token budget chain (use context-calculator to recompute when switching models):
+  #   ① context_window    = 1000000
+  #   ② max_output_tokens = 32000
+  #   ③ input_headroom    = ① − ② = 968000
+  #      batch_token_target = 32000  (conservative for reliable JSON output)
+  #      window_tokens      = batch_token_target / 4 = 8000
+  #      overlap_tokens     = window_tokens × 0.10 = 800
+  # ---------------------------------------------------------------------------
+    provider: gemini
+    llm_retry:
+      max_retries: 2        # retries on empty/blank response; set to 0 to disable
+    llm:
+      context_window: 1000000     # ① model's total context limit
+      max_output_tokens: 32000    # ② output cap — shared by thinking + answer
+      model: gemini-3.7-flash
+      thinking_level: low         # low | medium | high, or null to omit and let the
+                                  # model decide. Thinking tokens are billed as output
+                                  # AND drawn from max_output_tokens. Measured on an
+                                  # extraction prompt: low = 442 thinking tokens / 2.9s
+                                  # vs omitted = 942 / 4.4s, same parsed result.
+      timeout: 1800                # seconds per LLM call before raising a timeout error
+      retry_429_max: 5            # max retries on HTTP 429 rate-limit before giving up
+      retry_429_base_delay: 2.0   # initial backoff seconds; doubles on each retry (exponential)
+      # api_key:                  # optional: override GEMINI_API_KEY env var
+    pipeline:
+      # --- Ingestion & chunking -----------------------------------------------
+      ingest:
+        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+      # --- Preprocess (optional non-md document conversion via MinerU) ----------
+      # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
+      # call and deleted on exit; nothing is installed into mykg's interpreter.
+      preprocess:
+        enabled: true                # set true to convert non-md files (PDF/DOCX/images) via MinerU before ingest
+        subdir: _preprocessed         # converted .md files land in <session>/input/<subdir>/
+        keep_artifacts: false        # when false (default) keep only the final <stem>.md; drop MinerU's nested subtree, images/, and .mineru.json sidecar. Set true to retain everything MinerU wrote (debugging).
+        extra_args: []                # extra arguments passed through to mineru (e.g. ["--backend", "pipeline"])
+        timeout_seconds: 1800         # mineru run-phase timeout (30 min)
+        uv_path: uv                   # path or PATH name of the uv CLI (uv is a core mykg dependency)
+        uv_python_version: "3.12"    # interpreter version uv pins the ephemeral venv to
+        mineru_spec: "mineru[all] pdftext<0.7.0"      # package spec installed via `uv pip install -U <spec>`
+        install_timeout_seconds: 1800 # install-phase timeout (30 min); first-run downloads PyTorch/Ray
+        extensions:                   # suffixes the preprocess step may convert (.md is native and never listed). Backend per suffix is hardcoded: HTML → markdownify in-process, everything else → MinerU. Remove a line to skip that suffix.
+          - .pdf
+          - .docx
+          - .doc
+          - .pptx
+          - .xlsx
+          - .png
+          - .jpg
+          - .jpeg
+          - .html
+          - .htm
+          - .txt
+      # --- Fetch (optional web crawl via fetch-web command) --------------------
+      # The crawler runs inside an ephemeral uv-managed venv created per fetch-web
+      # call and deleted on exit; nothing is installed into mykg's interpreter.
+      fetch:
+        enabled: true                 # master toggle for the fetch-web command
+        output_dir: mykg_web_fetch    # default base folder for fetch-web output (./<output_dir>/<domain>/); overridden by --output
+        strategy: same-domain         # link-following scope, passed to Crawlee's enqueue_links(strategy=...):
+                                       #   same-domain — follow links to the same registrable domain, across subdomains (e.g. docs.example.com + www.example.com)
+                                       #   same-origin — follow links matching scheme+host+port exactly (stricter than same-domain; subdomains excluded)
+                                       #   all         — follow any link found, including off-site domains (use with care: max_pages/max_depth become the only guardrails)
+        max_pages: 1000                # hard cap on total fetched pages (bounds runtime)
+        max_depth: 1                   # max crawl depth from the seed URL
+        respect_robots: true          # honor robots.txt disallow + crawl-delay
+        request_delay_seconds: 0.5    # politeness delay between requests
+        concurrency: 4                # max concurrent requests
+        download_assets: true         # download linked binaries whose suffix is in preprocess.extensions
+        timeout_seconds: 1800         # crawl run-phase timeout (30 min)
+        uv_path: uv                   # uv CLI path (uv is a core mykg dependency)
+        uv_python_version: "3.12"    # interpreter pinned for the ephemeral crawl venv
+        crawlee_spec: "crawlee[beautifulsoup]"   # spec installed via `uv pip install -U`
+        install_timeout_seconds: 1800 # install-phase timeout (30 min)
+        github_clone_enabled: true    # master toggle for the GitHub-repo git-clone path (vs Crawlee)
+        github_clone_depth: 1          # `git clone --depth N` — shallow clone (history depth only; full working tree is always cloned). 1 = latest commit's files only, no history. Increase (or set higher) only if you want .git/ history in _repo/ for provenance.
+        github_clone_timeout_seconds: 1800  # git clone timeout (30 min)
+        max_workers: 2                 # max concurrent seed crawls inside one shared venv for --url-list
+      chunking:
+        window_tokens: 8000     # = batch_token_target / 4
+        overlap_tokens: 800     # = window_tokens × 0.10
+        tiktoken_encoding: cl100k_base
+      # --- Pass 1: schema induction -------------------------------------------
+      pass1:
+        batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
+        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        per_file_batching: false
+        max_schema_proposals: 25  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
+        random_seed: 0  # fixed seed for deterministic batch sampling when batches exceed max_schema_proposals; scoped per-call, not shared across repeated Pass 1 invocations
+      # --- Pass 2: instance extraction ----------------------------------------
+      pass2:
+        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        stateful_chunks: true
+        prep_mode: batch_chunks             # per_file | concat | batch_chunks — controls how files are prepared before Pass 2
+        per_file_token_target: 32000   # token cap per file; used when prep_mode=per_file. Files over this are truncated to the first N tokens. 0 = no cap
+        concat_batch_token_target: 32000  # target token budget per virtual batch; used when prep_mode=concat
+        batch_token_target: 32000         # token budget per chunk batch; used when prep_mode=batch_chunks
+        batch_per_file: false              # when true, never mix chunks from different files in one batch; used when prep_mode=batch_chunks
+        batch_retry_max: 1                 # max in-run retry rounds for failed batches (0 = disabled)
+      normalize_names:
+        enabled: true
+        max_names_per_type: 50000 # safety-net cap per type; primary batch sizing is controlled by batch_token_target
+        batch_token_target: 32000 # max tokens per LLM normalization call; types are bin-packed greedily up to this limit
+      # --- Orphan recovery -----------------------------------------------------
+      orphan_pass:
+        enabled: false
+        min_cooccurrence: 1
+        top_k_per_orphan: 5
+        confidence_base: 0.5
+        confidence_weight: 0.5
+        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        schema_max_restarts: 0
+        excerpt_window: 4000
+        excerpt_context: 1500
+        excerpt_max_total: 16000
+        blank_recovery_enabled: true
+        connected_sample_size: 200
+      # --- Assembly & deduplication -------------------------------------------
+      assembly:
+        confidence_agg: mean
+        edge_id_prefix: "edge-"
+        edge_id_hex_length: 6
+        edge_dedup_separator: "|"
+        confidence_fallback: 0.0
+        confidence_scalar_omitted: 0.5
+      # --- Export --------------------------------------------------------------
+      export:
+        schema_namespace: "http://mykg.local/schema/"
+        data_namespace: "http://mykg.local/data/"
+        rdf_namespace: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        rdfs_namespace: "http://www.w3.org/2000/01/rdf-schema#"
+        schema_prefix_label: ex
+        data_prefix_label: data
+        comment_width: 42
+        skos_namespace: "http://www.w3.org/2004/02/skos/core#"
+        networkx_enabled: true
+        obsidian_enabled: true
+        obsidian_vault_dir: obsidian_vault
+        neo4j_csv_enabled: false
+        neo4j_csv_dir: neo4j_csv
+      # --- Pipeline infrastructure --------------------------------------------
+      error_gate:
+        enabled: false
+        threshold: 3
+      feedback:
+        max_file_chars: 224640
+      paths:
+        output_dir: output
+        intermediate_dir: intermediate
+        sessions_dir: mykg_sessions
+      output:
+        json_indent: 2
+      logging:
+        max_bytes: 10485760
+        backup_count: 3
+        llm_log: false
+        capture_prompts: false
+        error_output_max_chars: 500
+      report:
+        enabled: true           # generate walkthrough.md after each extract run; set false to skip
+      merge_graphs:
+        reextraction_strategy: surgical  # none | surgical | full — controls re-extraction when merged schema has new properties absent from a source session
+        surgical_top_k_chunks_per_property: 0  # 0 = no cap; >0 = top-K chunks per new property (ranked by domain/range node co-occurrence)
+        human_review: false             # pause for human review of merged schema; overridden by --human-review CLI flag
+        orphan_pass_max_restarts: 1     # max schema-gap restart loops during merge orphan pass (0 = disabled)
+      append:
+        grow_schema_backfill_top_k_chunks_per_type: 10  # --append --grow-schema: 0 = disable back-fill; >0 = top-K old chunks re-extracted per newly added concept/property (ranked by domain/range/hierarchy node co-occurrence) (D52)
+    # --- MCP server — mykg mcp-serve settings --------------------------------
+    mcp:
+      enabled: true                # master toggle for the MCP server (mykg mcp-serve) (mykg mcp-serve)
+      host: localhost              # bind address for streamable HTTP (ignored for stdio)
+      port: 3100                   # port for streamable HTTP (ignored for stdio)
+      transport: stdio             # default transport: stdio | streamable_http
+
+  # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
   ollama-local:
   # Ollama — local inference, no API key required.
   # Requires Ollama running at base_url (default: http://localhost:11434).

--- a/src/mykg/data/mykg_config.yaml
+++ b/src/mykg/data/mykg_config.yaml
@@ -745,14 +745,16 @@ profiles:
   # MAX_TOKENS. Keep max_output_tokens generous. Use thinking_level (not
   # thinking_budget) — thinking_budget=0 is rejected by gemini-3.6-flash.
   #
-  # NOTE ON RATE LIMITS (Invariant 13): the Gemini free tier allows only
-  # 5 requests/minute/model, so max_workers below is deliberately 2, not 8.
-  # On a paid tier, raise the max_workers values to match your quota.
+  # NOTE ON RATE LIMITS (Invariant 13): max_workers below matches the openai
+  # profile. The Gemini FREE tier allows only 5 requests/minute/model and will
+  # return 429 RESOURCE_EXHAUSTED at these settings — drop pass1/pass2/
+  # orphan_pass max_workers to 1–2 if you are on it. Paid tiers handle these
+  # values fine.
   #
   # Token budget chain (use context-calculator to recompute when switching models):
-  #   ① context_window    = 1000000
+  #   ① context_window    = 128000
   #   ② max_output_tokens = 32000
-  #   ③ input_headroom    = ① − ② = 968000
+  #   ③ input_headroom    = ① − ② = 96000
   #      batch_token_target = 32000  (conservative for reliable JSON output)
   #      window_tokens      = batch_token_target / 4 = 8000
   #      overlap_tokens     = window_tokens × 0.10 = 800
@@ -761,7 +763,7 @@ profiles:
     llm_retry:
       max_retries: 2        # retries on empty/blank response; set to 0 to disable
     llm:
-      context_window: 1000000     # ① model's total context limit
+      context_window: 128000      # ① model's total context limit
       max_output_tokens: 32000    # ② output cap — shared by thinking + answer
       model: gemini-3.7-flash
       thinking_level: low         # low | medium | high, or null to omit and let the
@@ -776,7 +778,7 @@ profiles:
     pipeline:
       # --- Ingestion & chunking -----------------------------------------------
       ingest:
-        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        max_workers: 8
       # --- Preprocess (optional non-md document conversion via MinerU) ----------
       # MinerU runs inside an ephemeral uv-managed venv created per parse-docs
       # call and deleted on exit; nothing is installed into mykg's interpreter.
@@ -834,13 +836,13 @@ profiles:
       # --- Pass 1: schema induction -------------------------------------------
       pass1:
         batch_token_target: 32000  # conservative; MUST stay ≤ context_window − max_output_tokens
-        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        max_workers: 4
         per_file_batching: false
         max_schema_proposals: 25  # cap raw proposals sent to harmonize_schema; prevents context overflow on large corpora
         random_seed: 0  # fixed seed for deterministic batch sampling when batches exceed max_schema_proposals; scoped per-call, not shared across repeated Pass 1 invocations
       # --- Pass 2: instance extraction ----------------------------------------
       pass2:
-        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        max_workers: 4
         stateful_chunks: true
         prep_mode: batch_chunks             # per_file | concat | batch_chunks — controls how files are prepared before Pass 2
         per_file_token_target: 32000   # token cap per file; used when prep_mode=per_file. Files over this are truncated to the first N tokens. 0 = no cap
@@ -859,7 +861,7 @@ profiles:
         top_k_per_orphan: 5
         confidence_base: 0.5
         confidence_weight: 0.5
-        max_workers: 2  # free tier = 5 req/min/model; raise on a paid tier
+        max_workers: 4
         schema_max_restarts: 0
         excerpt_window: 4000
         excerpt_context: 1500

--- a/src/mykg/llm/config.py
+++ b/src/mykg/llm/config.py
@@ -97,6 +97,24 @@ def load_adapter(
             error_gate=error_gate,
         )
 
+    if provider == "gemini":
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        return GeminiAdapter(
+            model=section["model"],
+            max_tokens=section["max_output_tokens"],
+            timeout=section["timeout"],
+            api_key=(
+                section.get("api_key")
+                or os.environ.get("GEMINI_API_KEY")
+                or os.environ.get("GOOGLE_API_KEY")
+            ),
+            thinking_level=section.get("thinking_level", "low"),
+            retry_429_max=section.get("retry_429_max", _cfg.LLM_RETRY_429_MAX),
+            retry_429_base_delay=section.get("retry_429_base_delay", _cfg.LLM_RETRY_429_BASE_DELAY),
+            error_gate=error_gate,
+        )
+
     if provider == "claude-cli":
         from mykg.llm.claude_cli_adapter import ClaudeCLIAdapter
 

--- a/src/mykg/llm/gemini_adapter.py
+++ b/src/mykg/llm/gemini_adapter.py
@@ -41,6 +41,36 @@ _log = logging.getLogger(__name__)
 _DEFAULT_THINKING_LEVEL = "low"
 
 
+# google-genai logs an INFO notice on every generate_content call recommending
+# Chat.send_message for automatic function calling. mykg never uses tools, so
+# that notice is pure noise repeated once per chunk in run.log.
+#
+# A filter on that one message is used rather than raising the logger's level:
+# setLevel would also suppress genuine warnings from google_genai.models, and
+# re-applying it per adapter construction would mutate global logging state on
+# behalf of the whole process. The filter is installed exactly once and drops
+# only the AFC line.
+# Two distinct AFC lines are emitted: an INFO "AFC is enabled with max remote
+# calls: N." on every call, and a longer "Direct use of automatic function
+# calling (AFC) ... is not recommended" notice.
+_AFC_MARKERS = ("automatic function calling", "afc is enabled")
+_afc_filter_installed = False
+
+
+def _drop_afc_notice(record: logging.LogRecord) -> bool:
+    msg = record.getMessage().lower()
+    return not any(marker in msg for marker in _AFC_MARKERS)
+
+
+def _silence_afc_notice() -> None:
+    """Install the AFC-notice filter once per process."""
+    global _afc_filter_installed
+    if _afc_filter_installed:
+        return
+    logging.getLogger("google_genai.models").addFilter(_drop_afc_notice)
+    _afc_filter_installed = True
+
+
 class _GeminiRetryable(Exception):
     """Marker for Gemini errors worth retrying (429 and 5xx).
 
@@ -92,13 +122,8 @@ class GeminiAdapter(LLMAdapter):
                 "set it in your environment or supply api_key in mykg_config.yaml"
             )
 
+        _silence_afc_notice()
         self._client = genai.Client(api_key=api_key)
-
-        # google-genai warns on every generate_content call that automatic
-        # function calling is better used via Chat.send_message. mykg never uses
-        # tools/function calling, so the notice is pure noise that would repeat
-        # once per chunk in run.log.
-        logging.getLogger("google_genai.models").setLevel(logging.ERROR)
 
     def endpoint_label(self) -> str:
         return f"gemini / {self._model} @ https://generativelanguage.googleapis.com"

--- a/src/mykg/llm/gemini_adapter.py
+++ b/src/mykg/llm/gemini_adapter.py
@@ -36,8 +36,9 @@ _log = logging.getLogger(__name__)
 #
 # `thinking_level` is the portable control: thinking_budget=0 is rejected with
 # 400 INVALID_ARGUMENT by gemini-3.6-flash while being accepted by 3.7/3.5/3.1.
-# Set llm.thinking_level to null in mykg_config.yaml to omit it entirely and let
-# the model use its own default.
+# The shipped gemini profile does not carry the key, so this default applies;
+# add an optional llm.thinking_level to the profile to override it, or set it to
+# null there to omit thinking_config entirely and let the model decide.
 _DEFAULT_THINKING_LEVEL = "low"
 
 

--- a/src/mykg/llm/gemini_adapter.py
+++ b/src/mykg/llm/gemini_adapter.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import TYPE_CHECKING
+
+from google import genai
+from google.genai import errors as genai_errors
+from google.genai import types as genai_types
+
+from mykg.llm.adapter import LLMAdapter
+from mykg.llm.retry import (
+    log_context_overflow,
+    log_truncated_output,
+    looks_like_context_exceeded,
+    retry_on_rate_limit,
+)
+from mykg.logging import record_llm_call
+
+if TYPE_CHECKING:
+    from mykg.llm.error_gate import ErrorGate
+
+_log = logging.getLogger(__name__)
+
+# Gemini 3.x models reason before answering, and those thinking tokens are drawn
+# from the same max_output_tokens budget as the visible answer. A budget that is
+# too small returns finish_reason=MAX_TOKENS with an EMPTY response body rather
+# than an error, which the pipeline would record as a blank_response chunk (D33).
+#
+# "low" is the default rather than leaving thinking unconfigured because omitting
+# it costs materially more for no gain: measured on a representative extraction
+# prompt (gemini-3.5-flash), omitted = 942 thinking tokens / 4.4s versus
+# low = 442 / 2.9s, with both producing identical parseable output. Those tokens
+# are billed as output and consume the max_output_tokens allowance.
+#
+# `thinking_level` is the portable control: thinking_budget=0 is rejected with
+# 400 INVALID_ARGUMENT by gemini-3.6-flash while being accepted by 3.7/3.5/3.1.
+# Set llm.thinking_level to null in mykg_config.yaml to omit it entirely and let
+# the model use its own default.
+_DEFAULT_THINKING_LEVEL = "low"
+
+
+class _GeminiRetryable(Exception):
+    """Marker for Gemini errors worth retrying (429 and 5xx).
+
+    google-genai raises ClientError for the whole 4xx family, so catching it
+    wholesale in retry_on_rate_limit would also retry genuine caller mistakes
+    (bad model name, malformed request) that no amount of retrying can fix.
+    Wrapping only the retryable statuses keeps precondition errors failing fast.
+    """
+
+    def __init__(self, message: str, original: BaseException):
+        super().__init__(message)
+        self.original = original
+
+
+def _status_of(exc: BaseException) -> int | None:
+    """Best-effort HTTP status extraction from a google-genai APIError."""
+    code = getattr(exc, "code", None)
+    if isinstance(code, int):
+        return code
+    status = getattr(exc, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+class GeminiAdapter(LLMAdapter):
+    def __init__(
+        self,
+        model: str,
+        max_tokens: int,
+        timeout: int,
+        api_key: str | None = None,
+        thinking_level: str | None = _DEFAULT_THINKING_LEVEL,
+        retry_429_max: int = 5,
+        retry_429_base_delay: float = 2.0,
+        error_gate: ErrorGate | None = None,
+    ):
+        self._model = model
+        self._max_tokens = max_tokens
+        self._timeout = timeout
+        self._thinking_level = thinking_level
+        self._retry_429_max = retry_429_max
+        self._retry_429_base_delay = retry_429_base_delay
+        self._error_gate = error_gate
+
+        if api_key is None:
+            api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "GEMINI_API_KEY (or GOOGLE_API_KEY) is required — "
+                "set it in your environment or supply api_key in mykg_config.yaml"
+            )
+
+        self._client = genai.Client(api_key=api_key)
+
+        # google-genai warns on every generate_content call that automatic
+        # function calling is better used via Chat.send_message. mykg never uses
+        # tools/function calling, so the notice is pure noise that would repeat
+        # once per chunk in run.log.
+        logging.getLogger("google_genai.models").setLevel(logging.ERROR)
+
+    def endpoint_label(self) -> str:
+        return f"gemini / {self._model} @ https://generativelanguage.googleapis.com"
+
+    def _build_config(
+        self, system: str, max_output_tokens: int, timeout_s: int
+    ) -> genai_types.GenerateContentConfig:
+        # The system prompt carries the run-stable prefix (flattened schema +
+        # instructions). Passing it as system_instruction is what lets Gemini's
+        # implicit caching latch onto it — no explicit cache object is created or
+        # needed; caching is automatic and server-side on 2.5+ models.
+        thinking = (
+            genai_types.ThinkingConfig(thinking_level=self._thinking_level)
+            if self._thinking_level
+            else None
+        )
+        return genai_types.GenerateContentConfig(
+            system_instruction=system,
+            max_output_tokens=max_output_tokens,
+            response_mime_type="application/json",
+            thinking_config=thinking,
+            # HttpOptions.timeout is in MILLISECONDS, while every mykg timeout
+            # config value is in seconds.
+            http_options=genai_types.HttpOptions(timeout=timeout_s * 1000),
+        )
+
+    def complete(
+        self,
+        system: str,
+        user: str,
+        context_label: str = "",
+        max_tokens: int | None = None,
+        timeout: int | None = None,
+    ) -> str:
+        effective_max_tokens = max_tokens if max_tokens is not None else self._max_tokens
+        effective_timeout = timeout if timeout is not None else self._timeout
+
+        def _call() -> str:
+            t0 = time.monotonic()
+            try:
+                resp = self._client.models.generate_content(
+                    model=self._model,
+                    contents=user,
+                    config=self._build_config(system, effective_max_tokens, effective_timeout),
+                )
+            except genai_errors.APIError as exc:
+                status = _status_of(exc)
+                error_msg = str(exc)
+                if looks_like_context_exceeded(exc):
+                    log_context_overflow("gemini", self._model, context_label, exc)
+                    error_msg = f"context_length_exceeded: {error_msg}"
+                record_llm_call(
+                    provider="gemini",
+                    model=self._model,
+                    context_label=context_label,
+                    input_tokens=0,
+                    output_tokens=0,
+                    duration_s=time.monotonic() - t0,
+                    system_prompt=system,
+                    user_prompt=user,
+                    status_code=status,
+                    error=error_msg,
+                )
+                # 429 (quota) and 5xx (transient overload) are worth retrying;
+                # everything else is a caller error that retrying cannot fix.
+                if status == 429 or (status is not None and status >= 500):
+                    raise _GeminiRetryable(f"Gemini {status}: {exc}", exc) from exc
+                raise
+
+            raw = resp.text or ""
+            raw_reason = self._raw_finish_reason(resp)
+            truncated = raw_reason is not None and raw_reason.endswith("MAX_TOKENS")
+            finish_reason = "max_tokens" if truncated else None
+            label = f" [{context_label}]" if context_label else ""
+            blocked_reason: str | None = None
+
+            if truncated:
+                log_truncated_output("gemini", self._model, context_label, finish_reason)
+                if not raw.strip():
+                    # The entire token budget went to thinking, leaving no answer.
+                    # Without this warning the failure surfaces far downstream as an
+                    # unexplained blank chunk.
+                    _log.warning(
+                        "gemini/%s%s — hit max_output_tokens with an empty response; "
+                        "the thinking budget consumed the whole allowance. Raise "
+                        "llm.max_output_tokens or lower llm.thinking_level.",
+                        self._model,
+                        label,
+                    )
+            elif not raw.strip() and raw_reason not in (None, "STOP", "FINISH_REASON_UNSPECIFIED"):
+                # SAFETY / RECITATION / PROHIBITED_CONTENT and friends return an
+                # empty body with a 200. Without this the chunk lands in
+                # failed_chunks.json as an unexplained blank_response (D33).
+                blocked_reason = raw_reason
+                _log.warning(
+                    "gemini/%s%s — empty response, blocked with finish_reason=%s; "
+                    "the model refused to answer for this input.",
+                    self._model,
+                    label,
+                    raw_reason,
+                )
+
+            usage = getattr(resp, "usage_metadata", None)
+            input_tokens = _count(usage, "prompt_token_count")
+            output_tokens = _count(usage, "candidates_token_count") + _count(
+                usage, "thoughts_token_count"
+            )
+            # Implicit caching is automatic — this only reports the saving it
+            # already delivered. cache_creation_tokens stays 0: there is no
+            # creation step for an implicit cache.
+            cache_read = _count(usage, "cached_content_token_count")
+
+            record_llm_call(
+                provider="gemini",
+                model=self._model,
+                context_label=context_label,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                duration_s=time.monotonic() - t0,
+                cache_read_tokens=cache_read,
+                raw_response=raw,
+                system_prompt=system,
+                user_prompt=user,
+                finish_reason=finish_reason,
+                error=(f"blocked: finish_reason={blocked_reason}" if blocked_reason else None),
+            )
+            return self.strip_code_fences(raw)
+
+        try:
+            return retry_on_rate_limit(  # type: ignore[return-value]
+                _call,
+                _GeminiRetryable,
+                "Gemini",
+                self._retry_429_max,
+                self._retry_429_base_delay,
+                error_gate=self._error_gate,
+            )
+        except _GeminiRetryable as exc:
+            # Retries exhausted — surface the provider's own exception, not the
+            # internal marker, so callers see a normal google-genai error.
+            raise exc.original from None
+
+    @staticmethod
+    def _raw_finish_reason(resp: object) -> str | None:
+        """Return the response's finish reason as an upper-case name, if any.
+
+        google-genai reports finish_reason as a FinishReason enum, so this reads
+        the member name rather than comparing against a string literal.
+        """
+        candidates = getattr(resp, "candidates", None) or []
+        if not candidates:
+            return None
+        reason = getattr(candidates[0], "finish_reason", None)
+        if reason is None:
+            return None
+        name = getattr(reason, "name", None) or str(reason)
+        return name.rsplit(".", 1)[-1].upper() or None
+
+
+def _count(usage: object, field: str) -> int:
+    """Read a token count off usage_metadata, coercing absent/None to 0.
+
+    Probing showed these attributes are present-but-None (not absent, not 0)
+    whenever the corresponding count does not apply to a response.
+    """
+    value = getattr(usage, field, 0) or 0
+    return value if isinstance(value, int) else 0

--- a/src/mykg/llm/retry.py
+++ b/src/mykg/llm/retry.py
@@ -30,6 +30,13 @@ _CONTEXT_EXCEEDED_MARKERS = (
     "too many tokens",
     "prompt is too long",
     "context_length_exceeded",
+    # Gemini phrases input overflow as "The input token count (N) exceeds the
+    # maximum number of tokens allowed" — matched by neither "maximum context"
+    # nor "too many tokens". Anchored on "input token count" rather than the
+    # looser "exceeds the maximum number of tokens", which also matches Gemini's
+    # *output*-cap rejection and would mislabel a max_output_tokens problem as a
+    # context-window one (different fix, different knob).
+    "input token count",
 )
 
 

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -2767,3 +2767,25 @@ def test_gemini_raw_finish_reason_edge_cases():
     assert read(_NoneReason()) is None
     # dotted enum repr is reduced to the bare member name
     assert read(_PlainStringEnum()) == "MAX_TOKENS"
+
+
+def test_config_gemini_thinking_level_defaults_when_key_absent():
+    """Omitting llm.thinking_level yields the adapter's "low" default.
+
+    The shipped gemini profile deliberately does not carry the key, so the
+    default must survive its absence rather than becoming None.
+    """
+    raw = {
+        "provider": "gemini",
+        "llm": {
+            "model": "gemini-3.7-flash",
+            "max_output_tokens": 4096,
+            "timeout": 120,
+        },
+    }
+    with patch("google.genai.Client"), patch.dict(os.environ, {"GEMINI_API_KEY": "k"}):
+        from mykg.llm.config import load_adapter
+
+        adapter = load_adapter(_raw=raw)
+
+    assert adapter._thinking_level == "low"

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -1102,8 +1102,7 @@ def test_openrouter_wall_clock_timeout_raises_timeouterror(monkeypatch):
 
     # record_llm_call should have been invoked with the wall-clock error
     found = any(
-        "wall-clock timeout" in str(c.kwargs.get("error", ""))
-        for c in mock_record.call_args_list
+        "wall-clock timeout" in str(c.kwargs.get("error", "")) for c in mock_record.call_args_list
     )
     assert found, "record_llm_call should record the wall-clock timeout error"
 
@@ -1309,9 +1308,7 @@ def test_anthropic_adapter_context_exceeded_logs_and_reraises():
             adapter.complete("sys", "user")
 
     call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
-    assert any(
-        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
-    )
+    assert any("context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list)
 
 
 def test_openai_adapter_truncated_response_logs_finish_reason():
@@ -1387,9 +1384,7 @@ def test_openai_adapter_context_exceeded_logs_and_reraises():
             adapter.complete("sys", "user")
 
     call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
-    assert any(
-        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
-    )
+    assert any("context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list)
 
 
 def test_openrouter_adapter_truncated_response_logs_finish_reason():
@@ -1463,9 +1458,7 @@ def test_openrouter_adapter_context_exceeded_marks_error():
             adapter.complete("s", "u")
 
     call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
-    assert any(
-        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
-    )
+    assert any("context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list)
 
 
 def test_ollama_adapter_truncated_response_logs_finish_reason():
@@ -1545,9 +1538,7 @@ def test_ollama_adapter_context_exceeded_http_error_logs_and_reraises():
             adapter.complete("sys", "user")
 
     call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
-    assert any(
-        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
-    )
+    assert any("context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list)
 
 
 def test_ollama_adapter_context_exceeded_url_error_logs_and_reraises():
@@ -1563,9 +1554,7 @@ def test_ollama_adapter_context_exceeded_url_error_logs_and_reraises():
             adapter.complete("sys", "user")
 
     call_kwargs_list = [c.kwargs for c in mock_record.call_args_list]
-    assert any(
-        "context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list
-    )
+    assert any("context_length_exceeded" in str(k.get("error", "")) for k in call_kwargs_list)
 
 
 def test_ollama_adapter_non_context_url_error_not_logged():
@@ -1606,7 +1595,10 @@ def test_anthropic_truncation_warns_on_standard_logger(caplog):
     truncated_response.content = [truncated_block]
     truncated_response.stop_reason = "max_tokens"
 
-    with patch("anthropic.Anthropic") as mock_cls, caplog.at_level("WARNING", logger="mykg.llm.retry"):
+    with (
+        patch("anthropic.Anthropic") as mock_cls,
+        caplog.at_level("WARNING", logger="mykg.llm.retry"),
+    ):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
         mock_client.messages.create.return_value = truncated_response
@@ -1630,7 +1622,10 @@ def test_anthropic_normal_completion_emits_no_warning(caplog):
     ok_response.content = [ok_block]
     ok_response.stop_reason = "end_turn"
 
-    with patch("anthropic.Anthropic") as mock_cls, caplog.at_level("WARNING", logger="mykg.llm.retry"):
+    with (
+        patch("anthropic.Anthropic") as mock_cls,
+        caplog.at_level("WARNING", logger="mykg.llm.retry"),
+    ):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client
         mock_client.messages.create.return_value = ok_response
@@ -2042,3 +2037,589 @@ def test_anthropic_adapter_missing_usage_defaults_all_to_zero():
     assert kwargs.get("output_tokens") == 0
     assert kwargs.get("cache_read_tokens") == 0
     assert kwargs.get("cache_creation_tokens") == 0
+
+
+# ---------------------------------------------------------------------------
+# GeminiAdapter
+# ---------------------------------------------------------------------------
+
+
+class _GeminiUsage:
+    """usage_metadata stand-in.
+
+    Plain class rather than MagicMock so a test can omit fields entirely and
+    exercise the adapter's absent-field default path. Gemini reports these as
+    present-but-None when a count does not apply, so None is the default here
+    rather than 0.
+    """
+
+    def __init__(
+        self,
+        prompt_token_count=100,
+        candidates_token_count=20,
+        thoughts_token_count=None,
+        cached_content_token_count=None,
+    ):
+        self.prompt_token_count = prompt_token_count
+        self.candidates_token_count = candidates_token_count
+        self.thoughts_token_count = thoughts_token_count
+        self.cached_content_token_count = cached_content_token_count
+
+
+def _gemini_response(text="{}", finish_reason="STOP", usage=None):
+    """Build a generate_content response double.
+
+    finish_reason is an enum in the real SDK, so the double exposes `.name`
+    exactly as FinishReason does.
+    """
+    candidate = MagicMock()
+    candidate.finish_reason = MagicMock()
+    candidate.finish_reason.name = finish_reason
+    resp = MagicMock()
+    resp.candidates = [candidate]
+    resp.text = text
+    resp.usage_metadata = usage if usage is not None else _GeminiUsage()
+    return resp
+
+
+def _gemini_client(response=None, side_effect=None):
+    """Patch google.genai.Client and return (patcher_cm, mock_client)."""
+    mock_client = MagicMock()
+    if side_effect is not None:
+        mock_client.models.generate_content.side_effect = side_effect
+    else:
+        mock_client.models.generate_content.return_value = response or _gemini_response()
+    return mock_client
+
+
+def _api_error(status: int, message: str = "boom"):
+    """Construct a google-genai APIError carrying an HTTP status code."""
+    from google.genai import errors as genai_errors
+
+    exc = genai_errors.APIError.__new__(genai_errors.APIError)
+    Exception.__init__(exc, message)
+    exc.code = status
+    exc.message = message
+    return exc
+
+
+def test_gemini_adapter_complete():
+    """complete() sends system as system_instruction and user as contents."""
+    with patch("google.genai.Client") as mock_cls:
+        mock_client = _gemini_client(_gemini_response(text='{"ok": true}'))
+        mock_cls.return_value = mock_client
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash", max_tokens=4096, timeout=30, api_key="test-key"
+        )
+        result = adapter.complete("system prompt", "user prompt")
+
+    assert result == '{"ok": true}'
+    kwargs = mock_client.models.generate_content.call_args.kwargs
+    assert kwargs["model"] == "gemini-3.7-flash"
+    assert kwargs["contents"] == "user prompt"
+    assert kwargs["config"].system_instruction == "system prompt"
+    assert kwargs["config"].max_output_tokens == 4096
+
+
+def test_gemini_adapter_requests_json_and_thinking_level():
+    """JSON mime type and the configured thinking_level reach the request config."""
+    with patch("google.genai.Client") as mock_cls:
+        mock_client = _gemini_client()
+        mock_cls.return_value = mock_client
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash",
+            max_tokens=4096,
+            timeout=30,
+            api_key="test-key",
+            thinking_level="medium",
+        )
+        adapter.complete("sys", "user")
+
+    config = mock_client.models.generate_content.call_args.kwargs["config"]
+    assert config.response_mime_type == "application/json"
+    # The SDK coerces the string into a ThinkingLevel enum, so compare on value.
+    assert str(config.thinking_config.thinking_level.value).lower() == "medium"
+
+
+def test_gemini_thinking_level_none_omits_thinking_config():
+    """thinking_level=None sends no thinking_config, letting the model decide.
+
+    Kept configurable because thinking tokens are billed as output and drawn from
+    the max_output_tokens allowance; "low" is only a measured default, not a
+    requirement.
+    """
+    with patch("google.genai.Client") as mock_cls:
+        mock_client = _gemini_client()
+        mock_cls.return_value = mock_client
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash",
+            max_tokens=4096,
+            timeout=30,
+            api_key="test-key",
+            thinking_level=None,
+        )
+        adapter.complete("sys", "user")
+
+    assert mock_client.models.generate_content.call_args.kwargs["config"].thinking_config is None
+
+
+def test_gemini_adapter_per_call_max_tokens_override():
+    """A per-call max_tokens overrides the adapter default."""
+    with patch("google.genai.Client") as mock_cls:
+        mock_client = _gemini_client()
+        mock_cls.return_value = mock_client
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash", max_tokens=4096, timeout=30, api_key="test-key"
+        )
+        adapter.complete("sys", "user", max_tokens=99)
+
+    assert mock_client.models.generate_content.call_args.kwargs["config"].max_output_tokens == 99
+
+
+def test_gemini_adapter_forwards_timeout_as_milliseconds():
+    """The configured timeout reaches the SDK, converted from seconds to ms."""
+    with patch("google.genai.Client") as mock_cls:
+        mock_client = _gemini_client()
+        mock_cls.return_value = mock_client
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash", max_tokens=10, timeout=30, api_key="test-key"
+        )
+        adapter.complete("sys", "user")
+        adapter.complete("sys", "user", timeout=7)
+
+    calls = mock_client.models.generate_content.call_args_list
+    assert calls[0].kwargs["config"].http_options.timeout == 30_000
+    # per-call override wins
+    assert calls[1].kwargs["config"].http_options.timeout == 7_000
+
+
+def test_gemini_adapter_raises_without_api_key():
+    """Missing GEMINI_API_KEY and GOOGLE_API_KEY raises a helpful ValueError."""
+    with patch("google.genai.Client"), patch.dict(os.environ, {}, clear=True):
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+            GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10)
+
+
+def test_gemini_adapter_falls_back_to_google_api_key():
+    """GOOGLE_API_KEY is accepted when GEMINI_API_KEY is absent."""
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch.dict(os.environ, {"GOOGLE_API_KEY": "goog-key"}, clear=True),
+    ):
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10)
+
+    assert mock_cls.call_args.kwargs["api_key"] == "goog-key"
+
+
+def test_gemini_endpoint_label_includes_model():
+    with patch("google.genai.Client"):
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+    label = adapter.endpoint_label()
+    assert "gemini" in label
+    assert "gemini-3.7-flash" in label
+
+
+def test_config_creates_gemini_adapter():
+    """load_adapter dispatches provider 'gemini' and forwards retry settings."""
+    raw = {
+        "provider": "gemini",
+        "llm": {
+            "model": "gemini-3.7-flash",
+            "max_output_tokens": 4096,
+            "timeout": 120,
+            "thinking_level": "high",
+            "retry_429_max": 4,
+            "retry_429_base_delay": 5.0,
+        },
+    }
+    with patch("google.genai.Client"), patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}):
+        from mykg.llm.config import load_adapter
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = load_adapter(_raw=raw)
+
+    assert isinstance(adapter, GeminiAdapter)
+    assert adapter._model == "gemini-3.7-flash"
+    assert adapter._max_tokens == 4096
+    assert adapter._thinking_level == "high"
+    assert adapter._retry_429_max == 4
+    assert adapter._retry_429_base_delay == 5.0
+
+
+def test_gemini_429_retries_and_succeeds():
+    """A 429 is retried and the subsequent success is returned."""
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("time.sleep"),
+    ):
+        mock_client = _gemini_client(
+            side_effect=[_api_error(429, "quota"), _gemini_response(text='{"ok":1}')]
+        )
+        mock_cls.return_value = mock_client
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash",
+            max_tokens=10,
+            timeout=10,
+            api_key="k",
+            retry_429_max=2,
+            retry_429_base_delay=0.01,
+        )
+        assert adapter.complete("sys", "user") == '{"ok":1}'
+
+    assert mock_client.models.generate_content.call_count == 2
+
+
+def test_gemini_5xx_is_retried():
+    """A transient 5xx is retried rather than surfaced immediately."""
+    with patch("google.genai.Client") as mock_cls, patch("time.sleep"):
+        mock_client = _gemini_client(
+            side_effect=[_api_error(503, "overloaded"), _gemini_response(text="{}")]
+        )
+        mock_cls.return_value = mock_client
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash",
+            max_tokens=10,
+            timeout=10,
+            api_key="k",
+            retry_429_max=2,
+            retry_429_base_delay=0.01,
+        )
+        adapter.complete("sys", "user")
+
+    assert mock_client.models.generate_content.call_count == 2
+
+
+def test_gemini_400_is_not_retried():
+    """A 400 is a caller error — surfaced immediately, never retried (cf. PR #44)."""
+    from google.genai import errors as genai_errors
+
+    with patch("google.genai.Client") as mock_cls, patch("time.sleep"):
+        mock_client = _gemini_client(side_effect=_api_error(400, "invalid argument"))
+        mock_cls.return_value = mock_client
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash",
+            max_tokens=10,
+            timeout=10,
+            api_key="k",
+            retry_429_max=3,
+            retry_429_base_delay=0.01,
+        )
+        with pytest.raises(genai_errors.APIError):
+            adapter.complete("sys", "user")
+
+    assert mock_client.models.generate_content.call_count == 1
+
+
+def test_gemini_exhausts_retries_and_raises_provider_error():
+    """After retries are exhausted the provider's own exception surfaces."""
+    from google.genai import errors as genai_errors
+
+    with patch("google.genai.Client") as mock_cls, patch("time.sleep"):
+        mock_client = _gemini_client(side_effect=_api_error(429, "quota"))
+        mock_cls.return_value = mock_client
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash",
+            max_tokens=10,
+            timeout=10,
+            api_key="k",
+            retry_429_max=2,
+            retry_429_base_delay=0.01,
+        )
+        with pytest.raises(genai_errors.APIError):
+            adapter.complete("sys", "user")
+
+    assert mock_client.models.generate_content.call_count == 3
+
+
+def test_gemini_reports_cached_token_usage():
+    """cached_content_token_count is forwarded as cache_read_tokens.
+
+    Implicit caching is automatic and server-side; the adapter only reports it.
+    """
+    usage = _GeminiUsage(
+        prompt_token_count=7005,
+        candidates_token_count=12,
+        thoughts_token_count=30,
+        cached_content_token_count=4037,
+    )
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("mykg.llm.gemini_adapter.record_llm_call") as mock_record,
+    ):
+        mock_cls.return_value = _gemini_client(_gemini_response(usage=usage))
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=100, timeout=10, api_key="k")
+        adapter.complete("sys", "user")
+
+    kwargs = mock_record.call_args.kwargs
+    assert kwargs["input_tokens"] == 7005
+    # thinking tokens are billed output, so they are counted as output
+    assert kwargs["output_tokens"] == 42
+    assert kwargs["cache_read_tokens"] == 4037
+    # implicit caching has no creation step
+    assert kwargs.get("cache_creation_tokens", 0) == 0
+
+
+def test_gemini_absent_usage_counts_default_to_zero():
+    """None-valued usage fields coerce to 0 rather than raising."""
+    usage = _GeminiUsage(
+        prompt_token_count=None,
+        candidates_token_count=None,
+        thoughts_token_count=None,
+        cached_content_token_count=None,
+    )
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("mykg.llm.gemini_adapter.record_llm_call") as mock_record,
+    ):
+        mock_cls.return_value = _gemini_client(_gemini_response(usage=usage))
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+        adapter.complete("sys", "user")
+
+    kwargs = mock_record.call_args.kwargs
+    assert kwargs["input_tokens"] == 0
+    assert kwargs["output_tokens"] == 0
+    assert kwargs["cache_read_tokens"] == 0
+
+
+def test_gemini_truncated_response_logs_finish_reason():
+    """MAX_TOKENS is normalised to 'max_tokens' for record_llm_call."""
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("mykg.llm.gemini_adapter.record_llm_call") as mock_record,
+    ):
+        mock_cls.return_value = _gemini_client(
+            _gemini_response(text='{"partial": ', finish_reason="MAX_TOKENS")
+        )
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+        adapter.complete("sys", "user")
+
+    assert mock_record.call_args.kwargs["finish_reason"] == "max_tokens"
+
+
+def test_gemini_normal_response_omits_finish_reason():
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("mykg.llm.gemini_adapter.record_llm_call") as mock_record,
+    ):
+        mock_cls.return_value = _gemini_client(_gemini_response(finish_reason="STOP"))
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+        adapter.complete("sys", "user")
+
+    assert mock_record.call_args.kwargs["finish_reason"] is None
+
+
+def test_gemini_empty_output_at_cap_warns_about_thinking_budget(caplog):
+    """An empty body at MAX_TOKENS names the thinking budget as the cause.
+
+    Gemini draws thinking tokens from max_output_tokens, so a too-small budget
+    returns finish_reason=MAX_TOKENS with no text at all. Without this warning
+    the failure surfaces downstream as an unexplained blank chunk (D33).
+    """
+    with patch("google.genai.Client") as mock_cls:
+        mock_cls.return_value = _gemini_client(
+            _gemini_response(text="", finish_reason="MAX_TOKENS")
+        )
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+        with caplog.at_level("WARNING", logger="mykg.llm.gemini_adapter"):
+            assert adapter.complete("sys", "user") == ""
+
+    assert any("thinking budget" in r.getMessage().lower() for r in caplog.records)
+    assert any("max_output_tokens" in r.getMessage() for r in caplog.records)
+
+
+def test_gemini_context_exceeded_logs_and_reraises(caplog):
+    """A context-overflow error is logged with the standard marker and re-raised."""
+    from google.genai import errors as genai_errors
+
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("time.sleep"),
+        caplog.at_level("WARNING", logger="mykg.llm.retry"),
+    ):
+        mock_cls.return_value = _gemini_client(
+            side_effect=_api_error(400, "input token count exceeds the maximum")
+        )
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(
+            model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k", retry_429_max=0
+        )
+        with pytest.raises(genai_errors.APIError):
+            adapter.complete("sys", "user")
+
+    assert any("context length exceeded" in r.message for r in caplog.records)
+    assert any("gemini/gemini-3.7-flash" in r.message for r in caplog.records)
+
+
+def test_gemini_strips_code_fences():
+    """A fenced JSON body is unwrapped like every other adapter."""
+    with patch("google.genai.Client") as mock_cls:
+        mock_cls.return_value = _gemini_client(_gemini_response(text='```json\n{"a": 1}\n```'))
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+        assert adapter.complete("sys", "user") == '{"a": 1}'
+
+
+@pytest.mark.live
+def test_gemini_live_call_returns_json():
+    """Real API call — skipped unless GEMINI_API_KEY is set."""
+    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not key:
+        pytest.skip("GEMINI_API_KEY not set")
+
+    from mykg.llm.gemini_adapter import GeminiAdapter
+
+    adapter = GeminiAdapter(
+        model=os.environ.get("GEMINI_MODEL", "gemini-3.7-flash"),
+        max_tokens=2000,
+        timeout=120,
+        api_key=key,
+    )
+    out = adapter.complete("Reply with JSON only.", 'Return {"pong": true}')
+    assert out.strip()
+    assert json.loads(out)["pong"] is True
+
+
+def test_gemini_safety_blocked_response_warns_and_records(caplog):
+    """A SAFETY-blocked empty body is diagnosed instead of returning silently.
+
+    Gemini returns HTTP 200 with an empty body and finish_reason=SAFETY when it
+    refuses. Without an explicit branch this looks identical to a successful
+    empty extraction and lands in failed_chunks.json unexplained (D33).
+    """
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("mykg.llm.gemini_adapter.record_llm_call") as mock_record,
+    ):
+        mock_cls.return_value = _gemini_client(_gemini_response(text="", finish_reason="SAFETY"))
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=500, timeout=10, api_key="k")
+        with caplog.at_level("WARNING", logger="mykg.llm.gemini_adapter"):
+            assert adapter.complete("sys", "user") == ""
+
+    assert any("blocked" in r.getMessage().lower() for r in caplog.records)
+    assert any("SAFETY" in r.getMessage() for r in caplog.records)
+    assert "SAFETY" in (mock_record.call_args.kwargs.get("error") or "")
+
+
+def test_gemini_recitation_block_is_reported():
+    """RECITATION is treated the same as any other non-STOP empty response."""
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("mykg.llm.gemini_adapter.record_llm_call") as mock_record,
+    ):
+        mock_cls.return_value = _gemini_client(
+            _gemini_response(text="", finish_reason="RECITATION")
+        )
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=500, timeout=10, api_key="k")
+        adapter.complete("sys", "user")
+
+    assert "RECITATION" in (mock_record.call_args.kwargs.get("error") or "")
+
+
+def test_gemini_successful_response_records_no_error():
+    """A normal STOP response carries no error field."""
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("mykg.llm.gemini_adapter.record_llm_call") as mock_record,
+    ):
+        mock_cls.return_value = _gemini_client(
+            _gemini_response(text='{"ok": true}', finish_reason="STOP")
+        )
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=500, timeout=10, api_key="k")
+        adapter.complete("sys", "user")
+
+    assert mock_record.call_args.kwargs.get("error") is None
+
+
+def test_gemini_empty_body_with_stop_is_not_flagged_as_blocked():
+    """An empty body with finish_reason=STOP is a genuine empty answer, not a block."""
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("mykg.llm.gemini_adapter.record_llm_call") as mock_record,
+    ):
+        mock_cls.return_value = _gemini_client(_gemini_response(text="", finish_reason="STOP"))
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=500, timeout=10, api_key="k")
+        assert adapter.complete("sys", "user") == ""
+
+    assert mock_record.call_args.kwargs.get("error") is None
+
+
+def test_gemini_output_cap_error_not_mislabelled_as_context_overflow():
+    """A max_output_tokens rejection must not be reported as context overflow.
+
+    The two have different fixes — one is a chunking-budget problem, the other a
+    max_output_tokens problem — so conflating them misdirects the operator.
+    """
+    from mykg.llm.retry import looks_like_context_exceeded
+
+    output_cap = Exception(
+        "Requested max_output_tokens exceeds the maximum number of tokens allowed"
+    )
+    input_overflow = Exception(
+        "The input token count (1200000) exceeds the maximum number of tokens allowed (1048576)"
+    )
+    assert looks_like_context_exceeded(output_cap) is False
+    assert looks_like_context_exceeded(input_overflow) is True

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -2623,3 +2623,147 @@ def test_gemini_output_cap_error_not_mislabelled_as_context_overflow():
     )
     assert looks_like_context_exceeded(output_cap) is False
     assert looks_like_context_exceeded(input_overflow) is True
+
+
+def test_gemini_missing_usage_metadata_defaults_to_zero():
+    """A response with no usage_metadata at all records zero counts, not an error.
+
+    Guards the `getattr(usage, field, 0)` default path in `_count` against a
+    malformed or usage-free response (raised in review of PR #61).
+    """
+    with (
+        patch("google.genai.Client") as mock_cls,
+        patch("mykg.llm.gemini_adapter.record_llm_call") as mock_record,
+    ):
+        resp = _gemini_response()
+        resp.usage_metadata = None
+        mock_cls.return_value = _gemini_client(resp)
+
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        adapter = GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+        adapter.complete("sys", "user")
+
+    kwargs = mock_record.call_args.kwargs
+    assert kwargs["input_tokens"] == 0
+    assert kwargs["output_tokens"] == 0
+    assert kwargs["cache_read_tokens"] == 0
+
+
+def test_gemini_count_helper_tolerates_absent_usage():
+    """_count returns 0 for a None usage object, a bare object, and non-int values."""
+    from mykg.llm.gemini_adapter import _count
+
+    class _Bare:
+        pass
+
+    class _NoneValued:
+        prompt_token_count = None
+
+    class _NonInt:
+        prompt_token_count = "12"
+
+    assert _count(None, "prompt_token_count") == 0
+    assert _count(_Bare(), "prompt_token_count") == 0
+    assert _count(_NoneValued(), "prompt_token_count") == 0
+    assert _count(_NonInt(), "prompt_token_count") == 0
+
+
+def test_gemini_afc_notice_filtered_without_muting_real_warnings():
+    """The AFC notice is dropped, but genuine google_genai warnings still pass.
+
+    Raised in review of PR #61: raising the logger's level would have suppressed
+    legitimate warnings from the same logger, so a message-specific filter is
+    used instead.
+    """
+    import logging as _logging
+
+    with patch("google.genai.Client"):
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+
+    logger = _logging.getLogger("google_genai.models")
+    # The level is untouched — only a filter was added.
+    assert logger.level == _logging.NOTSET
+
+    def _rec(msg):
+        return _logging.LogRecord(
+            "google_genai.models", _logging.WARNING, __file__, 1, msg, None, None
+        )
+
+    # Both AFC variants the SDK emits must be dropped.
+    for noisy in (
+        "Direct use of automatic function calling (AFC) is not recommended",
+        "AFC is enabled with max remote calls: 10.",
+    ):
+        assert any(not f(_rec(noisy)) for f in logger.filters), f"should be filtered: {noisy}"
+
+    assert all(f(_rec("quota exceeded for this project")) for f in logger.filters), (
+        "genuine warnings must still pass through"
+    )
+
+
+def test_gemini_afc_filter_installed_only_once():
+    """Constructing many adapters does not stack duplicate filters."""
+    import logging as _logging
+
+    logger = _logging.getLogger("google_genai.models")
+    with patch("google.genai.Client"):
+        from mykg.llm.gemini_adapter import GeminiAdapter
+
+        GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+        before = len(logger.filters)
+        for _ in range(5):
+            GeminiAdapter(model="gemini-3.7-flash", max_tokens=10, timeout=10, api_key="k")
+
+    assert len(logger.filters) == before
+
+
+def test_gemini_status_of_falls_back_to_status_code():
+    """_status_of reads .status_code when .code is absent or non-integer."""
+    from mykg.llm.gemini_adapter import _status_of
+
+    class _NoCode:
+        status_code = 503
+
+    class _StringCode:
+        code = "RESOURCE_EXHAUSTED"
+        status_code = 429
+
+    class _Neither:
+        pass
+
+    assert _status_of(_NoCode()) == 503
+    # a non-int .code must not be returned verbatim
+    assert _status_of(_StringCode()) == 429
+    assert _status_of(_Neither()) is None
+
+
+def test_gemini_raw_finish_reason_edge_cases():
+    """_raw_finish_reason handles absent candidates, a None reason, and enum reprs."""
+    from mykg.llm.gemini_adapter import GeminiAdapter
+
+    read = GeminiAdapter._raw_finish_reason
+
+    class _NoCandidates:
+        candidates = []
+
+    class _NoneReason:
+        def __init__(self):
+            c = MagicMock()
+            c.finish_reason = None
+            self.candidates = [c]
+
+    class _PlainStringEnum:
+        """finish_reason whose str() is a dotted enum repr and has no .name."""
+
+        def __init__(self):
+            c = MagicMock()
+            c.finish_reason = "FinishReason.MAX_TOKENS"
+            self.candidates = [c]
+
+    assert read(_NoCandidates()) is None
+    assert read(_NoneReason()) is None
+    # dotted enum repr is reduced to the bare member name
+    assert read(_PlainStringEnum()) == "MAX_TOKENS"

--- a/uv.lock
+++ b/uv.lock
@@ -439,6 +439,45 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.56.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/4c/fa42116a48bab3f7a143cf5042ecff7df9c8b73f8a376203cd534d1dc966/google_auth-2.56.3.tar.gz", hash = "sha256:40e229fc901f0a305b553050e5fce562d509bee0435be053abfa91582b51b90c", size = 367110, upload-time = "2026-08-06T06:24:01.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl", hash = "sha256:8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53", size = 259116, upload-time = "2026-08-06T06:22:51.788Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/e3/1dd592243a0dfc3487ddfff7995f12686d0557ec953173dd9bdbeba2cb96/google_genai-2.18.1.tar.gz", hash = "sha256:a1e2be75c16234adc6641afd1ad4dd44218c9eec005d938bdc428585a048918a", size = 659694, upload-time = "2026-08-13T22:13:50.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/7d/5310f7a1cf290a6cb22eab37059610bf338ab7595892902591d2220cf825/google_genai-2.18.1-py3-none-any.whl", hash = "sha256:36a5949233e64a60f6cc4521bff7a76b7c569d0aa227bbe9fa642213b8a3a3b2", size = 1051129, upload-time = "2026-08-13T22:13:48.083Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -659,11 +698,12 @@ wheels = [
 
 [[package]]
 name = "mykg"
-version = "0.3.26"
+version = "0.3.31"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "click" },
+    { name = "google-genai" },
     { name = "markdownify" },
     { name = "mcp" },
     { name = "networkx" },
@@ -687,6 +727,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.28" },
     { name = "click", specifier = ">=8.1" },
+    { name = "google-genai", specifier = ">=2.18" },
     { name = "markdownify", specifier = ">=0.13" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "networkx", specifier = ">=3.6.1" },
@@ -750,6 +791,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1422,6 +1484,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1625,4 +1696,103 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/f7/bc3a25c5ec26ce62ce487690becc2f3710bbc7b33338f005ad390db0b986/websockets-16.1.1.tar.gz", hash = "sha256:db234eda965dcce15df96bb9709f587cd87d4d52aaf0e80e2f34ec04c7670c57", size = 182204, upload-time = "2026-07-17T22:51:05.858Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/03/47debfe28e9d6d354be5d777b67fd44c359b9eb299a5d103500bd7cc3e37/websockets-16.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d0fcf657e9f13ff4b177960ab2200237b12994232dfb6df16f1cfe1d4339f93c", size = 179566, upload-time = "2026-07-17T22:48:49.596Z" },
+    { url = "https://files.pythonhosted.org/packages/72/93/31efa1ed78c17e5cfc229fd449e3966e1b9cc15753204cd585cc8dd01f4a/websockets-16.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b852788aa51764e2d8e4cf5493d559326bcae5e38d16ba25ffa322b034df272a", size = 177250, upload-time = "2026-07-17T22:48:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4a/542378ab3972b0c1cf1df3df3eff9591cea0d30c58c3aa3c4ddbc244e787/websockets-16.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1427fb4cf0d72f66333e2cacc3ff5f575bf2d7008166ce991a4a470b21d51a22", size = 177528, upload-time = "2026-07-17T22:48:52.59Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d9/162321f63c7eed558e9e1798ed7a1e34a4f6dab51f35419e4ed7a4907979/websockets-16.1.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:da4ca1a9d72f9030b3146b8d7022719a9f3d478f61efe6f7dd51d243f61c51b2", size = 186859, upload-time = "2026-07-17T22:48:53.915Z" },
+    { url = "https://files.pythonhosted.org/packages/de/09/87df740f7430ce564bd52402e9c9458d4d0459cc7d2ee29e530c8204851b/websockets-16.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86d7f0f8bdb25d2c632b72527325e4776430fd5bc61b9118de4e2b8ddb5f5b01", size = 188095, upload-time = "2026-07-17T22:48:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/12/3d2703af7cc095f3c81904c92208cc1ae79affbc67376944b50ee9301f73/websockets-16.1.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7dfcad78ea1492ee3a9ec765cb7f51bbc17d477107aaf6b22abf7b2558d1c5a0", size = 191385, upload-time = "2026-07-17T22:48:56.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/69/986aa0234a964a00f5149cfc46e136e96c8faad1c783474550f40d31aef4/websockets-16.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fb9a0a6dc3d1b3986cb88091b6899f0396651e0f74e2c9766ab8d6ffc3842e29", size = 188653, upload-time = "2026-07-17T22:48:58.134Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6b/10f9d03e3970a69ba67bd3b46b87a929b586d0300fadbfe14f57c1f85490/websockets-16.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29dfa8114c4a620c69591c5973860f768eac29d3fd6904f37f34266cb219c512", size = 187426, upload-time = "2026-07-17T22:48:59.515Z" },
+    { url = "https://files.pythonhosted.org/packages/56/db/bb3aad62bf63d8bb3f0634b2eabffcfb3677a34bd19492110ff6869cf703/websockets-16.1.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ff9417c0ada4d0f7d212f928303e5579bdf3ace4c802fa4afabb30995da58c3", size = 184882, upload-time = "2026-07-17T22:49:00.916Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4c/c09a2ea9bfbeccce52fdc383e5f28af4bc8843338aabac28c81489af6120/websockets-16.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fe0b50da2d84535fb4f7b4bfa951280f97ce3d558a0443b541166d609e67b57", size = 187584, upload-time = "2026-07-17T22:49:02.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8b/31bb4eb4d9eaacf1fdd39d115772a8aeaedfc19b5dc262e57ffbc8a9d42c/websockets-16.1.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:34420aaa64440ebd51ac72ca8a45ef4626429438c9b02e633ae412ed43f925d3", size = 186174, upload-time = "2026-07-17T22:49:03.973Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e4/dc02d725610a1ad49e193ef91a548194d71bdc6cdf27da83067dd1f73995/websockets-16.1.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a6a61aff018180c9c50b7b0da33bfd29d378af3497429c95006c589a23a11648", size = 187986, upload-time = "2026-07-17T22:49:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/73/30ed84c8bfd14c73d4af29d5ed9323c3073b48e0b7b23b67070f4e7fd59b/websockets-16.1.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:04fd29a0e2fe9414a95b00e92c67ae51bf900c50c0f8a4b2dafdad621f49ea1d", size = 185565, upload-time = "2026-07-17T22:49:06.959Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d3/4be8d4959f51e31b4f8fc0ece12b45bd3b6c0d15ea23b9990d9c11fc805f/websockets-16.1.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5c31aa7e39ee3e8a358573257f1c0bb5c52430d1b637030dd9c8cc2c282926be", size = 186598, upload-time = "2026-07-17T22:49:08.293Z" },
+    { url = "https://files.pythonhosted.org/packages/26/fa/abb38597a52d84ed9cfacadc7a0c6f2db282c0ab23cdf72b58a666a21227/websockets-16.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d14bfb217eb4701e850f1525c9d29d79c44794cdf1c299ead25f39f8c78dea81", size = 186834, upload-time = "2026-07-17T22:49:09.766Z" },
+    { url = "https://files.pythonhosted.org/packages/59/80/1119ad08a228b90c4eb77fbe48df7836731a605f5f881ba701ca826a4a65/websockets-16.1.1-cp311-cp311-win32.whl", hash = "sha256:2e28e602bb13da44fbe518c1781a88e3b9d4c3d48d02c9bad83e546164336f57", size = 179940, upload-time = "2026-07-17T22:49:11.196Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b2/e511c1c6f64a95c2f3fc54bffda0e14eaa7e9442be605c29270f7589b918/websockets-16.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:7421fad442de870a8cbf2287d1cad7e706ece0dbfeba5e911df132cbdc1cb56a", size = 180239, upload-time = "2026-07-17T22:49:12.519Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9d/681cda21c9eee743203a6cb79b9d3d05adad9aa60ec660c6c9bf4dd619ca/websockets-16.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cc97814dfb786a83b6e2dc2e79351e1b83e6d715647d6887fcabd83026417a00", size = 179600, upload-time = "2026-07-17T22:49:13.92Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8d/6195a88b45e8d2a8f745fc2046e36f885a3c9763e6767d2c46229bf9510c/websockets-16.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e047dc87ef7ca50f4d309bf775ad4a71711c58556d75d7bd0604b2317f43e94b", size = 177272, upload-time = "2026-07-17T22:49:15.453Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/fe2d498c64dea0095c9a9f9a351af4cd6eef31b618395582bc1f38ba45ff/websockets-16.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:01fbdcbac298efe19360b94bc0039c8f746f0220ba570f327577bfee81059175", size = 177542, upload-time = "2026-07-17T22:49:16.875Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ed/f1831681fce0e3242346e5458486003c5f124ed69e5e0b847fd029db4973/websockets-16.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0f62863e8a00a6d33c3d6566ec0b89f23787b747ffe0c3bc71ec0e76b82c94b1", size = 187137, upload-time = "2026-07-17T22:49:18.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/79/4ff9dcc1bb46f6b4c536936dde1fd60f9b564f3304307274db97f4c9496d/websockets-16.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8087e82f842609734c9b5a1330464f8e94e346ba0e18c832c08bafa4b0d63c15", size = 188374, upload-time = "2026-07-17T22:49:19.65Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/5c49b6efb36cab733d23773f6de575e1dba65736ead17d5d2b2a1daef779/websockets-16.1.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2bb5d041a8307d2e18782e7ce777f6fdb1e8c2f5d09291484b18c294b789d9aa", size = 191155, upload-time = "2026-07-17T22:49:21.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f6/56ccceda3a4838d18f1d40821480da4775397e8b1eecf4031e20c50e2e90/websockets-16.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1db4de4a0e95673f7545d393c49eeb0c2f18ac1ef93073218c79d5cdb2ee75ab", size = 189011, upload-time = "2026-07-17T22:49:22.889Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d6/ad5286241a2bce1107e2798d3bfbd62cf79aee167bdb654f8cb1e9dbf949/websockets-16.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f17dbe07eb3ea7f99e4df9b7e0efefe80fbf30d37a8cc4d561a0aed310bc8847", size = 187766, upload-time = "2026-07-17T22:49:24.339Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/67/d65c970b7e347fdca69479beb7811c2060529956730a7a4e3ae7c66b0e31/websockets-16.1.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4b57693728576d84ede0a77987ab16881b783d2cd9f1dc180a8fbbc3f79c4428", size = 185173, upload-time = "2026-07-17T22:49:25.743Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5b/14af3cd4ee69d8ea9baca58f3dc3cfb1ba78332a347fd478cb096549d60e/websockets-16.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2a636ff1e7a5c4edf71ef0e79adae7f25dba93b4fcbe3dc958733477ffeb0eaf", size = 187809, upload-time = "2026-07-17T22:49:27.147Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/11/be301710d70de97e3e7b3586e6d492c9c06d6a61bf1c2202c36cf0c75607/websockets-16.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d6bec75c290fe484a8ba4cacdf838501e17c06ecfbbf31eede81a9e431bd7751", size = 186412, upload-time = "2026-07-17T22:49:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/db/07/fe1435bf6fe738a3d3b54dbe0c18dabf12cba4d909ac8b58b539ce27c1f4/websockets-16.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:54509b8e92fee4453e152b7558ddef37ce9705a044922f2095a6105e3f80c96f", size = 188290, upload-time = "2026-07-17T22:49:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0a/81f394aff8efcbb01208c1ced77df0a3c7fcce584a88c7273663697946c2/websockets-16.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f0aa4aad3b1b69ad3fd85a0fd0952ec64331c762bd77ec51cc814170873890b2", size = 185844, upload-time = "2026-07-17T22:49:31.447Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/dd485b995473f415510251fe9bd708f2d24458f439fce958daf8d66dc7c6/websockets-16.1.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:42290eb6db4ccaca7012656738214f8514082fb6fa40cdeb61bb9a471b52e383", size = 186823, upload-time = "2026-07-17T22:49:33.104Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0b/f78de76ff446f1e66af12b43c48a35f31744de93cfdec2f4ea67d5d7bbf1/websockets-16.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:53260c8930da5771cec89439bff99c20c8cb03ddb9588b980697355a83cd4bd3", size = 187102, upload-time = "2026-07-17T22:49:34.616Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/4cf892007778eaf84ad162bfc98046e0ed89b63ac55949e3236626b2a23f/websockets-16.1.1-cp312-cp312-win32.whl", hash = "sha256:1d27fa8462ad6a1cb36206a3d0640b2333340def181fae11ed7f9adeaa5c0747", size = 179943, upload-time = "2026-07-17T22:49:36.213Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/de/6abe251d28c3a3f217096575400b27750b18e0b1d2fff3a2a239960fea07/websockets-16.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:b436f6ec4fc3a6b4237c84d3f83170ed2b40bb584222f0ac47a0c8a5921980c7", size = 180243, upload-time = "2026-07-17T22:49:37.626Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fd/6ec6c6d2850aea25b1b2aa9901a016980bb87d01e89b3eb00470b1b5d471/websockets-16.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ab59169ace05dcb49a1d4118f0bde139557adf45091bd85747e36bf5de984dd1", size = 179587, upload-time = "2026-07-17T22:49:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d8/1d299d2dd34087db39831a34cc645ef8a6f89d78efada6983093513cd81c/websockets-16.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5e3b7d601f6f84156b08cc4a5e541c2b50ad7b36cfc302b657a12477c904a5df", size = 177272, upload-time = "2026-07-17T22:49:40.293Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/86/0a70d3ae2f0f2256bb41302d9804dbca65d4360281e7feb3e1f94102ac46/websockets-16.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cd2ca96a082a36964aca83e992f72abeb61b7306c1a6cba4c7d06a7b93750cac", size = 177530, upload-time = "2026-07-17T22:49:41.786Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c2/c676c69444d9db448b3f0a55a98dcc534affce0bce961d9d2f0b8499b10a/websockets-16.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f5d497865f05bb222cab7016c6034542e84e5f29f49c6fd3f4939cda7197b5b8", size = 187197, upload-time = "2026-07-17T22:49:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/13/88137fbaf726ebe29d62c1117fa11fa2bbb6209dc79d4ad738efbe36a2aa/websockets-16.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bae954c382e013d5ea5b190d2830526bfa45ad121c326da0049b8c769f185db6", size = 188433, upload-time = "2026-07-17T22:49:45.147Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/46c2f2ce6751cb26f39293e1ecbf8544cb01321397cd476c2756b98c216d/websockets-16.1.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e09f753a169951eb4f28c2c774f71069304f66e7277e0f5a2892423599cfa854", size = 189868, upload-time = "2026-07-17T22:49:46.581Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2b/170a9e8097636cfde4dc3c592b6e00b18a44a2f5407606d96ca542dd5838/websockets-16.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:024193f8551a2b0eafbdd160911012c4e6c228c28430c84433253299a9e42d6a", size = 189059, upload-time = "2026-07-17T22:49:47.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/48/f0d4ebc9ab4b473b8861b9e20fdb663d515d42f7befdf62cdb60fee7a1ec/websockets-16.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:aabe464bfd13bd25f4821faf111da6fefdc389f870265a53105580e45b0a2e49", size = 187814, upload-time = "2026-07-17T22:49:49.344Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ba/39a41d3ae8e72696a9492581900611c5a91e2b07563b0bcd2523adea9854/websockets-16.1.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a28fcbc9b6baf54a2e23f8655f308e4ccc6afdd7266f8fe7954f320dcda0f785", size = 185229, upload-time = "2026-07-17T22:49:50.787Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/ac15b604f850d1907f0a85ed721cefe47cd45034b3620069b829746cccbe/websockets-16.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:79eace538c6a97e96d0d03d4f9d314f9677f5ed85a8a984992ffd90b13cb8a56", size = 187874, upload-time = "2026-07-17T22:49:52.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/3fbd5d71d59299c3770faa5884d4f45070236ca5a35ab3a61830812c409a/websockets-16.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:496af849a472b531f758dbd4d61338f5000538cb1a7b3d20d9d32a264517f509", size = 186469, upload-time = "2026-07-17T22:49:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/fc/dd90349bba58af2a53ef2ddd9c32716c81eb6d59a0687939fff561860878/websockets-16.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5283810d2646741a0d8da2aa733d6aefa0545809afccb2a5d105a26bc45125f1", size = 188347, upload-time = "2026-07-17T22:49:55.202Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f3/f73ba86427682da59b78c11d77ba56d5b801c32e84afe79b274bbd6a9bb2/websockets-16.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4e3b680b1e0a27457e727a0d572fd81dffa87b6dbf8b228ab57da64f7d85aead", size = 185903, upload-time = "2026-07-17T22:49:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7c/f95eb20e80104173b3a0a092291f89ea4047ef6e608e0a57ca06eb14eecb/websockets-16.1.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:69159730a823dde3ea8d08783e8d47ef135a6d7e8d44eb127e32b321c9db8e3e", size = 186855, upload-time = "2026-07-17T22:49:58.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/35/dd875b3e050ff232d60fa377707f890e369f74d134f1be32e8f68879747c/websockets-16.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ed5bb271084b46530ee2ddc0410537a9961152c5ccba2fc98c5276d992ccba87", size = 187140, upload-time = "2026-07-17T22:50:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/dc/5cbfcb41824502f6af93b8f3943a4d06c67c23c7d2e31eb18748c4a5b2a7/websockets-16.1.1-cp313-cp313-win32.whl", hash = "sha256:cfb70b4eb56cac4da0a83588f3ad50d46beb0690391082f3d4e2d488c70b68ea", size = 179928, upload-time = "2026-07-17T22:50:01.685Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c1/71e5deb5b7f8f226997ab64908c184ac3105c0155ce2d486f318e5dd08a8/websockets-16.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:d9531d9cbeac99af6f038fb1bc351403531f7d634a2c2e10e2f7c854c6ed5b68", size = 180242, upload-time = "2026-07-17T22:50:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a2/ba78a164eeea4620df4a4df4bd2ed6017438c4655cc0f36f2c0bc0432355/websockets-16.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:443aefe96b7fdb132e2a70806cca1f2af49bb3f28e47abcd7c2e9dcf4d8fa1b8", size = 179635, upload-time = "2026-07-17T22:50:05.001Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/08/d26d7a7628cd4ac34cbbdb63ac80914ca842ed8e42938c40a53567806df3/websockets-16.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6456ff333092d509127d75a638cb411afae8ff17f092635015d1902efec8a293", size = 177320, upload-time = "2026-07-17T22:50:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/45/ebec83e6269536aa5932533c67b0af5c781f3e73fdbcd68672dcf43f4f44/websockets-16.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fce6c48559c86d1ac3632ccb1bebc7d5442fbe79bd9bb0e40379ee54be2a4051", size = 177544, upload-time = "2026-07-17T22:50:07.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d5/abc614d2297f6c1c3e01e61260364457a47c25cc1cf6a879038902bc6aa8/websockets-16.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:92b820d345f7a3fc7b8163949ee92df910f290c3fc517b3d5301c78065adafe1", size = 187270, upload-time = "2026-07-17T22:50:09.275Z" },
+    { url = "https://files.pythonhosted.org/packages/52/71/4c99af3b87dff1b2927981f6876607d4acb45338c665242168d3982f7758/websockets-16.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a606d9c24035242a3e256e9d5b77ed9cd6bccfcb7cf993e5ca3c0f6f68fb6a7", size = 188509, upload-time = "2026-07-17T22:50:10.722Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5c8ca14b0df7eb84ed0524165c5359150210140817a3312aee57bf62a1cf/websockets-16.1.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:414e596c75f74e0994084694189d7dc9229fb278e33064d6784b73ffbba3ca31", size = 189882, upload-time = "2026-07-17T22:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c1/bedfba9e70557129cb8083748d167bdcc01483dedf0f0df143676df05cbe/websockets-16.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:536676848fc5961aca9d20389951f59169508f765637a172403dc5434d722fa0", size = 189114, upload-time = "2026-07-17T22:50:13.789Z" },
+    { url = "https://files.pythonhosted.org/packages/df/09/aa835b2787835aebd839114be5de51b797cb480b63ba42b26d34dfe147cb/websockets-16.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:97fd3a0e8b53efa41970ac1dff3d8cf0d2884cadeb4caaf95db7ad1526926ee3", size = 187861, upload-time = "2026-07-17T22:50:15.179Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/f6408330694dbc9830857d9d23bc14ac4f6875127a480cfdda8d5ca21198/websockets-16.1.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7b1b19636af86a3c7995d4d028dbe376f39b4bf31541146f9c123582a6c94562", size = 185286, upload-time = "2026-07-17T22:50:16.741Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9a/e0675e70dd8a80762cf35bb18799d3f290a4890ffe6439bc51d222796083/websockets-16.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:41c8e77f17294c0ac18008a7309b99b34ee72247ef10b6dff4c3f8b5ac29896b", size = 187935, upload-time = "2026-07-17T22:50:18.213Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c1/3234cfb86afde01b81e9bddcc6e534c440975d60a13991259e833069ab3e/websockets-16.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:9f63bcef7f4b02b06b35fc01c93b96c43b5e88e1e8868676caacf493d5a31f3a", size = 186444, upload-time = "2026-07-17T22:50:19.67Z" },
+    { url = "https://files.pythonhosted.org/packages/89/87/9c15206e1d778923d8daa9657de07aa62ea815e13448319c98458c37b281/websockets-16.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dab9eb87869da2d6ed3af3f3adf28414baae6ec9d4df355ffc18889132f3436c", size = 188409, upload-time = "2026-07-17T22:50:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/cf5de5c67676de2d3eef8b2a518f168f6796595447a5b7161ba0d012915c/websockets-16.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:43e3a9fdd7cbf7ba6040c31fae0faf84ca1474fef777c4e37912f1540f854499", size = 185958, upload-time = "2026-07-17T22:50:22.719Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c0/731b6ddede2e4136912ec4cff2cffbda35af73546be4762c3d7bd3bd79af/websockets-16.1.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:056ae37939ed7e9974f364f5864e76e49182622d8f9751ac1903c0d09b013985", size = 186911, upload-time = "2026-07-17T22:50:24.108Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/7f/39c634472c4469a24a7c09cecddffb08fac6d0e74f73881a94ee8a40a196/websockets-16.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a0eadbbf2c30f01efa58e1f110eb6fa293261f6b0b1aa38f7f48707107690af9", size = 187204, upload-time = "2026-07-17T22:50:25.548Z" },
+    { url = "https://files.pythonhosted.org/packages/26/89/9667c256c256dafcc62d21328ce7a40067da857969b68ee9af375b0aaf72/websockets-16.1.1-cp314-cp314-win32.whl", hash = "sha256:195c978b065fa40910582464f99d6b15c8b314c68e0546549a55ed83f4735328", size = 179603, upload-time = "2026-07-17T22:50:27.086Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/dd/1c099d6c0fc5deb6b46ccdbb6981fdb4b12c917869cb3952408409dc18db/websockets-16.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:4e8d01cc3bcae7bbf8167f944aeafefed590fae5693552bba9794a9df68371cc", size = 179948, upload-time = "2026-07-17T22:50:28.521Z" },
+    { url = "https://files.pythonhosted.org/packages/35/25/9956b2d5e0529d5d23924f21bba1440d4c5c88a562e4f08550871ffa97a7/websockets-16.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0ffd3031ea8bda8d61762e84220186105ba3b748b3c8da2ae4f7816fac03e573", size = 179963, upload-time = "2026-07-17T22:50:29.982Z" },
+    { url = "https://files.pythonhosted.org/packages/17/06/55ffc976c488b6aee9ea05761ff7c4e88e7c1fd82818c8ca7b556ad2f90c/websockets-16.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:84a2cef8deffbd9ab8ee0ea546a2a6a7030c28f44e6cdd4547dbfeb489eb8999", size = 177497, upload-time = "2026-07-17T22:50:31.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/f7dac2e980bacc92bdc26cebae4ae4d50cae5380732c50980598fc0bbae4/websockets-16.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3df13f73af9b3b38ab1195eb299ecb67a4330c911c97ae04043ff74085728abe", size = 177698, upload-time = "2026-07-17T22:50:32.829Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/39/26762f734113e22da2b942c3aca85798e0c0405d64c256549540ff31e5a1/websockets-16.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:23253dd5bcae3f9aaee0a1d30967a8dbd52e5d3cff93a2e5b84df57b77d4750d", size = 187561, upload-time = "2026-07-17T22:50:34.24Z" },
+    { url = "https://files.pythonhosted.org/packages/11/94/c3f330851806b9b02138b774d593478323e73c99238681b4b93efe64e02d/websockets-16.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c1c5705e314449e3308872fe084b8571ce078ee4fc55a98a769bdefe5917392", size = 188732, upload-time = "2026-07-17T22:50:36.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f2/eb2c450f052de334ae33cf200ece6e87b0e14d186807074e4eb1cd2cdea2/websockets-16.1.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:69e52d175a0a7d1e13b4b67ad41c560b7d98e8c6f6126eb0bda496c784faf8c7", size = 190872, upload-time = "2026-07-17T22:50:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/70/31/2ac8cecf3a74f7fed9132129fc3d90b3998a1554570c11a69b2a8c20332d/websockets-16.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1f79c89b5eb034d1722938a891916582f8f7f503f58ca22518a63c3f2cd18499", size = 189305, upload-time = "2026-07-17T22:50:39.53Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/cf/8ab19650d3c0d4562c92e70ab47c257c4aa5c6a713ed87fe63766b31fefc/websockets-16.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39f2a024af5c345ffe8fcf1ee18c049c024c94df393bb09b044a6917c77bde43", size = 188033, upload-time = "2026-07-17T22:50:40.912Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/a49a38a6127a4acb134fb1912b215d900cc657605cff32445bf519f3acc4/websockets-16.1.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:952303a7318d4cbe1011400839bb2051c9f84fa0a35923267f5daba34b15d458", size = 185748, upload-time = "2026-07-17T22:50:42.559Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3e/ad1fa40388c7f2e0bb2c7930d0090b6c5498594bd1cdaec18864df3d9e97/websockets-16.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:249116b4a76063d930a46391ad56e135c286e4562a18309029fc2c73f4ed4c62", size = 188285, upload-time = "2026-07-17T22:50:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b8/d5db28ca264b9104f82196f92dc8843e35fd391f763d42e4ad358f5bc97e/websockets-16.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:61922544a0587a13fd3f53e4c0e5e606510c7b0d9d22c8444e5fae22a06b38cb", size = 186777, upload-time = "2026-07-17T22:50:45.474Z" },
+    { url = "https://files.pythonhosted.org/packages/42/9c/726cb39d0cc43ae848dce4aa2acb04eecc6738b1264ec6d700bf6bcfb9f8/websockets-16.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:46dcaa042cd1de6c59e7d9269fa63ff7572b6df40510600b678f0826b3c7af51", size = 188682, upload-time = "2026-07-17T22:50:46.973Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c7/1168704de8c2dd483edabe4a22cbe4465dd8be8dd95561d214f9fe092871/websockets-16.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:38565aca3e01ea8734e578fb2118dade0ecb0250533f29e22b8d1a7a196cf4d0", size = 186377, upload-time = "2026-07-17T22:50:48.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/40/f9ff2d630ffce4e7dfea0b2288e1caf9ebbf9ff8a9ec9396136ce8b94935/websockets-16.1.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:42f599f4d48c7e1a3338fdaac3acd075be3b3cf02d4b274f3bf2767aedd3d217", size = 187148, upload-time = "2026-07-17T22:50:49.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/e177c8299f78d7cbe2d14df228643c10c70c0e86e108e092056bbcc16e46/websockets-16.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dcc04fedf83effaeb9cce98abc9469bb1b42ef85f03e01c8c1f4438ef7555737", size = 187578, upload-time = "2026-07-17T22:50:51.619Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/b6987faf330f5af5c787a2610124c2e8403d51724f9001ec4fff6311fe7a/websockets-16.1.1-cp314-cp314t-win32.whl", hash = "sha256:8483c2096363120eea8b07c06ae7304d520f686665fffd4811fad423930a65d7", size = 179729, upload-time = "2026-07-17T22:50:53.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6e/fbac6ed878dd362fbad7d415fa4f84d38e3e33fed8cde45c64e783acf826/websockets-16.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bcce07e23e5769375158f5efdcdafa8d5cd014b93c6683865b840ed65b96f231", size = 180072, upload-time = "2026-07-17T22:50:54.969Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ed/71fea6e141590cafc40b14dc5943b0845606bee87bdb52a21b6a73eb4311/websockets-16.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:820fb8450edddae3812fd58cbc08e2bf22812cb248ecb5f06dbb82119a56e869", size = 177185, upload-time = "2026-07-17T22:50:56.665Z" },
+    { url = "https://files.pythonhosted.org/packages/01/ec/00e7eeca200facf9266a83e4cbbf1bed0e67fba1d4d45031d3e5b3d81b5c/websockets-16.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:125f22dbefaf1554fea66fc83851490edb284ce4f501d37ffed2752f418332d9", size = 177459, upload-time = "2026-07-17T22:50:58.197Z" },
+    { url = "https://files.pythonhosted.org/packages/75/fd/5774c4b33f7c0d8f0c51809c8b3a93456c48e3543579262cfa64eb5f522e/websockets-16.1.1-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:30bbe120437b5648a77d3519b7024ea09530e0b5b18d3698c5a0ae536fe0cc2e", size = 178294, upload-time = "2026-07-17T22:50:59.641Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c3/48e2c03d2bd79bb45948841c592d24156312dd5f58cdf8f549febe652fb6/websockets-16.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b6b9dadbef0cccd9f4c4ee96b08898afa73e26803bbe0f6aeb5bb12b0074206d", size = 179190, upload-time = "2026-07-17T22:51:01.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3f/73e511ecf2496ceac57dd4ed8388efe2bcf0769338a2dbf242c8366ae87e/websockets-16.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56cd5fc4f10a9ea8aa0804bddb7b42506cf9e136046f3b4c27de8fec9e2ecba5", size = 180330, upload-time = "2026-07-17T22:51:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
 ]


### PR DESCRIPTION
## Summary

Closes #62.

Adds a **seventh LLM provider**. Gemini is wired through Google's native `google-genai` SDK rather than its OpenAI-compatibility shim: that shim [silently ignores unsupported parameters](https://ai.google.dev/gemini-api/docs/openai), and neither `max_tokens` nor `max_completion_tokens` appears in its supported-parameter table — so the output cap that Invariant 13 depends on would fail *open*, not closed.

## Live probing changed the design

Every decision below came from running against the real API, not from the docs.

| Finding | Evidence | Consequence |
|---|---|---|
| Thinking tokens consume `max_output_tokens` | `max_output_tokens=12` → `finish_reason=MAX_TOKENS`, `thoughts=8`, **`r.text` empty** | Must set `thinking_config`, or calls return blank → mass `blank_response` chunks (D33) |
| `thinking_budget=0` is **not** portable | Accepted by 3.7/3.5/3.1-lite; **400 INVALID_ARGUMENT on 3.6-flash** | Use `thinking_level` |
| `low` is cheaper than omitting | omitted = 942 thinking tokens / 4.4s vs low = 442 / 2.9s, identical parsed output | `low` default, `null` opts out |
| Implicit caching needs zero code | call 1 = 0 cached; calls 2–3 = **4037 cached tokens** of a 7005-token prefix | Report only |
| `gemini-2.5-flash` closed to new users | 404 "no longer available to new users" | Not a viable default |
| Free tier = 5 req/min/model | repeated `RESOURCE_EXHAUSTED` | Profile ships `max_workers: 2` |
| `HttpOptions.timeout` is **milliseconds** | SDK field docs | Converted at the boundary |

## No caching is implemented

Gemini's implicit caching is automatic and server-side. This PR **writes no caching code**. It only reads back the `cached_content_token_count` Gemini already returns and forwards it as `cache_read_tokens`, so `llm.log` and the walkthrough's existing cache columns populate. Explicit caching (`client.caches.create`) is out of scope: it carries storage cost ($1.00–$4.50/1M tokens/hour) and lives only on the `generateContent` surface Google now labels **"Legacy"**.

## Two defects fixed along the way

1. **`retry.py` missed Gemini's overflow wording.** None of the existing `_CONTEXT_EXCEEDED_MARKERS` matched it, so context overflow would have gone undetected for this provider. The new marker is anchored on `"input token count"` specifically so it does *not* also match the output-cap rejection — those have different fixes and conflating them misdirects the operator.

2. **Safety refusals returned silently.** A `SAFETY`/`RECITATION` block is HTTP 200 with an empty body and a non-STOP `finish_reason` — previously indistinguishable from a genuine empty answer, surfacing far downstream as an unexplained blank chunk. Now warned and recorded with an `error` field. (Found by `/code-review`; the regression tests fail without the fix and pass with it.)

## Files

**New:** `src/mykg/llm/gemini_adapter.py` (268 lines)
**Modified:** `llm/config.py` dispatch · `llm/retry.py` marker · `cli.py` `_PROFILE_META` · both `mykg_config.yaml` copies (Invariant 17) · `sample.env.mykg` · `pyproject.toml` · README + architecture docs (six → seven)

## Verification

- **Unit:** `1351 passed` (baseline 1345), 31 new Gemini tests; `ruff` clean
- **Config:** both YAML copies byte-identical; all 7 profiles load; gemini profile key-for-key identical to `openai` plus `thinking_level`
- **Live adapter:** `pytest -m live -k gemini` passes against the real API
- **Full pipeline:** `extract-graph --profile gemini` ran end-to-end → 6 nodes / 8 edges, `knowledge_graph.ttl` **valid**, **no** `failed_chunks.json`, 429 backoff exercised and recovered

### Reviewer note

On the free tier a multi-file corpus will hit 429s even at `max_workers: 2` — that is the documented quota (5 req/min/model), not an adapter bug. Raise `max_workers` on a paid tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add native Google Gemini support as a fully integrated LLM provider with robust usage reporting, retries, and response diagnostics.

New Features:
- Add Google Gemini as a seventh LLM provider using the native google-genai SDK, with configurable thinking levels, token limits, timeouts, and API-key support.
- Report Gemini usage and implicit cache reads while supporting JSON responses and standard adapter behavior.

Bug Fixes:
- Handle Gemini context-overflow errors without misclassifying output-cap failures.
- Diagnose and record Gemini safety and recitation refusals instead of silently returning blank responses.

Enhancements:
- Add provider-specific retry handling for Gemini rate limits and transient server errors, including timeout conversion and response truncation reporting.

Build:
- Add the google-genai dependency and lockfile updates.

Documentation:
- Document Gemini setup, configuration, caching behavior, token budgets, and its inclusion among supported providers.

Tests:
- Add comprehensive Gemini adapter coverage, including configuration, retries, usage accounting, truncation, refusals, logging, and an optional live API test.

Chores:
- Add Gemini profile configuration to both shipped YAML configuration copies and expose it in the CLI provider metadata.
