### PR TITLE
fix: address Sourcery review findings on #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,26 +215,6 @@ The wizard walks you through three prompts:
 
 Switch provider by setting `profile:` at the top of [`mykg_config.yaml`](mykg_config.yaml).
 
-**Sampling temperature.** myKG sends `temperature: 0.0` on every LLM call, so
-the same corpus induces the same schema and yields the same nodes and edges run
-over run. Extraction is a structured-output task, not a creative one — provider
-defaults (typically ~1.0) work against reproducibility.
-
-Two cases fall outside this, and in both the provider's own sampling applies:
-
-- **Models that reject an explicit temperature** — OpenAI's o-series and gpt-5
-  reasoning families — have it omitted automatically and use their own fixed
-  sampling.
-- **`claude-cli` and `agent`** have no temperature control at all: `claude -p`
-  exposes no such flag, and the host Claude Code session servicing the agent
-  inbox has no sampling dial. These two profiles accept the setting and ignore
-  it, so extraction on them is **not** reproducible in the sense above.
-
-> Changed in 0.4.5 — earlier versions sent no temperature at all and inherited
-> each provider's default. If you were relying on that, extraction output will
-> shift. To restore the old behaviour, set an explicit empty `temperature:` in
-> the active profile's `llm:` block; a `null` value means "send nothing".
-
 ### API Keys
 
 myKG reads API keys from environment variables. Set them by exporting directly or by creating a `.env.mykg` file in your project directory (loaded automatically on startup).
@@ -313,6 +293,34 @@ A `429` surfaces in the log as a retry warning like:
 Lower these (e.g. from `8` down to `2`–`4`) in the active profile to reduce concurrent requests. This is especially likely on `openrouter-free` (free-tier models have very low per-minute caps), on `gemini` with a free-tier key (5 requests/minute/model — drop `pass1`/`pass2`/`orphan_pass` to `1`–`2`), and on lower-tier `anthropic-claude`/`openai` accounts. `llm.retry_429_max` / `llm.retry_429_base_delay` control automatic backoff on a 429, but a persistent 429 is a signal to reduce `max_workers`, not just retry harder. `claude-cli` is unaffected — it is serial by design (`max_workers: 1`); it doesn't hit API rate limits since there's no API call. `agent-claude-code` is not API rate-limited either (no API key involved), but it is not serial — its default profile sets `pass1`/`pass2`/`orphan_pass` `max_workers` > 1 (configurable, like any other profile), since the skill dispatches multiple subagents per wave.
 
 **Also check your quota/credits.** Some providers return `429` when your account has exhausted its token quota or spending balance, not only for request cadence. If lowering `max_workers` doesn't help and the 429s persist from the very first call, **check that your account still has available tokens/credits** (e.g. the OpenAI/Anthropic billing dashboard, or your OpenRouter balance). No `max_workers` value will clear a 429 caused by a depleted balance — top up or switch to a profile with quota (e.g. `ollama-local` for local inference, or `claude-cli` which bills via your Claude Pro/Max plan instead of the API).
+
+
+### Non-Reproducible Extraction (Different Graph Each Run)
+
+If the same corpus produces a different schema or a different set of nodes and
+edges on each run, sampling temperature is the usual cause.
+
+myKG sends `temperature: 0.0` on every LLM call so extraction is repeatable —
+it is a structured-output task, not a creative one, and provider defaults
+(typically ~1.0) work against that. Two cases fall outside it, and in both the
+provider's own sampling applies:
+
+- **Models that reject an explicit temperature** — OpenAI's o-series and gpt-5
+  reasoning families — have it omitted automatically and use their own fixed
+  sampling.
+- **`claude-cli` and `agent`** have no temperature control at all: `claude -p`
+  exposes no such flag, and the host Claude Code session servicing the agent
+  inbox has no sampling dial. These two profiles accept the setting and ignore
+  it, so extraction on them is **not** reproducible in the sense above.
+
+If you need reproducibility, switch to a profile whose provider exposes
+temperature (`anthropic-claude`, `openai` on a non-reasoning model, `gemini`,
+`ollama-local`, `openrouter-free`).
+
+> Changed in 0.4.5 — earlier versions sent no temperature at all and inherited
+> each provider's default. If you were relying on that, extraction output will
+> shift. To restore the old behaviour, set an explicit empty `temperature:` in
+> the active profile's `llm:` block; a `null` value means "send nothing".
 
 
 ## Extract Pipeline

--- a/README.md
+++ b/README.md
@@ -218,9 +218,17 @@ Switch provider by setting `profile:` at the top of [`mykg_config.yaml`](mykg_co
 **Sampling temperature.** myKG sends `temperature: 0.0` on every LLM call, so
 the same corpus induces the same schema and yields the same nodes and edges run
 over run. Extraction is a structured-output task, not a creative one — provider
-defaults (typically ~1.0) work against reproducibility. Models that reject an
-explicit temperature (OpenAI's o-series and gpt-5 reasoning families) have it
-omitted automatically, and use their own fixed sampling instead.
+defaults (typically ~1.0) work against reproducibility.
+
+Two cases fall outside this, and in both the provider's own sampling applies:
+
+- **Models that reject an explicit temperature** — OpenAI's o-series and gpt-5
+  reasoning families — have it omitted automatically and use their own fixed
+  sampling.
+- **`claude-cli` and `agent`** have no temperature control at all: `claude -p`
+  exposes no such flag, and the host Claude Code session servicing the agent
+  inbox has no sampling dial. These two profiles accept the setting and ignore
+  it, so extraction on them is **not** reproducible in the sense above.
 
 > Changed in 0.4.5 — earlier versions sent no temperature at all and inherited
 > each provider's default. If you were relying on that, extraction output will

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -703,6 +703,11 @@ myKG sends **`temperature: 0.0`** on every call by default
 structured-output task: the same corpus should induce the same schema and yield
 the same graph run over run, and provider defaults (~1.0) work against that.
 
+The default is resolved for all seven adapters, but only five can act on it.
+`claude-cli` and `agent` accept and discard it (see the table below), so the
+reproducibility guarantee does not extend to those two profiles — a caveat worth
+stating plainly rather than leaving implicit in the table.
+
 The key stays absent from the shipped profiles — the default lives in code, not
 config. A profile may override it, and an explicit `temperature:` (null) means
 "send nothing", restoring each provider's own default.

--- a/tests/test_agent_adapter.py
+++ b/tests/test_agent_adapter.py
@@ -197,3 +197,19 @@ def test_agent_task_id_is_unaffected_by_temperature(tmp_path):
     a = _make_adapter(tmp_path / "a", temperature=None)
     b = _make_adapter(tmp_path / "b", temperature=0.7)
     assert a._make_task_id("sys", "user", "lbl") == b._make_task_id("sys", "user", "lbl")
+
+
+def test_agent_discards_the_zero_default(tmp_path):
+    """Same caveat as claude-cli: the default is resolved but not actionable."""
+    from mykg.llm.config import load_adapter
+    from mykg.llm.temperature import DEFAULT_TEMPERATURE
+
+    raw = {
+        "provider": "agent",
+        "llm": {"model": "claude", "max_output_tokens": 100, "timeout": 30},
+        "agent": {"inbox_dir": "in", "outbox_dir": "out", "poll_interval_seconds": 0.1},
+    }
+    adapter = load_adapter(_raw=raw, intermediate_dir=tmp_path)
+    assert adapter._temperature == DEFAULT_TEMPERATURE
+    # ...but it never reaches the envelope; pinned by
+    # test_agent_temperature_is_not_written_to_the_envelope above.

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -229,3 +229,28 @@ def test_claude_cli_complete_accepts_temperature_kwarg():
         with patch("subprocess.run", return_value=_make_proc(stdout=_envelope())):
             adapter = ClaudeCLIAdapter(max_tokens=4096, timeout=30)
             assert adapter.complete("sys", "user", temperature=0.0) == '{"nodes": []}'
+
+
+def test_claude_cli_discards_the_zero_default():
+    """DEFAULT_TEMPERATURE reaches this adapter but cannot be acted on.
+
+    `claude -p` has no temperature flag, so the README's reproducibility
+    guarantee explicitly excludes this profile. Pinned here so the code and that
+    caveat cannot drift apart.
+    """
+    from mykg.llm.config import load_adapter
+    from mykg.llm.temperature import DEFAULT_TEMPERATURE
+
+    raw = {
+        "provider": "claude-cli",
+        "llm": {"model": "sonnet", "max_output_tokens": 4096, "timeout": 30},
+    }
+    with patch("shutil.which", return_value="/usr/bin/claude"):
+        adapter = load_adapter(_raw=raw)
+        assert adapter._temperature == DEFAULT_TEMPERATURE
+
+        with patch("subprocess.run", return_value=_make_proc(stdout=_envelope())) as run:
+            adapter.complete("sys", "user")
+
+    argv = run.call_args[0][0]
+    assert not any("temperature" in str(a) for a in argv)

--- a/tests/test_llm_adapters.py
+++ b/tests/test_llm_adapters.py
@@ -3940,7 +3940,7 @@ def test_unconfigured_reasoning_model_still_omits(monkeypatch):
     assert "temperature" not in kwargs
 
 
-def test_shipped_default_profile_resolves_the_zero_default():
+def test_shipped_default_profile_resolves_the_zero_default(monkeypatch):
     """End-to-end on whatever profile the shipped config actually selects.
 
     The wire assertion is conditional on the active model, deliberately: pinning
@@ -3949,12 +3949,15 @@ def test_shipped_default_profile_resolves_the_zero_default():
     catch. What holds for every profile is that the default resolves to 0.0 and
     that the payload agrees with the guard's verdict for that model.
     """
-    import os
-
-    os.environ.setdefault("OPENAI_API_KEY", "test-key")
-    os.environ.setdefault("ANTHROPIC_API_KEY", "test-key")
-    os.environ.setdefault("OPENROUTER_API_KEY", "test-key")
-    os.environ.setdefault("GEMINI_API_KEY", "test-key")
+    # monkeypatch, not os.environ: a leaked fake key would make a later live
+    # test attempt a real call with "test-key" instead of skipping cleanly.
+    for var in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+        "GEMINI_API_KEY",
+    ):
+        monkeypatch.setenv(var, "test-key")
 
     from mykg.llm.config import load_adapter
     from mykg.llm.temperature import DEFAULT_TEMPERATURE, temperature_unsupported


### PR DESCRIPTION
Follow-up to #70. Sourcery flagged two issues there; both are real and both are fixed here.

## 1. The README promised reproducibility that two providers cannot deliver

The note added in #70 said myKG "sends `temperature: 0.0` on every LLM call". That is false for `claude-cli` and `agent`: both accept the value and discard it — `claude -p` exposes no temperature flag, and the host Claude Code session servicing the agent inbox has no sampling dial.

Verified rather than assumed: `_temperature` appears exactly once in each of those two adapters — the assignment — and is never read.

Anyone running those profiles was told they had deterministic extraction when they did not. The README and `docs/architecture.md` now state the exclusion explicitly, and two new tests pin it so the code and the caveat cannot drift apart.

## 2. Test leaked fake API keys into the process environment

`test_shipped_default_profile_resolves_the_zero_default` seeded four API-key variables via `os.environ.setdefault` and never restored them.

This is worse than generic test hygiene in this repo: the live tests skip based on key presence, so a leaked `"test-key"` turns a clean skip into a real API call with an invalid credential and a confusing failure. Reproduced with a two-test file before fixing. Now uses `monkeypatch.setenv`.

## Testing

1547 offline tests passing (up from 1545). Shipped `mykg_config.yaml` files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify extraction reproducibility limitations and isolate test credentials from the process environment.

Bug Fixes:
- Correct reproducibility documentation by explicitly excluding the `claude-cli` and `agent` profiles, which cannot apply sampling temperature.
- Prevent test-only API keys from leaking into the process environment and triggering unintended live API tests.

Enhancements:
- Add regression coverage confirming that `claude-cli` and `agent` resolve the default temperature but do not apply it.

Documentation:
- Update the README and architecture documentation to clarify temperature-based reproducibility limitations and identify profiles that support reproducible extraction.

Tests:
- Add tests pinning the temperature behavior of the `claude-cli` and `agent` adapters.
- Update the shipped-profile test to use automatically restored environment variables.