### PR TITLE
feat(llm)!: default sampling temperature to 0.0 for reproducible extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,18 @@ The wizard walks you through three prompts:
 
 Switch provider by setting `profile:` at the top of [`mykg_config.yaml`](mykg_config.yaml).
 
+**Sampling temperature.** myKG sends `temperature: 0.0` on every LLM call, so
+the same corpus induces the same schema and yields the same nodes and edges run
+over run. Extraction is a structured-output task, not a creative one — provider
+defaults (typically ~1.0) work against reproducibility. Models that reject an
+explicit temperature (OpenAI's o-series and gpt-5 reasoning families) have it
+omitted automatically, and use their own fixed sampling instead.
+
+> Changed in 0.4.5 — earlier versions sent no temperature at all and inherited
+> each provider's default. If you were relying on that, extraction output will
+> shift. To restore the old behaviour, set an explicit empty `temperature:` in
+> the active profile's `llm:` block; a `null` value means "send nothing".
+
 ### API Keys
 
 myKG reads API keys from environment variables. Set them by exporting directly or by creating a `.env.mykg` file in your project directory (loaded automatically on startup).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -698,9 +698,14 @@ All provider parameters — model, context window, token limits, timeout, base U
 
 #### Sampling temperature
 
-Temperature is an **internal knob, not a documented user-facing setting**. It is
-absent from the shipped profiles and from the README, so every provider applies
-its own default and payloads are unchanged from before it existed.
+myKG sends **`temperature: 0.0`** on every call by default
+(`DEFAULT_TEMPERATURE` in `llm/temperature.py`). Extraction is a
+structured-output task: the same corpus should induce the same schema and yield
+the same graph run over run, and provider defaults (~1.0) work against that.
+
+The key stays absent from the shipped profiles — the default lives in code, not
+config. A profile may override it, and an explicit `temperature:` (null) means
+"send nothing", restoring each provider's own default.
 
 The set of model families that reject an explicit temperature is a **default,
 not a hardcoded rule**. Provider lineups change faster than mykg releases, so
@@ -718,8 +723,10 @@ in the active profile. The last exists because the factory reads the `llm:`
 block uniformly; it is deliberately not advertised, so treat it as unsupported
 rather than as public API.
 
-An unset value is omitted from the request entirely rather than sent as a null,
-which is what lets one code path serve providers with very different support:
+A `None` value — whether from an explicit YAML null or from a model that
+rejects the parameter — is omitted from the request entirely rather than sent as
+a null, which is what lets one code path serve providers with very different
+support:
 
 | Provider | Temperature |
 |---|---|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mykg"
-version = "0.4.4"
+version = "0.4.5"
 description = "AI workflow that turns documents into a confidence-scored knowledge graph with an induced RDFS/OWL ontology"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/mykg/llm/config.py
+++ b/src/mykg/llm/config.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import mykg.config as _cfg
 from mykg.llm.adapter import LLMAdapter
+from mykg.llm.temperature import DEFAULT_TEMPERATURE
 
 if TYPE_CHECKING:
     from mykg.llm.error_gate import ErrorGate
@@ -75,7 +76,7 @@ def load_adapter(
             retry_429_max=section.get("retry_429_max", _cfg.LLM_RETRY_429_MAX),
             retry_429_base_delay=section.get("retry_429_base_delay", _cfg.LLM_RETRY_429_BASE_DELAY),
             error_gate=error_gate,
-            temperature=section.get("temperature"),
+            temperature=section.get("temperature", DEFAULT_TEMPERATURE),
         )
 
     if provider == "anthropic":
@@ -94,7 +95,7 @@ def load_adapter(
             retry_429_max=section.get("retry_429_max", _cfg.LLM_RETRY_429_MAX),
             retry_429_base_delay=section.get("retry_429_base_delay", _cfg.LLM_RETRY_429_BASE_DELAY),
             error_gate=error_gate,
-            temperature=section.get("temperature"),
+            temperature=section.get("temperature", DEFAULT_TEMPERATURE),
         )
 
     if provider == "openrouter":
@@ -113,7 +114,7 @@ def load_adapter(
             retry_429_max=section.get("retry_429_max", _cfg.LLM_RETRY_429_MAX),
             retry_429_base_delay=section.get("retry_429_base_delay", _cfg.LLM_RETRY_429_BASE_DELAY),
             error_gate=error_gate,
-            temperature=section.get("temperature"),
+            temperature=section.get("temperature", DEFAULT_TEMPERATURE),
             temperature_unsupported_prefixes=_temperature_prefixes(section),
         )
 
@@ -129,7 +130,7 @@ def load_adapter(
             retry_429_max=section.get("retry_429_max", _cfg.LLM_RETRY_429_MAX),
             retry_429_base_delay=section.get("retry_429_base_delay", _cfg.LLM_RETRY_429_BASE_DELAY),
             error_gate=error_gate,
-            temperature=section.get("temperature"),
+            temperature=section.get("temperature", DEFAULT_TEMPERATURE),
             temperature_unsupported_prefixes=_temperature_prefixes(section),
         )
 
@@ -149,7 +150,7 @@ def load_adapter(
             retry_429_max=section.get("retry_429_max", _cfg.LLM_RETRY_429_MAX),
             retry_429_base_delay=section.get("retry_429_base_delay", _cfg.LLM_RETRY_429_BASE_DELAY),
             error_gate=error_gate,
-            temperature=section.get("temperature"),
+            temperature=section.get("temperature", DEFAULT_TEMPERATURE),
         )
 
     if provider == "claude-cli":
@@ -161,7 +162,7 @@ def load_adapter(
             model=section.get("model", "auto"),
             effort=section.get("effort", "auto"),
             error_gate=error_gate,
-            temperature=section.get("temperature"),
+            temperature=section.get("temperature", DEFAULT_TEMPERATURE),
         )
 
     if provider == "agent":
@@ -193,7 +194,7 @@ def load_adapter(
             timeout=section["timeout"],
             max_tokens=section["max_output_tokens"],
             error_gate=error_gate,
-            temperature=section.get("temperature"),
+            temperature=section.get("temperature", DEFAULT_TEMPERATURE),
         )
 
     raise ValueError(f"Unknown provider in mykg_config.yaml: {provider!r}")

--- a/src/mykg/llm/temperature.py
+++ b/src/mykg/llm/temperature.py
@@ -11,6 +11,17 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+# Sampling temperature applied when a profile does not set `llm.temperature`.
+#
+# 0.0 rather than "omit and let the provider decide": knowledge-graph extraction
+# wants the same corpus to induce the same schema and yield the same nodes and
+# edges run over run, and provider defaults (~1.0 for most chat models) actively
+# work against that. Set `llm.temperature` in a profile to override; models that
+# reject an explicit value still have it dropped by the prefix guard below, so
+# this default is safe on every shipped profile including the gpt-5 one.
+DEFAULT_TEMPERATURE: float = 0.0
+
+
 # Default model-name prefixes whose families reject an explicit temperature.
 # OpenAI reasoning models (o-series, gpt-5) return 400 unsupported_parameter:
 # "Only the default (1) value is supported".

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -3416,11 +3416,13 @@ _TEMP_PROVIDER_CASES = [
 
 
 @pytest.mark.parametrize("provider,llm,patch_target", _TEMP_PROVIDER_CASES)
-def test_load_adapter_defaults_temperature_to_none(provider, llm, patch_target, monkeypatch):
-    """A config with no temperature key builds fine and omits the parameter.
+def test_load_adapter_defaults_temperature_to_zero(provider, llm, patch_target, monkeypatch):
+    """A config with no temperature key resolves to DEFAULT_TEMPERATURE (0.0).
 
-    This is the guard on the shipped mykg_config.yaml files, which intentionally
-    do not carry the key: existing users must see no behaviour change at all.
+    Extraction wants determinism: the same corpus should induce the same schema
+    and yield the same graph run over run, which provider defaults (~1.0) work
+    against. Models that reject an explicit value still have it dropped by the
+    prefix guard, so this default is safe on every shipped profile.
     """
     for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY"):
         monkeypatch.setenv(var, "test-key")
@@ -3434,7 +3436,10 @@ def test_load_adapter_defaults_temperature_to_none(provider, llm, patch_target, 
     else:
         adapter = load_adapter(_raw=raw)
 
-    assert adapter._temperature is None
+    from mykg.llm.temperature import DEFAULT_TEMPERATURE
+
+    assert adapter._temperature == DEFAULT_TEMPERATURE
+    assert DEFAULT_TEMPERATURE == 0.0
 
 
 @pytest.mark.parametrize("provider,llm,patch_target", _TEMP_PROVIDER_CASES)
@@ -3876,22 +3881,150 @@ def test_shipped_config_has_no_temperature_prefix_key():
 
 
 def test_shipped_yaml_files_never_mention_temperature():
-    """The shipped configs must not mention temperature at all — not as a key,
-    and not as a comment either.
+    """The configs *as committed to this repo* must not mention temperature.
 
-    Both files are the user's first contact with mykg's configuration surface,
-    and this knob is deliberately internal. A comment is still an invitation, so
-    the check is on the raw text rather than the parsed mapping.
+    The default lives in code (DEFAULT_TEMPERATURE), not config, and the shipped
+    files are left untouched by design. A comment is still an edit, so the check
+    is on raw text rather than the parsed mapping.
+
+    Scoped to git's committed content, not the file on disk: a user is expressly
+    told in the README to add `temperature:` to their own working copy to restore
+    per-provider defaults, and doing so must not fail this suite.
     """
+    import subprocess
     from pathlib import Path
 
     repo_root = Path(__file__).parent.parent
-    shipped = [repo_root / "mykg_config.yaml", repo_root / "src" / "mykg" / "data" / "mykg_config.yaml"]
+    tracked = ["mykg_config.yaml", "src/mykg/data/mykg_config.yaml"]
 
-    for path in shipped:
-        assert path.exists(), f"{path} is missing"
-        text = path.read_text(encoding="utf-8")
-        assert "temperature" not in text.lower(), (
-            f"{path.name} mentions temperature; the shipped configs are left "
-            "untouched by design — document the knob in docs/architecture.md instead"
+    for rel in tracked:
+        committed = subprocess.run(
+            ["git", "show", f"HEAD:{rel}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
         )
+        if committed.returncode != 0:
+            pytest.skip(f"cannot read {rel} from git (not a checkout?)")
+        assert "temperature" not in committed.stdout.lower(), (
+            f"{rel} mentions temperature as committed; the shipped configs are "
+            "left untouched by design — document it in docs/architecture.md"
+        )
+
+
+# ---------------------------------------------------------------------------
+# temperature — the 0.0 default reaches the wire
+# ---------------------------------------------------------------------------
+
+
+def test_unconfigured_standard_model_sends_zero(monkeypatch):
+    """The point of the default: deterministic extraction with no config."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    kwargs = _openai_wire(
+        {"provider": "openai", "llm": {"model": "gpt-4o", "max_output_tokens": 100, "timeout": 30}}
+    )
+    assert kwargs["temperature"] == 0.0
+
+
+def test_unconfigured_reasoning_model_still_omits(monkeypatch):
+    """The prefix guard outranks the default, so the shipped gpt-5 profile does
+    not start 400-ing the moment the default became a real value."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    kwargs = _openai_wire(
+        {
+            "provider": "openai",
+            "llm": {"model": "gpt-5-mini", "max_output_tokens": 100, "timeout": 30},
+        }
+    )
+    assert "temperature" not in kwargs
+
+
+def test_shipped_default_profile_resolves_the_zero_default():
+    """End-to-end on whatever profile the shipped config actually selects.
+
+    The wire assertion is conditional on the active model, deliberately: pinning
+    "temperature is absent" would silently go vacuous if `profile:` were switched
+    to a provider with no prefix guard, un-guarding the regression it exists to
+    catch. What holds for every profile is that the default resolves to 0.0 and
+    that the payload agrees with the guard's verdict for that model.
+    """
+    import os
+
+    os.environ.setdefault("OPENAI_API_KEY", "test-key")
+    os.environ.setdefault("ANTHROPIC_API_KEY", "test-key")
+    os.environ.setdefault("OPENROUTER_API_KEY", "test-key")
+    os.environ.setdefault("GEMINI_API_KEY", "test-key")
+
+    from mykg.llm.config import load_adapter
+    from mykg.llm.temperature import DEFAULT_TEMPERATURE, temperature_unsupported
+
+    adapter = load_adapter()
+    assert adapter._temperature == DEFAULT_TEMPERATURE == 0.0
+
+    model = getattr(adapter, "_model", "")
+    if not hasattr(adapter, "_client"):
+        pytest.skip(f"active profile {model!r} has no HTTP client to inspect")
+
+    with patch.object(adapter, "_client") as client:
+        response = MagicMock()
+        response.choices[0].message.content = "ok"
+        response.choices[0].finish_reason = "stop"
+        client.chat.completions.create.return_value = response
+        client.messages.create.return_value = MagicMock(content=[MagicMock(text="ok")])
+        try:
+            adapter.complete("sys", "user")
+        except Exception:  # noqa: BLE001 - unfamiliar client shape; nothing to assert
+            pytest.skip(f"active profile {model!r} does not expose an inspectable payload")
+
+        # Providers differ in call shape: OpenAI-compatible clients use
+        # chat.completions.create, Anthropic uses messages.create.
+        for call in (client.chat.completions.create, client.messages.create):
+            if call.call_args is not None:
+                kwargs = call.call_args[1]
+                break
+        else:
+            pytest.skip(f"active profile {model!r} issued no inspectable request")
+
+    if temperature_unsupported(model):
+        assert "temperature" not in kwargs, f"{model} rejects temperature; it must be omitted"
+    else:
+        assert kwargs["temperature"] == 0.0, f"{model} accepts temperature; 0.0 must be sent"
+
+
+def test_explicit_config_still_overrides_the_default(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    kwargs = _openai_wire(
+        {
+            "provider": "openai",
+            "llm": {
+                "model": "gpt-4o",
+                "max_output_tokens": 100,
+                "timeout": 30,
+                "temperature": 0.7,
+            },
+        }
+    )
+    assert kwargs["temperature"] == 0.7
+
+
+def test_explicit_null_temperature_restores_provider_default(monkeypatch):
+    """An explicit `temperature:` (empty) in YAML parses as None and means
+    "send nothing" — the documented escape hatch back to pre-0.4.5 behaviour.
+
+    This works because .get(key, default) returns a stored None rather than the
+    default, so the distinction between "absent" and "explicitly null" survives.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    kwargs = _openai_wire(
+        {
+            "provider": "openai",
+            "llm": {
+                "model": "gpt-4o",
+                "max_output_tokens": 100,
+                "timeout": 30,
+                "temperature": None,
+            },
+        }
+    )
+    assert "temperature" not in kwargs

--- a/uv.lock
+++ b/uv.lock
@@ -698,7 +698,7 @@ wheels = [
 
 [[package]]
 name = "mykg"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Why

mykg had no reproducible extraction out of the box. Temperature defaulted to `None`, so the parameter was never sent and each provider applied its own default — typically ~1.0. The same corpus could induce a different schema and yield a different graph on every run.

Extraction is a structured-output task, not a creative one. `0.0` is the right default; `~1.0` was never a deliberate choice, just an inherited one.

## ⚠️ Breaking

**Extraction output will shift for every user on upgrade.** This is the honest trade for reproducibility, and it is called out in the README under a "Changed in 0.4.5" note rather than buried.

To restore the old behaviour, set an explicit empty `temperature:` in the active profile's `llm:` block — a `null` value means "send nothing". Pinned by a test.

## What holds

| Case | Behaviour |
|---|---|
| Unconfigured, standard model | sends `0.0` |
| Unconfigured, gpt-5 / o-series | **omitted** — the guard outranks the default, so the shipped `openai` profile does not start 400-ing |
| Explicit `temperature: 0.7` | sends `0.7` |
| Explicit `temperature:` (null) | omitted — pre-0.4.5 behaviour |

The default lives in code (`DEFAULT_TEMPERATURE`), not config: both shipped `mykg_config.yaml` files remain untouched.

## Review round

A `/code-review` pass found three issues, all fixed:

- **The README documented an escape hatch its own test forbade.** `test_shipped_yaml_files_never_mention_temperature` asserted the working copy never contains the string, so following the README broke the suite — reproduced before fixing. The tripwire is now scoped to git's *committed* content: the repo must not ship the key, but a user editing their own config is a different thing.
- `DEFAULT_TEMPERATURE` was appended to the prefix list's comment block, divorcing that list from its rationale. Separated.
- `test_shipped_default_profile_...` only tested the reasoning-model path because `profile:` happens to select gpt-5; switching profiles made it vacuous. It now derives its expectation from the guard's verdict for the active model, and is verified to pass under `anthropic-claude`/`openai`/`openrouter-free` and skip cleanly where there is no inspectable payload.

## Testing

1545 offline tests passing. Mutation-tested: reverting the default to `None` makes the profile test fail under both `openai` and `anthropic-claude`, so it is not vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make LLM extraction reproducible by default with zero-temperature sampling while safely omitting the parameter for unsupported model families.

New Features:
- Default LLM sampling temperature to 0.0 for reproducible knowledge-graph extraction while preserving model-specific compatibility.

Enhancements:
- Allow explicit temperature overrides, including null to restore provider-default behavior.
- Document the temperature behavior, compatibility rules, and upgrade impact for users.

Build:
- Bump the project version to 0.4.5.

Documentation:
- Update the README and architecture documentation with deterministic sampling defaults and the null-value escape hatch.

Tests:
- Add coverage for default, override, null, standard-model, and reasoning-model temperature payload behavior.
- Make shipped-config validation inspect committed files while allowing user-local configuration changes.